### PR TITLE
fix(cluster): break the WireGuard/raft bootstrap deadlock and stop WASM teardown crashing the gateway

### DIFF
--- a/core/pkg/environments/production/logrotate.go
+++ b/core/pkg/environments/production/logrotate.go
@@ -1,0 +1,61 @@
+package production
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// logrotateConfigPath is where the Orama log-rotation policy is installed.
+	// Debian/Ubuntu's logrotate reads every file in this directory daily.
+	logrotateConfigPath = "/etc/logrotate.d/orama"
+
+	// logrotateFileMode matches what logrotate expects for its config files.
+	logrotateFileMode = 0o644
+)
+
+// GenerateLogrotateConfig renders the rotation policy for the service logs
+// written under <oramaDir>/logs.
+//
+// Every long-running unit is configured with `StandardOutput=append:<file>`,
+// which never rotates on its own — the file grows for the lifetime of the
+// install. On a busy node that reaches multiple gigabytes (node.log has been
+// observed at 2.7 GB, gateway.log at 861 MB), and the only bound is the disk
+// filling up and taking the node down with it.
+//
+// `copytruncate` is required rather than the default create-and-signal
+// behaviour: systemd holds the append fd open and there is no reopen signal to
+// send it, so renaming the file would leave the service writing to an unlinked
+// inode and the "rotated" log would stay invisible and keep growing.
+func GenerateLogrotateConfig(oramaDir string) string {
+	logGlob := filepath.Join(oramaDir, "logs", "*.log")
+	return fmt.Sprintf(`# Managed by Orama — do not edit by hand.
+#
+# Service units write with systemd's append: redirection, which holds the file
+# descriptor open and never rotates. copytruncate keeps that fd valid.
+%s {
+    daily
+    rotate 7
+    maxsize 200M
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    su orama orama
+    create 0644 orama orama
+}
+`, logGlob)
+}
+
+// InstallLogrotateConfig writes the rotation policy to logrotateConfigPath.
+// Requires root. Returns an error the caller may downgrade to a warning —
+// missing rotation degrades disk usage, it does not break the node.
+func InstallLogrotateConfig(oramaDir string) error {
+	cfg := GenerateLogrotateConfig(oramaDir)
+	if err := os.WriteFile(logrotateConfigPath, []byte(cfg), logrotateFileMode); err != nil {
+		return fmt.Errorf("failed to write %s: %w", logrotateConfigPath, err)
+	}
+	return nil
+}

--- a/core/pkg/environments/production/logrotate_test.go
+++ b/core/pkg/environments/production/logrotate_test.go
@@ -1,0 +1,59 @@
+package production
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateLogrotateConfig_coversServiceLogGlob(t *testing.T) {
+	cfg := GenerateLogrotateConfig("/opt/orama/.orama")
+
+	if !strings.Contains(cfg, "/opt/orama/.orama/logs/*.log {") {
+		t.Errorf("config does not target the service log directory:\n%s", cfg)
+	}
+}
+
+// systemd's append: redirection keeps the file descriptor open and offers no
+// reopen signal, so a rename-based rotation would leave every service writing
+// into an unlinked inode — the log would appear rotated while still growing
+// invisibly. copytruncate is the only correct mode here.
+func TestGenerateLogrotateConfig_usesCopytruncate(t *testing.T) {
+	cfg := GenerateLogrotateConfig("/opt/orama/.orama")
+
+	if !strings.Contains(cfg, "copytruncate") {
+		t.Error("copytruncate is required for systemd append: logs; without it rotation silently does nothing")
+	}
+	if strings.Contains(cfg, "\n    create 0644 orama orama\n") && !strings.Contains(cfg, "copytruncate") {
+		t.Error("create without copytruncate would orphan the open fd")
+	}
+}
+
+func TestGenerateLogrotateConfig_boundsGrowth(t *testing.T) {
+	cfg := GenerateLogrotateConfig("/opt/orama/.orama")
+
+	for _, want := range []string{"daily", "rotate 7", "maxsize 200M", "compress"} {
+		if !strings.Contains(cfg, want) {
+			t.Errorf("config missing %q — growth is not bounded:\n%s", want, cfg)
+		}
+	}
+}
+
+func TestGenerateLogrotateConfig_toleratesMissingLogs(t *testing.T) {
+	cfg := GenerateLogrotateConfig("/opt/orama/.orama")
+
+	// A fresh node has no logs yet; logrotate must not error on the empty glob.
+	if !strings.Contains(cfg, "missingok") {
+		t.Error("missingok required so a fresh install does not produce logrotate errors")
+	}
+	if !strings.Contains(cfg, "notifempty") {
+		t.Error("notifempty avoids rotating empty files")
+	}
+}
+
+func TestGenerateLogrotateConfig_respectsCustomDir(t *testing.T) {
+	cfg := GenerateLogrotateConfig("/var/lib/orama-test")
+
+	if !strings.Contains(cfg, "/var/lib/orama-test/logs/*.log") {
+		t.Errorf("config ignored the supplied orama dir:\n%s", cfg)
+	}
+}

--- a/core/pkg/environments/production/orchestrator.go
+++ b/core/pkg/environments/production/orchestrator.go
@@ -916,6 +916,14 @@ func (ps *ProductionSetup) Phase5CreateSystemdServices(enableHTTPS bool) error {
 		ps.logf("  ✓ SNI router service unit created: %s", ps.binaryInstaller.SNIRouterServiceName())
 	}
 
+	// Log rotation for the append:-redirected service logs. Without it these
+	// files grow without bound until the disk fills.
+	if err := InstallLogrotateConfig(ps.oramaDir); err != nil {
+		ps.logf("  ⚠️  Failed to install logrotate config: %v", err)
+	} else {
+		ps.logf("  ✓ Log rotation configured (%s)", logrotateConfigPath)
+	}
+
 	// Reload systemd daemon
 	if err := ps.serviceController.DaemonReload(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %w", err)
@@ -1283,7 +1291,6 @@ func (ps *ProductionSetup) LogSetupComplete(peerID string) {
 		ps.logf("  Wallet: %s", ps.anyoneRelayConfig.Wallet)
 		ps.logf("  Config: /etc/anon/anonrc")
 		ps.logf("  Register at: https://dashboard.anyone.io")
-		ps.logf("  IMPORTANT: You need 100 $ANYONE tokens in your wallet to receive rewards")
 	} else if ps.IsAnyoneClient() {
 		ps.logf("\nStart All Services:")
 		ps.logf("  systemctl start orama-ipfs orama-ipfs-cluster orama-olric orama-vault orama-anyone-client orama-node")

--- a/core/pkg/gateway/dependencies.go
+++ b/core/pkg/gateway/dependencies.go
@@ -42,6 +42,13 @@ const (
 	olricInitMaxAttempts    = 5
 	olricInitInitialBackoff = 500 * time.Millisecond
 	olricInitMaxBackoff     = 5 * time.Second
+
+	// rqliteReadyTimeout bounds how long gateway startup waits for the local
+	// RQLite to become leader-reachable before giving up. Generous enough to
+	// cover a cold node whose raft is still replaying (a large namespace log
+	// can take tens of seconds), short enough that a genuinely broken cluster
+	// surfaces a clear error instead of hanging forever.
+	rqliteReadyTimeout = 90 * time.Second
 )
 
 // Dependencies holds all service clients and components required by the Gateway.
@@ -217,6 +224,22 @@ func initializeRQLite(logger *logging.ColoredLogger, cfg *Config, deps *Dependen
 		zap.String("base_path", "/v1/db"),
 		zap.Duration("timeout", deps.ORMHTTP.Timeout),
 	)
+
+	// Wait for the local RQLite to actually be able to serve a leader-routed
+	// read before touching the schema.
+	//
+	// sql.Open above is lazy and rqlite accepts connections well before it has
+	// elected a leader, so without this the migrations below fire into a
+	// database that cannot answer them. systemd's After=/Requires= on the
+	// rqlite unit does not help: for Type=simple it orders process start, not
+	// readiness. Gating on the real signal turns "gateway dies at boot because
+	// the database was 3 seconds behind it" into "gateway waits 3 seconds".
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), rqliteReadyTimeout)
+	defer readyCancel()
+	if err := rqlite.WaitForLeader(readyCtx, db, rqliteReadyTimeout); err != nil {
+		return fmt.Errorf("rqlite not ready for schema work: %w", err)
+	}
+	logger.ComponentInfo(logging.ComponentGeneral, "RQLite ready (leader reachable), applying schema")
 
 	// Apply embedded migrations to ensure schema is up-to-date.
 	// This is critical for namespace gateways whose RQLite instances

--- a/core/pkg/node/wireguard_sync.go
+++ b/core/pkg/node/wireguard_sync.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -16,9 +17,118 @@ import (
 	"go.uber.org/zap"
 )
 
-// syncWireGuardPeers reads all peers from RQLite and reconciles the local
-// WireGuard interface so it matches the cluster state. This is called on
-// startup after RQLite is ready and periodically thereafter.
+const (
+	// defaultWireGuardPort is the listen port assumed for a peer row that
+	// records wg_port = 0 (older rows predate the column being populated).
+	defaultWireGuardPort = 51820
+
+	// wgKeyLogPrefixLen is how much of a WireGuard public key is kept in log
+	// lines — enough to correlate against `wg show`, short enough to read.
+	wgKeyLogPrefixLen = 8
+
+	// wgSyncInterval is how often the local interface is reconciled against
+	// cluster membership.
+	wgSyncInterval = 60 * time.Second
+)
+
+// wgPeerQuery selects the mesh membership the local interface is reconciled
+// against. Ordered by wg_ip so log output and tests are deterministic.
+const wgPeerQuery = "SELECT node_id, wg_ip, public_key, public_ip, wg_port FROM wireguard_peers ORDER BY wg_ip"
+
+// desiredWGPeers is the outcome of loading the mesh membership.
+//
+// Authoritative distinguishes "this is the cluster's committed membership"
+// from "this is the best guess I could scrape locally". Only an authoritative
+// set may drive REMOVALS — see reconcileWireGuardPeers.
+type desiredWGPeers struct {
+	peers         map[string]production.WireGuardPeer
+	authoritative bool
+	source        string
+}
+
+// loadDesiredWireGuardPeers reads the mesh membership, preferring the
+// leader-routed view and falling back to this node's local replica.
+//
+// Why the fallback exists (the bootstrap deadlock): raft runs OVER the
+// WireGuard mesh. A node whose interface has no peers cannot reach any other
+// node, so its rqlite can never elect a leader, so a leader-routed read of
+// `wireguard_peers` can never succeed — and the peer list is precisely what it
+// needs to repair the mesh. Left there, a single restart is an unrecoverable
+// outage: the rows sit readable on local disk while the node retries a query
+// that cannot succeed until those very rows are applied.
+//
+// The local replica may be stale, so a fallback result is returned with
+// authoritative=false and is only ever used to ADD peers. Adding a peer that
+// has since left is self-correcting (it simply never handshakes, and the next
+// authoritative sync removes it); failing to add one is not.
+func (n *Node) loadDesiredWireGuardPeers(ctx context.Context, localPubKey string) (desiredWGPeers, error) {
+	leaderDB := n.rqliteAdapter.GetSQLDB()
+	peers, err := scanWGPeers(ctx, leaderDB, localPubKey)
+	if err == nil {
+		return desiredWGPeers{peers: peers, authoritative: true, source: "leader"}, nil
+	}
+	leaderErr := err
+
+	localDB, localErr := n.rqliteAdapter.LocalDB()
+	if localErr != nil {
+		return desiredWGPeers{}, fmt.Errorf("failed to query wireguard_peers (leader: %v; local handle: %w)", leaderErr, localErr)
+	}
+	peers, localErr = scanWGPeers(ctx, localDB, localPubKey)
+	if localErr != nil {
+		return desiredWGPeers{}, fmt.Errorf("failed to query wireguard_peers (leader: %v; local: %w)", leaderErr, localErr)
+	}
+
+	n.logger.ComponentWarn(logging.ComponentNode,
+		"WireGuard peer list unavailable from the raft leader — falling back to the local replica so the mesh can be repaired without a quorum (additive only, no peers will be removed)",
+		zap.Int("local_peers", len(peers)),
+		zap.Error(leaderErr))
+	return desiredWGPeers{peers: peers, authoritative: false, source: "local-replica"}, nil
+}
+
+// scanWGPeers runs the membership query against db and returns the peer set
+// keyed by public key, excluding this node.
+//
+// A row that fails to scan is a hard error rather than a skip: silently
+// dropping rows shrinks the desired set, and a short desired set used to mean
+// "remove the peers that are missing from it" — i.e. a malformed row could cut
+// the node out of the mesh. Callers get all-or-nothing.
+func scanWGPeers(ctx context.Context, db *sql.DB, localPubKey string) (map[string]production.WireGuardPeer, error) {
+	rows, err := rqlite.SafeQueryContext(db, ctx, wgPeerQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	peers := make(map[string]production.WireGuardPeer)
+	for rows.Next() {
+		var nodeID, wgIP, pubKey, pubIP string
+		var wgPort int
+		if err := rows.Scan(&nodeID, &wgIP, &pubKey, &pubIP, &wgPort); err != nil {
+			return nil, fmt.Errorf("scan wireguard_peers row: %w", err)
+		}
+		if pubKey == "" || wgIP == "" {
+			return nil, fmt.Errorf("wireguard_peers row for node %q has an empty public_key or wg_ip", nodeID)
+		}
+		if pubKey == localPubKey {
+			continue // skip self
+		}
+		if wgPort == 0 {
+			wgPort = defaultWireGuardPort
+		}
+		peers[pubKey] = production.WireGuardPeer{
+			PublicKey: pubKey,
+			Endpoint:  fmt.Sprintf("%s:%d", pubIP, wgPort),
+			AllowedIP: wgIP + "/32",
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate wireguard_peers: %w", err)
+	}
+	return peers, nil
+}
+
+// syncWireGuardPeers reads the mesh membership and reconciles the local
+// WireGuard interface against it. Called at startup and every syncInterval.
 func (n *Node) syncWireGuardPeers(ctx context.Context) error {
 	if n.rqliteAdapter == nil {
 		return fmt.Errorf("rqlite adapter not initialized")
@@ -41,71 +151,98 @@ func (n *Node) syncWireGuardPeers(ctx context.Context) error {
 	currentPeers := parseWGShowPeers(string(out))
 	localPubKey := parseWGShowLocalKey(string(out))
 
-	// Query all peers from RQLite
-	db := n.rqliteAdapter.GetSQLDB()
-	rows, err := db.QueryContext(ctx,
-		"SELECT node_id, wg_ip, public_key, public_ip, wg_port FROM wireguard_peers ORDER BY wg_ip")
+	desired, err := n.loadDesiredWireGuardPeers(ctx, localPubKey)
 	if err != nil {
-		return fmt.Errorf("failed to query wireguard_peers: %w", err)
+		return err
 	}
-	defer rows.Close()
 
-	// Build desired peer set (excluding self)
-	desiredPeers := make(map[string]production.WireGuardPeer)
-	for rows.Next() {
-		var nodeID, wgIP, pubKey, pubIP string
-		var wgPort int
-		if err := rows.Scan(&nodeID, &wgIP, &pubKey, &pubIP, &wgPort); err != nil {
+	n.reconcileWireGuardPeers(currentPeers, desired)
+	return nil
+}
+
+// wgPeerProvisioner is the subset of production.WireGuardProvisioner the
+// reconciler needs. Declared here so reconcileWireGuardPeers can be exercised
+// without shelling out to `wg` — the add/remove decisions are the part worth
+// testing, and getting them wrong severs the cluster.
+type wgPeerProvisioner interface {
+	AddPeer(peer production.WireGuardPeer) error
+	RemovePeer(publicKey string) error
+}
+
+// reconcileWireGuardPeers applies desired onto the live interface.
+//
+// Removal is deliberately conservative. It runs ONLY when the desired set is
+// authoritative AND non-empty, because "I read zero peers" and "the cluster has
+// zero peers" are indistinguishable at this layer and the first is far more
+// likely — a node that has just lost quorum, a replica mid-restore, or a
+// migration in flight all produce an empty read. Treating that as "remove every
+// peer" severs the mesh, and severing the mesh is what makes the loss
+// unrecoverable. Adding peers is always safe, so adds are unconditional.
+func (n *Node) reconcileWireGuardPeers(currentPeers map[string]struct{}, desired desiredWGPeers) {
+	n.reconcileWireGuardPeersWith(&production.WireGuardProvisioner{}, currentPeers, desired)
+}
+
+// reconcileWireGuardPeersWith is reconcileWireGuardPeers against an injected
+// provisioner.
+func (n *Node) reconcileWireGuardPeersWith(wp wgPeerProvisioner, currentPeers map[string]struct{}, desired desiredWGPeers) {
+	added := 0
+	for pubKey, peer := range desired.peers {
+		if _, exists := currentPeers[pubKey]; exists {
 			continue
 		}
-		if pubKey == localPubKey {
-			continue // skip self
+		if err := wp.AddPeer(peer); err != nil {
+			n.logger.ComponentWarn(logging.ComponentNode, "failed to add WG peer",
+				zap.String("public_key", shortWGKey(pubKey)),
+				zap.Error(err))
+			continue
 		}
-		if wgPort == 0 {
-			wgPort = 51820
-		}
-		desiredPeers[pubKey] = production.WireGuardPeer{
-			PublicKey: pubKey,
-			Endpoint:  fmt.Sprintf("%s:%d", pubIP, wgPort),
-			AllowedIP: wgIP + "/32",
-		}
+		added++
+		n.logger.ComponentInfo(logging.ComponentNode, "added WG peer",
+			zap.String("allowed_ip", peer.AllowedIP),
+			zap.String("source", desired.source))
 	}
 
-	wp := &production.WireGuardProvisioner{}
-
-	// Add missing peers
-	for pubKey, peer := range desiredPeers {
-		if _, exists := currentPeers[pubKey]; !exists {
-			if err := wp.AddPeer(peer); err != nil {
-				n.logger.ComponentWarn(logging.ComponentNode, "failed to add WG peer",
-					zap.String("public_key", pubKey[:8]+"..."),
-					zap.Error(err))
-			} else {
-				n.logger.ComponentInfo(logging.ComponentNode, "added WG peer",
-					zap.String("allowed_ip", peer.AllowedIP))
+	removed := 0
+	canRemove := desired.authoritative && len(desired.peers) > 0
+	if canRemove {
+		for pubKey := range currentPeers {
+			if _, exists := desired.peers[pubKey]; exists {
+				continue
 			}
-		}
-	}
-
-	// Remove peers not in the desired set
-	for pubKey := range currentPeers {
-		if _, exists := desiredPeers[pubKey]; !exists {
 			if err := wp.RemovePeer(pubKey); err != nil {
 				n.logger.ComponentWarn(logging.ComponentNode, "failed to remove stale WG peer",
-					zap.String("public_key", pubKey[:8]+"..."),
+					zap.String("public_key", shortWGKey(pubKey)),
 					zap.Error(err))
-			} else {
-				n.logger.ComponentInfo(logging.ComponentNode, "removed stale WG peer",
-					zap.String("public_key", pubKey[:8]+"..."))
+				continue
 			}
+			removed++
+			n.logger.ComponentInfo(logging.ComponentNode, "removed stale WG peer",
+				zap.String("public_key", shortWGKey(pubKey)))
 		}
+	} else if len(currentPeers) > 0 {
+		n.logger.ComponentInfo(logging.ComponentNode,
+			"skipping WG peer removal — membership is not authoritative or came back empty; keeping the live mesh intact",
+			zap.Bool("authoritative", desired.authoritative),
+			zap.Int("desired_peers", len(desired.peers)),
+			zap.String("source", desired.source))
 	}
 
 	n.logger.ComponentInfo(logging.ComponentNode, "WireGuard peer sync completed",
-		zap.Int("desired_peers", len(desiredPeers)),
-		zap.Int("current_peers", len(currentPeers)))
+		zap.Int("desired_peers", len(desired.peers)),
+		zap.Int("current_peers", len(currentPeers)),
+		zap.Int("added", added),
+		zap.Int("removed", removed),
+		zap.Bool("authoritative", desired.authoritative),
+		zap.String("source", desired.source))
+}
 
-	return nil
+// shortWGKey truncates a WireGuard public key for logging. Full keys are not
+// secret (they are public keys) but they are noise at 44 chars.
+func shortWGKey(pubKey string) string {
+	if len(pubKey) <= wgKeyLogPrefixLen {
+		return pubKey
+	}
+	return pubKey[:wgKeyLogPrefixLen] + "..."
 }
 
 // ensureWireGuardSelfRegistered ensures this node's WireGuard info is in the
@@ -175,13 +312,13 @@ func (n *Node) ensureWireGuardSelfRegistered(ctx context.Context) {
 
 	_, err = rqlite.SafeExecContext(db, ctx,
 		"INSERT OR REPLACE INTO wireguard_peers (node_id, wg_ip, public_key, public_ip, wg_port, ipfs_peer_id) VALUES (?, ?, ?, ?, ?, ?)",
-		nodeID, wgIP, localPubKey, publicIP, 51820, ipfsPeerID)
+		nodeID, wgIP, localPubKey, publicIP, defaultWireGuardPort, ipfsPeerID)
 	if err != nil {
 		n.logger.ComponentWarn(logging.ComponentNode, "Failed to self-register WG peer", zap.Error(err))
 	} else {
 		n.logger.ComponentInfo(logging.ComponentNode, "WireGuard self-registered",
 			zap.String("wg_ip", wgIP),
-			zap.String("public_key", localPubKey[:8]+"..."),
+			zap.String("public_key", shortWGKey(localPubKey)),
 			zap.String("ipfs_peer_id", ipfsPeerID))
 	}
 }
@@ -214,9 +351,9 @@ func (n *Node) startWireGuardSyncLoop(ctx context.Context) {
 		n.logger.ComponentWarn(logging.ComponentNode, "initial WireGuard peer sync failed", zap.Error(err))
 	}
 
-	// Periodic sync every 60 seconds
+	// Periodic sync every wgSyncInterval
 	go func() {
-		ticker := time.NewTicker(60 * time.Second)
+		ticker := time.NewTicker(wgSyncInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/core/pkg/node/wireguard_sync_reconcile_test.go
+++ b/core/pkg/node/wireguard_sync_reconcile_test.go
@@ -1,0 +1,169 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/environments/production"
+	"github.com/DeBrosOfficial/network/pkg/logging"
+)
+
+// fakeProvisioner records reconciler decisions instead of touching a real
+// WireGuard interface.
+type fakeProvisioner struct {
+	added   []production.WireGuardPeer
+	removed []string
+	addErr  error
+	rmErr   error
+}
+
+func (f *fakeProvisioner) AddPeer(peer production.WireGuardPeer) error {
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.added = append(f.added, peer)
+	return nil
+}
+
+func (f *fakeProvisioner) RemovePeer(publicKey string) error {
+	if f.rmErr != nil {
+		return f.rmErr
+	}
+	f.removed = append(f.removed, publicKey)
+	return nil
+}
+
+func testNode(t *testing.T) *Node {
+	t.Helper()
+	lg, err := logging.NewColoredLogger(logging.ComponentNode, false)
+	if err != nil {
+		t.Fatalf("NewColoredLogger: %v", err)
+	}
+	return &Node{logger: lg}
+}
+
+func peerSet(keys ...string) map[string]struct{} {
+	s := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		s[k] = struct{}{}
+	}
+	return s
+}
+
+func desired(auth bool, source string, keys ...string) desiredWGPeers {
+	m := make(map[string]production.WireGuardPeer, len(keys))
+	for _, k := range keys {
+		m[k] = production.WireGuardPeer{PublicKey: k, AllowedIP: "10.0.0.9/32", Endpoint: "203.0.113.9:51820"}
+	}
+	return desiredWGPeers{peers: m, authoritative: auth, source: source}
+}
+
+func TestReconcileWireGuardPeers_authoritative_addsAndRemoves(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{}
+
+	// live: A, B — cluster says: B, C  => add C, remove A
+	n.reconcileWireGuardPeersWith(f, peerSet("A", "B"), desired(true, "leader", "B", "C"))
+
+	if len(f.added) != 1 || f.added[0].PublicKey != "C" {
+		t.Errorf("added = %+v; want exactly peer C", f.added)
+	}
+	if len(f.removed) != 1 || f.removed[0] != "A" {
+		t.Errorf("removed = %v; want exactly [A]", f.removed)
+	}
+}
+
+// The bootstrap-deadlock guarantee: a non-authoritative (local-replica) read
+// may ADD peers so a partitioned node can rebuild its mesh, but must never
+// remove — the local snapshot can be arbitrarily stale.
+func TestReconcileWireGuardPeers_localFallback_addsButNeverRemoves(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{}
+
+	n.reconcileWireGuardPeersWith(f, peerSet("A", "B"), desired(false, "local-replica", "B", "C"))
+
+	if len(f.added) != 1 || f.added[0].PublicKey != "C" {
+		t.Errorf("added = %+v; want exactly peer C (fallback must still repair the mesh)", f.added)
+	}
+	if len(f.removed) != 0 {
+		t.Errorf("removed = %v; a non-authoritative read must never remove peers", f.removed)
+	}
+}
+
+// The regression that severs a cluster: an empty desired set is "I learned
+// nothing", not "the cluster has no members". Removing on it takes the node
+// off the mesh, and being off the mesh is what makes the failure permanent.
+func TestReconcileWireGuardPeers_emptyAuthoritativeSet_doesNotRemove(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{}
+
+	n.reconcileWireGuardPeersWith(f, peerSet("A", "B"), desired(true, "leader"))
+
+	if len(f.removed) != 0 {
+		t.Errorf("removed = %v; an empty membership read must never wipe the live mesh", f.removed)
+	}
+	if len(f.added) != 0 {
+		t.Errorf("added = %+v; want none", f.added)
+	}
+}
+
+func TestReconcileWireGuardPeers_noCurrentPeers_addsAll(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{}
+
+	// The devnet outage shape: interface has zero peers, membership known.
+	n.reconcileWireGuardPeersWith(f, peerSet(), desired(false, "local-replica", "A", "B"))
+
+	if len(f.added) != 2 {
+		t.Errorf("added %d peers; want 2 (a peerless node must be able to rebuild)", len(f.added))
+	}
+	if len(f.removed) != 0 {
+		t.Errorf("removed = %v; want none", f.removed)
+	}
+}
+
+func TestReconcileWireGuardPeers_alreadyConverged_noChanges(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{}
+
+	n.reconcileWireGuardPeersWith(f, peerSet("A", "B"), desired(true, "leader", "A", "B"))
+
+	if len(f.added) != 0 || len(f.removed) != 0 {
+		t.Errorf("added=%+v removed=%v; a converged mesh must be left alone", f.added, f.removed)
+	}
+}
+
+// A failing AddPeer must not abort the loop — one unreachable peer should not
+// stop the others from being installed.
+func TestReconcileWireGuardPeers_addErrorDoesNotAbortRemaining(t *testing.T) {
+	n := testNode(t)
+	f := &fakeProvisioner{addErr: errFake}
+
+	n.reconcileWireGuardPeersWith(f, peerSet(), desired(true, "leader", "A", "B"))
+
+	if len(f.added) != 0 {
+		t.Errorf("added = %+v; the fake fails every add", f.added)
+	}
+	// Reaching here without panicking is the assertion: errors are logged and
+	// iteration continues.
+}
+
+func TestShortWGKey(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"abc", "abc"},
+		{"12345678", "12345678"},
+		{"123456789", "12345678..."},
+	}
+	for _, c := range cases {
+		if got := shortWGKey(c.in); got != c.want {
+			t.Errorf("shortWGKey(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// fakeErr is a canned provisioner failure.
+type fakeErr string
+
+func (e fakeErr) Error() string { return string(e) }
+
+var errFake = fakeErr("wg set failed")

--- a/core/pkg/rqlite/adapter.go
+++ b/core/pkg/rqlite/adapter.go
@@ -3,6 +3,7 @@ package rqlite
 import (
 	"database/sql"
 	"fmt"
+	"sync"
 	"time"
 
 	_ "github.com/rqlite/gorqlite/stdlib" // Import the database/sql driver
@@ -12,6 +13,11 @@ import (
 type RQLiteAdapter struct {
 	manager *RQLiteManager
 	db      *sql.DB
+
+	// localDB is the lazily-created level=none read handle returned by
+	// LocalDB(). Guarded by localMu. See localReadConsistencyLevel.
+	localMu sync.Mutex
+	localDB *sql.DB
 }
 
 // adapterReadConsistencyLevel is the rqlite consistency level used for
@@ -29,12 +35,19 @@ const adapterReadConsistencyLevel = "weak"
 // Pulled out for unit testing — the URL must encode `level=weak` (bug #235)
 // in addition to `disableClusterDiscovery=true`.
 func buildRQLiteDSN(host string, port int, username, password string) string {
+	return buildRQLiteDSNWithLevel(host, port, username, password, adapterReadConsistencyLevel)
+}
+
+// buildRQLiteDSNWithLevel is buildRQLiteDSN with an explicit read level, so the
+// bootstrap-only local handle (LocalDB) can ask for `none` while the main pool
+// keeps `weak`.
+func buildRQLiteDSNWithLevel(host string, port int, username, password, level string) string {
 	if username != "" && password != "" {
 		return fmt.Sprintf("http://%s:%s@%s:%d?disableClusterDiscovery=true&level=%s",
-			username, password, host, port, adapterReadConsistencyLevel)
+			username, password, host, port, level)
 	}
 	return fmt.Sprintf("http://%s:%d?disableClusterDiscovery=true&level=%s",
-		host, port, adapterReadConsistencyLevel)
+		host, port, level)
 }
 
 // NewRQLiteAdapter creates a new adapter that provides sql.DB interface for RQLite.
@@ -74,5 +87,62 @@ func (a *RQLiteAdapter) Close() error {
 	if a.db != nil {
 		a.db.Close()
 	}
+	a.localMu.Lock()
+	if a.localDB != nil {
+		a.localDB.Close()
+		a.localDB = nil
+	}
+	a.localMu.Unlock()
 	return a.manager.Stop()
+}
+
+// localReadConsistencyLevel is the rqlite read level used by LocalDB(). Unlike
+// adapterReadConsistencyLevel ("weak", leader-routed), `none` is answered from
+// THIS node's local SQLite without contacting the raft leader.
+//
+// It exists for exactly one job: BOOTSTRAP reads that must succeed while the
+// cluster has no leader. The canonical case is the WireGuard peer list — raft
+// runs over the WireGuard mesh, so a node with no peers can never elect a
+// leader, and a leader-routed read of `wireguard_peers` can never succeed. That
+// is a deadlock: the data needed to repair connectivity is unreachable because
+// connectivity is down. Reading the local replica breaks the cycle; the rows
+// are already on disk.
+//
+// A `none` read may be stale (bug #235), so callers MUST treat it as a
+// best-effort hint, never as authoritative cluster state — see
+// (*Node).loadDesiredWireGuardPeers for the additive-only contract this
+// enables.
+const localReadConsistencyLevel = "none"
+
+// LocalDB returns a lazily-created *sql.DB bound to this node's own rqlite at
+// read level `none`. Reads never leave the box and therefore work with no raft
+// leader; writes still route to the leader and fail without one, so this handle
+// is for reads only.
+//
+// The handle is created on first use and cached. Callers must not Close it —
+// Close() on the adapter owns its lifecycle.
+func (a *RQLiteAdapter) LocalDB() (*sql.DB, error) {
+	a.localMu.Lock()
+	defer a.localMu.Unlock()
+	if a.localDB != nil {
+		return a.localDB, nil
+	}
+	if a.manager == nil || a.manager.config == nil {
+		return nil, fmt.Errorf("rqlite adapter: manager config unavailable, cannot open local read connection")
+	}
+	dsn := buildRQLiteDSNWithLevel("localhost", a.manager.config.RQLitePort,
+		a.manager.config.RQLiteUsername, a.manager.config.RQLitePassword,
+		localReadConsistencyLevel)
+	db, err := sql.Open("rqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open local (level=none) RQLite connection: %w", err)
+	}
+	// Bootstrap-only path: a couple of connections is plenty and keeps the
+	// footprint next to the main pool negligible.
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(30 * time.Second)
+	db.SetConnMaxIdleTime(10 * time.Second)
+	a.localDB = db
+	return a.localDB, nil
 }

--- a/core/pkg/rqlite/batch.go
+++ b/core/pkg/rqlite/batch.go
@@ -79,6 +79,14 @@ type BatchResult struct {
 	Results     []OpResult `json:"results"`
 	Committed   bool       `json:"committed"`
 	FailedIndex int        `json:"failed_index,omitempty"` // valid only when !Committed
+	// Error carries a batch-level rejection reason — a validation failure
+	// (op count over MaxBatchOps, malformed JSON, unknown op kind) or a
+	// transport failure — as opposed to a per-op SQL error, which lives in the
+	// corresponding Results entry.
+	//
+	// Empty on success. Present whenever Committed is false for a reason that
+	// is not attributable to a single op.
+	Error string `json:"error,omitempty"`
 }
 
 // MaxBatchOps caps the number of ops in a single batch to prevent abuse.
@@ -328,7 +336,7 @@ func (c *client) BatchQueryConsistency(ctx context.Context, ops []BatchOp, rc Re
 	for i, qr := range qrs {
 		if totalBytes >= MaxBatchQueryTotalBytes {
 			out[i] = OpResult{
-				Kind:  BatchOpQuery,
+				Kind: BatchOpQuery,
 				Error: fmt.Sprintf("rqlite.BatchQuery: aggregate result bytes exceeded cap (%d) — earlier ops consumed the budget; this op result truncated",
 					MaxBatchQueryTotalBytes),
 			}
@@ -482,8 +490,8 @@ func queryResultToOpResult(qr gorqlite.QueryResult) OpResult {
 	for qr.Next() {
 		if len(rows) >= MaxBatchQueryRowsPerOp {
 			return OpResult{
-				Kind:  BatchOpQuery,
-				Rows:  rows,
+				Kind: BatchOpQuery,
+				Rows: rows,
 				Error: fmt.Sprintf("rqlite.BatchQuery: row cap exceeded (%d) — paginate via LIMIT/OFFSET",
 					MaxBatchQueryRowsPerOp),
 			}

--- a/core/pkg/rqlite/freshness.go
+++ b/core/pkg/rqlite/freshness.go
@@ -55,7 +55,7 @@ func LocalFollowerFresh(port int) (fresh bool, reason string, err error) {
 	if strings.EqualFold(raft.State, "Leader") {
 		return true, "leader", nil
 	}
-	lastContact := parseLastContact(raft.LastContact)
+	lastContact := parseLastContact(raft.LastContact.String())
 	if lastContact > StalenessMaxLastContact {
 		return false, fmt.Sprintf("follower last_contact=%q exceeds max %s (port %d) — degrading none-read to leader-routed weak", raft.LastContact, StalenessMaxLastContact, port), nil
 	}

--- a/core/pkg/rqlite/last_contact_test.go
+++ b/core/pkg/rqlite/last_contact_test.go
@@ -1,0 +1,95 @@
+package rqlite
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// rqlite reports store.raft.last_contact with a role-dependent JSON type: a
+// duration string on a follower, a bare number on the leader. Declaring the
+// field as a plain string made the LEADER's /status fail to decode, which took
+// out the whole RQLiteStatus parse and silently disabled the local-read
+// freshness gate on that node.
+func TestRQLiteStatus_lastContact_acceptsFollowerString(t *testing.T) {
+	body := `{"store":{"raft":{"state":"Follower","last_contact":"30.204191ms","commit_index":10,"applied_index":10}}}`
+
+	var st RQLiteStatus
+	if err := json.Unmarshal([]byte(body), &st); err != nil {
+		t.Fatalf("unmarshal follower status: %v", err)
+	}
+	if got := st.Store.Raft.LastContact.String(); got != "30.204191ms" {
+		t.Errorf("LastContact = %q; want 30.204191ms", got)
+	}
+}
+
+func TestRQLiteStatus_lastContact_acceptsLeaderNumber(t *testing.T) {
+	// The exact shape a live leader emits.
+	body := `{"store":{"raft":{"state":"Leader","last_contact":0,"commit_index":10,"applied_index":10}}}`
+
+	var st RQLiteStatus
+	if err := json.Unmarshal([]byte(body), &st); err != nil {
+		t.Fatalf("unmarshal leader status: %v — this is the bug: a number here aborted the whole decode", err)
+	}
+	if st.Store.Raft.State != "Leader" {
+		t.Errorf("State = %q; want Leader", st.Store.Raft.State)
+	}
+	if got := st.Store.Raft.LastContact.String(); got != "0s" {
+		t.Errorf("LastContact = %q; want 0s (nanoseconds rendered as a duration)", got)
+	}
+}
+
+func TestRQLiteStatus_lastContact_acceptsNonZeroNumber(t *testing.T) {
+	body := `{"store":{"raft":{"state":"Follower","last_contact":1500000}}}` // 1.5ms in ns
+
+	var st RQLiteStatus
+	if err := json.Unmarshal([]byte(body), &st); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := st.Store.Raft.LastContact.String(); got != "1.5ms" {
+		t.Errorf("LastContact = %q; want 1.5ms", got)
+	}
+}
+
+func TestRQLiteStatus_lastContact_acceptsNeverAndNull(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"never", `{"store":{"raft":{"last_contact":"never"}}}`, "never"},
+		{"null", `{"store":{"raft":{"last_contact":null}}}`, ""},
+		{"absent", `{"store":{"raft":{"state":"Leader"}}}`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var st RQLiteStatus
+			if err := json.Unmarshal([]byte(tc.body), &st); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := st.Store.Raft.LastContact.String(); got != tc.want {
+				t.Errorf("LastContact = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRQLiteStatus_lastContact_rejectsUnexpectedShape(t *testing.T) {
+	var st RQLiteStatus
+	err := json.Unmarshal([]byte(`{"store":{"raft":{"last_contact":{"nested":true}}}}`), &st)
+	if err == nil {
+		t.Fatal("an object last_contact should be rejected, not silently accepted")
+	}
+	if !strings.Contains(err.Error(), "last_contact") {
+		t.Errorf("error %q should name the offending field", err)
+	}
+}
+
+// The freshness gate's whole point: a Leader is always fresh enough to serve a
+// local read. That branch was unreachable while decoding failed first.
+func TestParseLastContact_leaderZeroIsFresh(t *testing.T) {
+	if got := parseLastContact("0s"); got != 0 {
+		t.Errorf("parseLastContact(%q) = %v; want 0", "0s", got)
+	}
+	if got := parseLastContact("never"); got != staleNeverContact {
+		t.Errorf("parseLastContact(never) = %v; want staleNeverContact", got)
+	}
+	if got := parseLastContact("garbage"); got != staleNeverContact {
+		t.Errorf("parseLastContact(garbage) = %v; want staleNeverContact (fail-safe)", got)
+	}
+}

--- a/core/pkg/rqlite/namespace_migrations.go
+++ b/core/pkg/rqlite/namespace_migrations.go
@@ -86,7 +86,7 @@ func ApplyEmbeddedMigrationsNamespace(ctx context.Context, db *sql.DB, fsys fs.F
 		if err := applySQLNamespace(ctx, db, string(sqlBytes)); err != nil {
 			return fmt.Errorf("apply migration %d (%s): %w", mf.Version, mf.Name, err)
 		}
-		if _, err := db.ExecContext(ctx, insert, mf.Version); err != nil {
+		if _, err := SafeExecContext(db, ctx, insert, mf.Version); err != nil {
 			return fmt.Errorf("record migration %d: %w", mf.Version, err)
 		}
 	}
@@ -151,7 +151,7 @@ func applySQLNamespace(ctx context.Context, db *sql.DB, script string) error {
 		if stmtTargetsStrippedTable(stmt) {
 			continue // core self-recording or dead-table DDL — never in a namespace DB
 		}
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
+		if _, err := SafeExecContext(db, ctx, stmt); err != nil {
 			if isAlreadyAppliedError(err) {
 				continue
 			}
@@ -177,7 +177,7 @@ func isolateNamespaceSchema(ctx context.Context, db *sql.DB, logger *zap.Logger)
 			return err
 		}
 		if isCoreTrackerShape(cols) {
-			if _, err := db.ExecContext(ctx, `DROP TABLE schema_migrations`); err != nil {
+			if _, err := SafeExecContext(db, ctx, `DROP TABLE schema_migrations`); err != nil {
 				return fmt.Errorf("drop core schema_migrations: %w", err)
 			}
 			logger.Info("namespace isolation: dropped core-owned schema_migrations (freed for tenant)")
@@ -201,7 +201,7 @@ func isolateNamespaceSchema(ctx context.Context, db *sql.DB, logger *zap.Logger)
 				return err
 			}
 			if n == 0 {
-				if _, err := db.ExecContext(ctx, `DROP TABLE subscriptions`); err != nil {
+				if _, err := SafeExecContext(db, ctx, `DROP TABLE subscriptions`); err != nil {
 					return fmt.Errorf("drop core subscriptions: %w", err)
 				}
 				logger.Info("namespace isolation: dropped dead core subscriptions table (freed for tenant)")
@@ -269,7 +269,7 @@ func seedTrackerFromLegacy(ctx context.Context, db *sql.DB, tracker string, logg
 		return nil // tenant-owned (any shape but core's exact {version,applied_at}); never read from it
 	}
 	q := fmt.Sprintf(`INSERT OR IGNORE INTO %s(version) SELECT version FROM schema_migrations`, tracker)
-	if _, err := db.ExecContext(ctx, q); err != nil {
+	if _, err := SafeExecContext(db, ctx, q); err != nil {
 		return fmt.Errorf("seed from legacy schema_migrations: %w", err)
 	}
 	logger.Info("namespace isolation: seeded isolated tracker from core-owned schema_migrations")
@@ -282,7 +282,7 @@ func ensureTrackerTable(ctx context.Context, db *sql.DB, tracker string) error {
 	if !safeIdent.MatchString(tracker) {
 		return fmt.Errorf("invalid tracker identifier %q", tracker)
 	}
-	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+	_, err := SafeExecContext(db, ctx, fmt.Sprintf(`
 CREATE TABLE IF NOT EXISTS %s (
 	version     INTEGER PRIMARY KEY,
 	applied_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -296,7 +296,7 @@ func loadAppliedVersionsFrom(ctx context.Context, db *sql.DB, tracker string) (m
 	if !safeIdent.MatchString(tracker) {
 		return nil, fmt.Errorf("invalid tracker identifier %q", tracker)
 	}
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(`SELECT version FROM %s`, tracker))
+	rows, err := SafeQueryContext(db, ctx, fmt.Sprintf(`SELECT version FROM %s`, tracker))
 	if err != nil {
 		if isNoSuchTable(err) {
 			if err := ensureTrackerTable(ctx, db, tracker); err != nil {
@@ -354,7 +354,7 @@ func tableColumns(ctx context.Context, db *sql.DB, name string) ([]string, error
 	if !safeIdent.MatchString(name) {
 		return nil, fmt.Errorf("invalid table identifier %q", name)
 	}
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(`SELECT name FROM pragma_table_info('%s')`, name))
+	rows, err := SafeQueryContext(db, ctx, fmt.Sprintf(`SELECT name FROM pragma_table_info('%s')`, name))
 	if err != nil {
 		return nil, fmt.Errorf("read columns of %q: %w", name, err)
 	}

--- a/core/pkg/rqlite/readiness.go
+++ b/core/pkg/rqlite/readiness.go
@@ -1,0 +1,75 @@
+package rqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const (
+	// readinessPollInterval is how often WaitForLeader re-probes. Short enough
+	// that a normal boot (leader already elected) proceeds immediately, long
+	// enough not to hammer a node that is still replaying its raft log.
+	readinessPollInterval = 500 * time.Millisecond
+
+	// readinessProbe is the cheapest statement that still proves the node can
+	// serve a leader-routed read: it needs a leader, but touches no table, so
+	// it works before any migration has run.
+	readinessProbe = "SELECT 1"
+)
+
+// WaitForLeader blocks until the rqlite behind db can serve a leader-routed
+// read, or until timeout elapses.
+//
+// Why this exists: opening a database/sql handle to rqlite establishes nothing
+// — sql.Open is lazy, and rqlite accepts connections long before it has
+// elected a leader. Schema migrations issued into that window fail with
+// "leader not found", and (before SafeExecContext was applied to the migration
+// path) crashed the process outright. systemd's After=/Requires= does not close
+// the gap: for Type=simple units it only orders process *start*, which says
+// nothing about whether the database is usable.
+//
+// So the ordering is enforced here, against the real readiness signal, rather
+// than assumed from unit ordering or slept on.
+//
+// A nil db is a programming error and returns immediately.
+func WaitForLeader(ctx context.Context, db *sql.DB, timeout time.Duration) error {
+	if db == nil {
+		return fmt.Errorf("rqlite.WaitForLeader: nil database handle")
+	}
+
+	deadline := time.Now().Add(timeout)
+	attempts := 0
+	var lastErr error
+
+	for {
+		attempts++
+		// A per-probe budget keeps one hung request from eating the whole
+		// window; the loop retries until the outer deadline instead.
+		probeCtx, cancel := context.WithTimeout(ctx, readinessPollInterval*4)
+		rows, err := SafeQueryContext(db, probeCtx, readinessProbe)
+		if err == nil {
+			rows.Close()
+			cancel()
+			return nil
+		}
+		cancel()
+		lastErr = err
+
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("rqlite.WaitForLeader: cancelled after %d attempts (last error: %v): %w", attempts, lastErr, ctxErr)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rqlite.WaitForLeader: no leader after %s and %d attempts — "+
+				"check that the local rqlited is running and that this node can reach its raft peers "+
+				"over the WireGuard mesh (last error: %w)", timeout, attempts, lastErr)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("rqlite.WaitForLeader: cancelled after %d attempts (last error: %v): %w", attempts, lastErr, ctx.Err())
+		case <-time.After(readinessPollInterval):
+		}
+	}
+}

--- a/core/pkg/rqlite/readiness_test.go
+++ b/core/pkg/rqlite/readiness_test.go
@@ -1,0 +1,161 @@
+package rqlite
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// flakyDriver answers the readiness probe with an error until failCount
+// attempts have been made, then succeeds — modelling an rqlite that comes up
+// without a leader and elects one shortly after.
+type flakyDriver struct {
+	failCount int32
+	attempts  atomic.Int32
+	failWith  error
+	panicOnce atomic.Bool
+	panics    bool
+}
+
+func (d *flakyDriver) Open(string) (driver.Conn, error) { return &flakyConn{d: d}, nil }
+
+type flakyConn struct{ d *flakyDriver }
+
+func (c *flakyConn) Prepare(string) (driver.Stmt, error) { return &flakyStmt{d: c.d}, nil }
+func (c *flakyConn) Close() error                        { return nil }
+func (c *flakyConn) Begin() (driver.Tx, error)           { return nil, errors.New("no tx") }
+
+type flakyStmt struct{ d *flakyDriver }
+
+func (s *flakyStmt) Close() error  { return nil }
+func (s *flakyStmt) NumInput() int { return 0 }
+func (s *flakyStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("not used")
+}
+
+func (s *flakyStmt) Query([]driver.Value) (driver.Rows, error) {
+	n := s.d.attempts.Add(1)
+	if s.d.panics && s.d.panicOnce.CompareAndSwap(false, true) {
+		// Reproduces the gorqlite defect: index a result slice that is empty.
+		var empty []int
+		_ = empty[0]
+	}
+	if n <= s.d.failCount {
+		return nil, s.d.failWith
+	}
+	return &emptyRows{}, nil
+}
+
+type emptyRows struct{}
+
+func (r *emptyRows) Columns() []string              { return []string{"1"} }
+func (r *emptyRows) Close() error                   { return nil }
+func (r *emptyRows) Next(dest []driver.Value) error { return io.EOF }
+
+func registerFlaky(t *testing.T, d *flakyDriver) *sql.DB {
+	t.Helper()
+	name := "flaky-" + t.Name()
+	sql.Register(name, d)
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestWaitForLeader_returnsOnceLeaderElected(t *testing.T) {
+	d := &flakyDriver{failCount: 3, failWith: errors.New("leader address: leader not found")}
+	db := registerFlaky(t, d)
+
+	start := time.Now()
+	if err := WaitForLeader(context.Background(), db, 10*time.Second); err != nil {
+		t.Fatalf("WaitForLeader: %v", err)
+	}
+	if got := d.attempts.Load(); got < 4 {
+		t.Errorf("attempts = %d; want at least 4 (3 failures then success)", got)
+	}
+	if elapsed := time.Since(start); elapsed < readinessPollInterval {
+		t.Errorf("returned in %s without backing off between probes", elapsed)
+	}
+}
+
+func TestWaitForLeader_succeedsImmediatelyWhenReady(t *testing.T) {
+	d := &flakyDriver{failCount: 0}
+	db := registerFlaky(t, d)
+
+	start := time.Now()
+	if err := WaitForLeader(context.Background(), db, 5*time.Second); err != nil {
+		t.Fatalf("WaitForLeader: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("a ready database took %s; startup must not pay a fixed delay", elapsed)
+	}
+}
+
+func TestWaitForLeader_timesOutWithActionableError(t *testing.T) {
+	d := &flakyDriver{failCount: 1 << 30, failWith: errors.New("leader address: leader not found")}
+	db := registerFlaky(t, d)
+
+	err := WaitForLeader(context.Background(), db, 1200*time.Millisecond)
+	if err == nil {
+		t.Fatal("want a timeout error when no leader ever appears")
+	}
+	for _, want := range []string{"no leader", "WireGuard", "leader not found"} {
+		if !contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q so an operator knows where to look", err, want)
+		}
+	}
+}
+
+func TestWaitForLeader_honoursContextCancellation(t *testing.T) {
+	d := &flakyDriver{failCount: 1 << 30, failWith: errors.New("leader address: leader not found")}
+	db := registerFlaky(t, d)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if err := WaitForLeader(ctx, db, time.Hour); err == nil {
+		t.Fatal("want an error when the context is cancelled")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("cancellation took %s to take effect", elapsed)
+	}
+}
+
+func TestWaitForLeader_nilDB(t *testing.T) {
+	if err := WaitForLeader(context.Background(), nil, time.Second); err == nil {
+		t.Fatal("want an error for a nil handle")
+	}
+}
+
+// The probe must survive the gorqlite panic rather than taking the process
+// down — that panic at boot is what turned a slow database into a crash-loop.
+func TestWaitForLeader_survivesDriverPanic(t *testing.T) {
+	d := &flakyDriver{failCount: 0, panics: true}
+	db := registerFlaky(t, d)
+
+	if err := WaitForLeader(context.Background(), db, 5*time.Second); err != nil {
+		t.Fatalf("WaitForLeader should recover the driver panic and retry, got: %v", err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/core/pkg/rqlite/safe_exec.go
+++ b/core/pkg/rqlite/safe_exec.go
@@ -6,9 +6,28 @@ import (
 	"fmt"
 )
 
-// SafeExecContext wraps db.ExecContext with panic recovery.
-// The gorqlite stdlib driver can panic with "index out of range" when
-// RQLite is temporarily unavailable. This converts the panic to an error.
+// The gorqlite stdlib driver reaches into the first element of the result slice
+// without checking that the slice is non-empty:
+//
+//	func (conn *Connection) WriteOneParameterizedContext(...) (WriteResult, error) {
+//	    wra, err := conn.WriteParameterizedContext(ctx, []ParameterizedStatement{statement})
+//	    return wra[0], err   // panics when wra is empty
+//	}
+//
+// When rqlite is reachable but cannot serve the request — no raft leader yet at
+// boot, an election in flight, a connection reset mid-statement — the driver
+// returns an empty slice alongside the error, and that indexing panics. An
+// unrecovered panic in a request goroutine takes the whole process down, so a
+// transient database condition becomes a crash-loop instead of a returned
+// error. The same shape exists in all four WriteOne* variants.
+//
+// The wrappers below convert that panic into an ordinary error at every call
+// site that touches the driver through database/sql. Every gateway and node
+// path that runs SQL against rqlite MUST go through them rather than calling
+// db.ExecContext / db.QueryContext directly.
+
+// SafeExecContext wraps db.ExecContext with panic recovery, converting a
+// gorqlite driver panic into an error.
 func SafeExecContext(db *sql.DB, ctx context.Context, query string, args ...interface{}) (result sql.Result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16,4 +35,19 @@ func SafeExecContext(db *sql.DB, ctx context.Context, query string, args ...inte
 		}
 	}()
 	return db.ExecContext(ctx, query, args...)
+}
+
+// SafeQueryContext wraps db.QueryContext with panic recovery, converting a
+// gorqlite driver panic into an error.
+//
+// On success the caller owns the returned *sql.Rows and must Close it, exactly
+// as with db.QueryContext. On error rows is nil.
+func SafeQueryContext(db *sql.DB, ctx context.Context, query string, args ...interface{}) (rows *sql.Rows, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			rows = nil
+			err = fmt.Errorf("gorqlite panic (QueryContext): %v", r)
+		}
+	}()
+	return db.QueryContext(ctx, query, args...)
 }

--- a/core/pkg/rqlite/safe_query_test.go
+++ b/core/pkg/rqlite/safe_query_test.go
@@ -1,0 +1,112 @@
+package rqlite
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// panicDriver reproduces the gorqlite defect: WriteOne*/query helpers index the
+// first element of a result slice without checking that the slice is non-empty,
+// so a transient database condition panics instead of returning an error.
+type panicDriver struct{ mode string }
+
+func (d *panicDriver) Open(string) (driver.Conn, error) { return &panicConn{d: d}, nil }
+
+type panicConn struct{ d *panicDriver }
+
+func (c *panicConn) Prepare(string) (driver.Stmt, error) { return &panicStmt{d: c.d}, nil }
+func (c *panicConn) Close() error                        { return nil }
+func (c *panicConn) Begin() (driver.Tx, error)           { return nil, errors.New("no tx") }
+
+type panicStmt struct{ d *panicDriver }
+
+func (s *panicStmt) Close() error  { return nil }
+func (s *panicStmt) NumInput() int { return 0 }
+
+func (s *panicStmt) Exec([]driver.Value) (driver.Result, error) {
+	if s.d.mode == "exec" || s.d.mode == "both" {
+		var empty []int
+		_ = empty[0] // index out of range [0] with length 0
+	}
+	return driver.RowsAffected(0), nil
+}
+
+func (s *panicStmt) Query([]driver.Value) (driver.Rows, error) {
+	if s.d.mode == "query" || s.d.mode == "both" {
+		var empty []int
+		_ = empty[0]
+	}
+	return &noRows{}, nil
+}
+
+type noRows struct{}
+
+func (r *noRows) Columns() []string              { return []string{"x"} }
+func (r *noRows) Close() error                   { return nil }
+func (r *noRows) Next(dest []driver.Value) error { return io.EOF }
+
+func openPanicDB(t *testing.T, mode string) *sql.DB {
+	t.Helper()
+	name := "panic-" + t.Name()
+	sql.Register(name, &panicDriver{mode: mode})
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestSafeQueryContext_convertsDriverPanicToError(t *testing.T) {
+	db := openPanicDB(t, "query")
+
+	rows, err := SafeQueryContext(db, context.Background(), "SELECT 1")
+	if err == nil {
+		if rows != nil {
+			rows.Close()
+		}
+		t.Fatal("want an error, not a panic escaping to the caller")
+	}
+	if rows != nil {
+		t.Error("rows must be nil when the driver panicked")
+	}
+	if !strings.Contains(err.Error(), "gorqlite panic") {
+		t.Errorf("error = %q; want it to name the gorqlite panic", err)
+	}
+}
+
+func TestSafeExecContext_convertsDriverPanicToError(t *testing.T) {
+	db := openPanicDB(t, "exec")
+
+	if _, err := SafeExecContext(db, context.Background(), "CREATE TABLE t (id INTEGER)"); err == nil {
+		t.Fatal("want an error, not a panic escaping to the caller")
+	} else if !strings.Contains(err.Error(), "gorqlite panic") {
+		t.Errorf("error = %q; want it to name the gorqlite panic", err)
+	}
+}
+
+func TestSafeQueryContext_passesThroughSuccess(t *testing.T) {
+	db := openPanicDB(t, "none")
+
+	rows, err := SafeQueryContext(db, context.Background(), "SELECT 1")
+	if err != nil {
+		t.Fatalf("SafeQueryContext: %v", err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		t.Error("expected no rows from the stub")
+	}
+}
+
+func TestSafeExecContext_passesThroughSuccess(t *testing.T) {
+	db := openPanicDB(t, "none")
+
+	if _, err := SafeExecContext(db, context.Background(), "CREATE TABLE t (id INTEGER)"); err != nil {
+		t.Fatalf("SafeExecContext: %v", err)
+	}
+}

--- a/core/pkg/rqlite/types.go
+++ b/core/pkg/rqlite/types.go
@@ -1,6 +1,11 @@
 package rqlite
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
 
 // RQLiteStatus represents the response from RQLite's /status endpoint
 type RQLiteStatus struct {
@@ -18,10 +23,10 @@ type RQLiteStatus struct {
 			// "1.2s") or the literal "never" before first contact. Empty/absent
 			// on the leader's own /status. Used by the local-follower freshness
 			// gate (freshness.go) to decide whether a none-read is safe.
-			LastContact       string `json:"last_contact"`
-			Term              uint64 `json:"term"`
-			NumPeers          int    `json:"num_peers"`
-			Voter             bool   `json:"voter"`
+			LastContact LastContactValue `json:"last_contact"`
+			Term        uint64           `json:"term"`
+			NumPeers    int              `json:"num_peers"`
+			Voter       bool             `json:"voter"`
 		} `json:"raft"`
 		DBConf struct {
 			DSN    string `json:"dsn"`
@@ -77,3 +82,56 @@ type ClusterMetrics struct {
 	CurrentLeader     string
 	AveragePeerHealth float64
 }
+
+// LastContactValue decodes rqlite's `store.raft.last_contact`, whose JSON type
+// depends on the node's raft role:
+//
+//	follower: "last_contact": "30.204191ms"   (duration string, or "never")
+//	leader:   "last_contact": 0               (number)
+//
+// Declaring it as a plain string made json.Unmarshal fail on the LEADER's
+// /status with "cannot unmarshal number into ... of type string". That error
+// aborted the whole RQLiteStatus decode, so GetRaftStatus returned an error,
+// so the freshness gate fail-safed to "not fresh" — silently disabling the
+// local (level=none) read path on the one node where a local read is always
+// authoritative. The gate's own `state == "Leader" → always fresh` fast path
+// was unreachable in production because decoding never got that far.
+//
+// Accepting both shapes keeps the gate working for either role.
+type LastContactValue string
+
+// UnmarshalJSON accepts a JSON string, a JSON number, or null.
+func (v *LastContactValue) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		*v = ""
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("last_contact string: %w", err)
+		}
+		*v = LastContactValue(s)
+		return nil
+	}
+	// Numeric form: rqlite emits nanoseconds (0 on the leader). Render it as a
+	// duration string so downstream has a single representation to parse.
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return fmt.Errorf("last_contact number: %w", err)
+	}
+	ns, err := n.Int64()
+	if err != nil {
+		f, ferr := n.Float64()
+		if ferr != nil {
+			return fmt.Errorf("last_contact numeric value %q: %w", n.String(), ferr)
+		}
+		ns = int64(f)
+	}
+	*v = LastContactValue(time.Duration(ns).String())
+	return nil
+}
+
+// String returns the duration text for logging and parsing.
+func (v LastContactValue) String() string { return string(v) }

--- a/core/pkg/serverless/engine.go
+++ b/core/pkg/serverless/engine.go
@@ -3,6 +3,7 @@ package serverless
 import (
 	"context"
 	cryptorand "crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 	"go.uber.org/zap"
 
+	"github.com/DeBrosOfficial/network/pkg/rqlite"
 	"github.com/DeBrosOfficial/network/pkg/serverless/cache"
 	"github.com/DeBrosOfficial/network/pkg/serverless/execution"
 )
@@ -742,7 +744,7 @@ func (e *Engine) instantiateReactorInstance(ctx context.Context, wasmCID, name s
 		WithStdout(discardWriter{}).
 		WithStderr(discardWriter{}).
 		WithArgs(name).
-		WithSysWalltime().  // real clocks (bugboard #27)
+		WithSysWalltime(). // real clocks (bugboard #27)
 		WithSysNanotime().
 		WithRandSource(cryptorand.Reader) // real CSPRNG (bugboard #120)
 
@@ -1314,10 +1316,35 @@ func (e *Engine) hDBTransaction(ctx context.Context, mod api.Module, opsPtr, ops
 	}
 	out, err := e.hostServices.DBTransaction(ctx, opsJSON)
 	if err != nil {
+		// Return a structured rejection instead of 0 (bugboard #175).
+		//
+		// Returning 0 gave the guest an empty buffer with no reason, which
+		// surfaced to callers as "host returned empty envelope". A real
+		// namespace outage was diagnosed that way: a group write exceeding
+		// MaxBatchOps failed deterministically, and neither the function nor
+		// its operators could see why — the reason existed only in the
+		// gateway's own journal, which tenants cannot read.
 		e.logger.Warn("host function db_transaction failed", zap.Error(err))
-		return 0
+		return e.writeBatchRejection(ctx, mod, err)
 	}
 	return e.executor.WriteToGuest(ctx, mod, out)
+}
+
+// writeBatchRejection serializes a batch-level failure into the guest as a
+// BatchResult carrying Error, so a WASM caller reading the normal envelope sees
+// committed=false plus the reason. Falls back to 0 only if the envelope itself
+// cannot be written, which is the pre-existing "no information" signal.
+func (e *Engine) writeBatchRejection(ctx context.Context, mod api.Module, cause error) uint64 {
+	payload, mErr := json.Marshal(rqlite.BatchResult{
+		Results:   []rqlite.OpResult{},
+		Committed: false,
+		Error:     cause.Error(),
+	})
+	if mErr != nil {
+		e.logger.Error("failed to marshal db_transaction rejection envelope", zap.Error(mErr))
+		return 0
+	}
+	return e.executor.WriteToGuest(ctx, mod, payload)
 }
 
 // hDBQueryBatch is the WASM-callable wrapper for DBQueryBatch.

--- a/core/pkg/serverless/persistent/fakes_test.go
+++ b/core/pkg/serverless/persistent/fakes_test.go
@@ -1,0 +1,75 @@
+package persistent
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// entryProbe records how many goroutines are inside the "module" at once.
+//
+// A real wazero instance does not detect concurrent entry — it corrupts its
+// guest stack and the Go runtime dies with a fatal error that recover() cannot
+// catch, taking the whole gateway process down. wazero's own docs say Call
+// "should not be called multiple times until the previous Call returns". So the
+// invariant is asserted here instead.
+type entryProbe struct {
+	inside    atomic.Int32
+	maxInside atomic.Int32
+	calls     atomic.Int32
+	hold      time.Duration
+}
+
+func (p *entryProbe) enter() {
+	n := p.inside.Add(1)
+	for {
+		cur := p.maxInside.Load()
+		if n <= cur || p.maxInside.CompareAndSwap(cur, n) {
+			break
+		}
+	}
+	p.calls.Add(1)
+	if p.hold > 0 {
+		time.Sleep(p.hold)
+	}
+	p.inside.Add(-1)
+}
+
+// fakeFunction is an api.Function whose Call routes through the probe.
+type fakeFunction struct {
+	probe  *entryProbe
+	result uint64
+}
+
+func (f *fakeFunction) Call(ctx context.Context, params ...uint64) ([]uint64, error) {
+	f.probe.enter()
+	return []uint64{f.result}, nil
+}
+
+// fakeMemory satisfies guestMemory.
+type fakeMemory struct{ buf []byte }
+
+func (m *fakeMemory) Write(offset uint32, v []byte) bool {
+	need := int(offset) + len(v)
+	if need > len(m.buf) {
+		grown := make([]byte, need)
+		copy(grown, m.buf)
+		m.buf = grown
+	}
+	copy(m.buf[offset:], v)
+	return true
+}
+
+// fakeModule satisfies guestModule. Close routes through the probe so a
+// teardown racing an in-flight frame is caught exactly as a real wazero
+// module.Close would race guest execution.
+type fakeModule struct {
+	probe  *entryProbe
+	closed atomic.Bool
+}
+
+func (m *fakeModule) Close(context.Context) error {
+	m.probe.enter()
+	m.closed.Store(true)
+	return nil
+}

--- a/core/pkg/serverless/persistent/instance.go
+++ b/core/pkg/serverless/persistent/instance.go
@@ -38,27 +38,50 @@ const (
 // to this function.
 type SendFunc func(data []byte) error
 
+// guestFunc is the callable surface of an exported WASM function.
+// api.Function satisfies it.
+type guestFunc interface {
+	Call(ctx context.Context, params ...uint64) ([]uint64, error)
+}
+
+// guestMemory is the part of a module's linear memory the instance writes to.
+// api.Memory satisfies it.
+type guestMemory interface {
+	Write(offset uint32, v []byte) bool
+}
+
+// guestModule is the instance's ownership handle on the wazero module.
+// api.Module satisfies it.
+type guestModule interface {
+	Close(ctx context.Context) error
+}
+
 // Instance owns one WASM module bound to one WebSocket connection.
 //
 // Lifecycle:
 //
-//	1. NewInstance — wraps an already-instantiated module
-//	2. Open(input) — calls ws_open; non-zero return = reject
-//	3. Run(ctx) — drains the inbound channel, calling ws_frame per message;
-//	              blocks until ctx cancelled or instance closed
-//	4. Submit(frame) — enqueues a frame for Run to pick up; returns error if full
-//	5. Close(reason) — calls ws_close; closes the wazero instance; idempotent
+//  1. NewInstance — wraps an already-instantiated module
+//  2. Open(input) — calls ws_open; non-zero return = reject
+//  3. Run(ctx) — drains the inbound channel, calling ws_frame per message;
+//     blocks until ctx cancelled or instance closed
+//  4. Submit(frame) — enqueues a frame for Run to pick up; returns error if full
+//  5. Close(reason) — calls ws_close; closes the wazero instance; idempotent
 type Instance struct {
 	clientID     string
 	functionName string
 	namespace    string
 
-	module   api.Module   // wazero instance, owned by this struct
-	openFn   api.Function // exported ws_open
-	frameFn  api.Function // exported ws_frame
-	closeFn  api.Function // exported ws_close
-	allocFn  api.Function // orama_alloc / malloc — for input bytes
-	memory   api.Memory
+	// The wazero handles are held through the narrowest interfaces this type
+	// actually uses. api.Module and api.Memory are sealed (wazeroOnly), so
+	// depending on them directly makes the instance lifecycle untestable
+	// without a full runtime — and the lifecycle is exactly where the
+	// process-killing concurrency bug lived.
+	module  guestModule // wazero instance, owned by this struct
+	openFn  guestFunc   // exported ws_open
+	frameFn guestFunc   // exported ws_frame
+	closeFn guestFunc   // exported ws_close
+	allocFn guestFunc   // orama_alloc / malloc — for input bytes
+	memory  guestMemory
 
 	// Per-instance invocation context. Bound at NewInstance time and
 	// attached to every WASM-host call's ctx via
@@ -80,9 +103,40 @@ type Instance struct {
 	// Per-frame timeout. Bounded by the function's TimeoutSeconds.
 	frameTimeout time.Duration
 
+	// callMu serializes EVERY entry into the wazero module — ws_open, ws_frame,
+	// ws_close and the final module.Close.
+	//
+	// wazero instances are not goroutine-safe: the wazevo engine keeps a single
+	// manually-managed guest stack per instance and executes guest code on the
+	// calling goroutine. Two goroutines inside one instance corrupt that
+	// bookkeeping, and the failure is not a returned error — it is a Go runtime
+	// fatal (`split stack overflow`, `unknown caller pc`, `bad recovery`) that
+	// no recover() can catch, so it kills the whole gateway process and every
+	// other WebSocket on the node.
+	//
+	// The frame loop and Close ran concurrently: teardown cancelled Run's
+	// context and then called ws_close immediately, without waiting for an
+	// in-flight frame to unwind. Frame execution is bounded by frameTimeout
+	// (seconds), so the window was wide open — and it is widest exactly when
+	// frames are slow, which is also when clients give up and disconnect.
+	callMu sync.Mutex
+
+	// runDone is closed when Run returns, so Close can wait for the frame loop
+	// to finish before tearing the module down. runStarted reports whether Run
+	// was ever launched — Close must not wait on a loop that will never run
+	// (e.g. an instance rejected by ws_open).
+	runDone    chan struct{}
+	runOnce    sync.Once
+	runStarted atomic.Bool
+
 	// Closed exactly once.
 	closeOnce sync.Once
 	closed    atomic.Bool
+}
+
+// signalRunDone marks the frame loop as finished. Idempotent.
+func (i *Instance) signalRunDone() {
+	i.runOnce.Do(func() { close(i.runDone) })
 }
 
 // Config holds knobs for a persistent instance. Zero values use sensible
@@ -167,6 +221,7 @@ func NewInstance(module api.Module, cfg Config, logger *zap.Logger) (*Instance, 
 		inbound:      make(chan []byte, maxInflight),
 		logger:       logger,
 		frameTimeout: frameTimeout,
+		runDone:      make(chan struct{}),
 	}, nil
 }
 
@@ -278,6 +333,11 @@ func (i *Instance) Submit(frame []byte) error {
 //
 // Frames are processed serially — wazero instances are not goroutine-safe.
 func (i *Instance) Run(ctx context.Context) {
+	i.runStarted.Store(true)
+	// Signalled on every exit path so Close never waits on a loop that has
+	// already stopped.
+	defer i.signalRunDone()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -318,11 +378,36 @@ func (i *Instance) handleFrame(ctx context.Context, frame []byte) error {
 func (i *Instance) Close(ctx context.Context, reason CloseReason) {
 	i.closeOnce.Do(func() {
 		i.closed.Store(true)
-		// Drain channel to unblock any blocked Submit on the way out.
-		go func() {
-			for range i.inbound {
-			}
-		}()
+		// The inbound channel is deliberately NOT closed, and there is no
+		// drain goroutine.
+		//
+		// Closing it raced Submit: the closed-flag check and the send are not
+		// atomic, so a frame arriving during teardown could send on an
+		// already-closed channel — an unrecoverable panic in the WebSocket
+		// read loop. The drain goroutine that motivated the close was itself
+		// unnecessary, because Submit is non-blocking (select with default),
+		// so no sender is ever parked on this channel.
+		//
+		// Leaving it open is safe: once Run has returned nothing reads it, any
+		// buffered frames are dropped, and the channel is reclaimed with the
+		// instance.
+
+		// Wait for the frame loop to unwind before entering the module again.
+		//
+		// The caller cancels Run's context just before calling us, but
+		// cancellation is asynchronous: a frame already executing inside wazero
+		// keeps running until the guest yields. Entering the module for
+		// ws_close while that frame is still in flight is a concurrent entry
+		// into a non-goroutine-safe instance, which crashes the PROCESS rather
+		// than failing the request (see callMu).
+		//
+		// callMu alone would make that safe, but waiting also preserves the
+		// ABI's ordering guarantee — ws_close is the last callback a function
+		// sees, after the final ws_frame. The wait is bounded so a wedged guest
+		// delays teardown instead of leaking the goroutine; callMu still holds
+		// the safety property if the wait times out.
+		i.waitForRunLoop()
+
 		// Best-effort ws_close — don't propagate errors; we're shutting down.
 		closeCtx, cancel := context.WithTimeout(i.withInvCtx(ctx), i.frameTimeout)
 		defer cancel()
@@ -332,13 +417,41 @@ func (i *Instance) Close(ctx context.Context, reason CloseReason) {
 				zap.Error(err),
 			)
 		}
-		close(i.inbound)
-		if err := i.module.Close(context.Background()); err != nil {
+		// module.Close tears down the same instance the frame loop executes in,
+		// so it takes callMu too.
+		i.callMu.Lock()
+		err := i.module.Close(context.Background())
+		i.callMu.Unlock()
+		if err != nil {
 			i.logger.Debug("persistent module.Close error",
 				zap.String("client_id", i.clientID),
 				zap.Error(err))
 		}
 	})
+}
+
+// runLoopDrainTimeout bounds how long Close waits for the frame loop to unwind
+// before proceeding anyway. Sized above the per-frame timeout so a normal
+// in-flight frame always gets to finish; past that the guest is wedged and
+// teardown must not be held hostage (callMu still guarantees safety).
+const runLoopDrainGrace = 2 * time.Second
+
+// waitForRunLoop blocks until Run has returned, or until the frame timeout plus
+// a small grace elapses. Returns immediately when Run was never started.
+func (i *Instance) waitForRunLoop() {
+	if !i.runStarted.Load() {
+		return
+	}
+	timer := time.NewTimer(i.frameTimeout + runLoopDrainGrace)
+	defer timer.Stop()
+	select {
+	case <-i.runDone:
+	case <-timer.C:
+		i.logger.Warn("persistent frame loop did not stop before teardown deadline; closing anyway",
+			zap.String("client_id", i.clientID),
+			zap.String("function", i.functionName),
+		)
+	}
 }
 
 // callExport allocates space in the guest, copies `payload` into it, calls
@@ -349,7 +462,13 @@ func (i *Instance) Close(ctx context.Context, reason CloseReason) {
 // at the per-instance level, and we rely on the module being closed at
 // session end. For long-running instances with very high frame rates,
 // memory growth is bounded by the function's memory_limit_mb.
-func (i *Instance) callExport(ctx context.Context, fn api.Function, payload []byte) (uint32, error) {
+func (i *Instance) callExport(ctx context.Context, fn guestFunc, payload []byte) (uint32, error) {
+	// Single entry point into the module — see callMu. Every export call and
+	// the module teardown funnel through this lock, so a wazero instance is
+	// only ever executing on one goroutine at a time.
+	i.callMu.Lock()
+	defer i.callMu.Unlock()
+
 	var ptr uint64
 	if len(payload) > 0 {
 		results, err := i.allocFn.Call(ctx, uint64(len(payload)))

--- a/core/pkg/serverless/persistent/instance_concurrency_test.go
+++ b/core/pkg/serverless/persistent/instance_concurrency_test.go
@@ -1,0 +1,146 @@
+package persistent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// newProbeInstance builds an Instance wired to the fake module/exports so the
+// locking contract can be exercised without a real wazero runtime.
+func newProbeInstance(p *entryProbe, frameTimeout time.Duration) *Instance {
+	mem := &fakeMemory{buf: make([]byte, 4096)}
+	mod := &fakeModule{probe: p}
+	return &Instance{
+		clientID:     "probe-client",
+		functionName: "rpc-router",
+		namespace:    "test-ns",
+		module:       mod,
+		openFn:       &fakeFunction{probe: p},
+		frameFn:      &fakeFunction{probe: p},
+		closeFn:      &fakeFunction{probe: p},
+		allocFn:      &fakeFunction{probe: p, result: 128},
+		memory:       mem,
+		inbound:      make(chan []byte, 16),
+		logger:       zap.NewNop(),
+		frameTimeout: frameTimeout,
+		runDone:      make(chan struct{}),
+	}
+}
+
+// TestInstance_callExport_neverConcurrent drives many frames and a concurrent
+// Close, and fails if two goroutines were ever inside the module at once.
+func TestInstance_callExport_neverConcurrent(t *testing.T) {
+	p := &entryProbe{hold: 200 * time.Microsecond}
+	i := newProbeInstance(p, 2*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i.Run(ctx)
+	}()
+
+	// Feed frames while a second goroutine races the teardown — the exact
+	// shape of the production crash (a client disconnecting mid-frame).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 200; n++ {
+			if err := i.Submit([]byte("frame")); err != nil {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+	i.Close(context.Background(), CloseReasonClientDisconnect)
+	wg.Wait()
+
+	if got := p.maxInside.Load(); got > 1 {
+		t.Fatalf("max concurrent module entries = %d; want 1 — concurrent entry into a wazero instance crashes the process", got)
+	}
+	if p.calls.Load() == 0 {
+		t.Fatal("probe was never entered; the test did not exercise the module path")
+	}
+}
+
+// TestInstance_Close_waitsForInflightFrame asserts the ordering half of the
+// fix: ws_close must not run while a frame is still executing.
+func TestInstance_Close_waitsForInflightFrame(t *testing.T) {
+	p := &entryProbe{hold: 150 * time.Millisecond}
+	i := newProbeInstance(p, 5*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		i.Run(ctx)
+		close(done)
+	}()
+
+	if err := i.Submit([]byte("slow-frame")); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	// Let the frame get inside the module.
+	time.Sleep(20 * time.Millisecond)
+
+	cancel()
+	i.Close(context.Background(), CloseReasonClientDisconnect)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after Close")
+	}
+
+	if got := p.maxInside.Load(); got > 1 {
+		t.Fatalf("max concurrent module entries = %d; want 1", got)
+	}
+}
+
+// Close must not block forever when Run was never started — the ws_open
+// rejection path closes an instance whose frame loop never launches.
+func TestInstance_Close_withoutRun_returnsPromptly(t *testing.T) {
+	p := &entryProbe{}
+	i := newProbeInstance(p, 30*time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		i.Close(context.Background(), CloseReasonRejected)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked waiting on a frame loop that was never started")
+	}
+}
+
+// Close is idempotent and safe from several goroutines at once.
+func TestInstance_Close_idempotentUnderConcurrency(t *testing.T) {
+	p := &entryProbe{}
+	i := newProbeInstance(p, time.Second)
+
+	var wg sync.WaitGroup
+	for n := 0; n < 8; n++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			i.Close(context.Background(), CloseReasonServerShutdown)
+		}()
+	}
+	wg.Wait()
+
+	if got := p.maxInside.Load(); got > 1 {
+		t.Fatalf("max concurrent module entries = %d; want 1", got)
+	}
+}

--- a/docs/SERVERLESS.md
+++ b/docs/SERVERLESS.md
@@ -183,6 +183,84 @@ if res.Error != "" {
 
 The legacy `db_execute` is kept indefinitely so existing functions don't break. New code should use `db_execute_v2` for any path where distinguishing "no rows" from "SQL error" matters — most paths.
 
+#### Database Transactions
+
+`db_transaction(opsJSON)` runs a set of statements as one atomic batch.
+
+**Input** — `{"ops": [{"kind": "exec"|"query", "sql": "...", "args": [...]}, ...]}`
+
+**Output** — a `BatchResult`:
+
+```json
+{
+  "results": [{"kind": "exec", "rows_affected": 1, "last_insert_id": 42}],
+  "committed": true,
+  "failed_index": 0,
+  "error": ""
+}
+```
+
+Always check `committed`. A non-empty return does **not** imply the writes landed.
+
+- `committed: true` — every `exec` op is durable.
+- `committed: false` with `failed_index` set — one statement failed and the whole
+  batch rolled back; that op's `results` entry carries its SQL error.
+- `error` non-empty — the batch was rejected as a whole, before or instead of
+  execution. This is where limit violations and transport failures appear.
+
+**Semantics**
+
+- All `exec` ops go to RQLite in one transactional request. Any failure rolls back
+  the entire batch.
+- `query` ops are sequenced **after** the exec batch commits, on the same node, and
+  see the committed writes. A failing query does **not** roll back the writes — its
+  own `results` entry gets `error` and `committed` stays `true`.
+- Result order always matches input order.
+
+**Limits** — exceeding any of these fails the whole batch with `error` set:
+
+| Limit | Value | Applies to |
+|---|---|---|
+| Statements per batch | **100** | `db_transaction`, `db_query_batch`, `exec_and_publish` |
+| Rows returned per query op | 10,000 | `db_query_batch` |
+| Total result bytes per batch | 32 MiB | `db_query_batch` |
+| Batch round-trip deadline | 10s | `db_query_batch` |
+
+> ⚠️ The 100-statement cap is the one that bites in practice. A write whose size
+> scales with fan-out — one row per group participant, per device — crosses it as
+> the group grows, and it fails **deterministically at 101**, not under load. Split
+> such work into chunks of ≤100 and drive them as separate transactions, or restructure
+> so a single statement covers many rows.
+
+```go
+resultBytes := callDBTransaction(ops)
+
+var res struct {
+    Committed   bool   `json:"committed"`
+    FailedIndex int    `json:"failed_index"`
+    Error       string `json:"error"`
+}
+json.Unmarshal(resultBytes, &res)
+
+if res.Error != "" {
+    return fmt.Errorf("batch rejected: %s", res.Error)   // e.g. "too many ops: max 100"
+}
+if !res.Committed {
+    return fmt.Errorf("batch rolled back at op %d", res.FailedIndex)
+}
+```
+
+**Read consistency** — `db_query_batch` (not `db_transaction`) accepts an optional
+`consistency` field on the request body:
+
+- omitted / `"weak"` (default) — leader-routed, always sees the latest committed
+  write. Costs one round trip to the raft leader.
+- `"none"` — served from the local node's SQLite. Much faster, but may be stale;
+  only safe for reads that do not need read-your-own-writes.
+
+`db_query_v2` does **not** accept `consistency`; wrap a single read as a one-op
+`db_query_batch` if you need it.
+
 ### Cache (Olric Distributed Cache)
 
 | Function | Description |


### PR DESCRIPTION
## Why

Two production failures, both self-inflicted:

1. **devnet has been down since 2026-08-26 07:12 UTC.** A routine `orama-node` restart became an unrecoverable outage. `orama-node` has restarted **422 times** and cannot recover on its own.
2. **The namespace gateway crashes ~1×/day/node** on devnet *and* testnet — ~40 crashes in 30 days on testnet alone, killing every WebSocket on the node each time.

## The devnet deadlock

Raft runs **over** the WireGuard mesh, and mesh membership is stored **in rqlite**. So a node with no WireGuard peers cannot reach any peer → cannot elect a leader → cannot read `wireguard_peers` → cannot repair the mesh. Forever.

The rows were sitting readable on local disk the whole time. `syncWireGuardPeers` only ever issued a leader-routed read.

Observed state before this fix:

| node | WireGuard peers | expected |
|---|---|---|
| 57.129.7.232 | **0** | 2 |
| 57.131.41.160 | 1 (no handshake) | 2 |
| 169.58.118.206 | 6, mostly decommissioned (last handshakes 15h / 2d / **24d**) | 2 |

All three stuck in permanent leader election. Every log line bottoms out at `leader address: leader not found`. DNS records live in the same database, so `orama-devnet.network` stopped resolving worldwide.

**Fix:** fall back to a local `level=none` read when the leader is unreachable. A fallback result is non-authoritative and may only **add** peers — adding a departed peer is self-correcting, failing to add a live one is not.

**Second bug in the same function:** the reconciler deleted any live peer missing from the desired set, and silently skipped rows that failed to scan. So an empty or short read — a node that just lost quorum, a replica mid-restore, one malformed row — would *actively sever the mesh*. Removal now requires an authoritative **and** non-empty read; scan failures are hard errors.

## The gateway crashes

wazero instances are not goroutine-safe. Teardown cancelled the frame loop's context and then called `ws_close` **immediately**, without waiting for an in-flight frame to unwind. Two goroutines in one instance doesn't return an error — it corrupts the guest stack and the Go runtime dies with `split stack overflow` / `unknown caller pc` / `bad recovery`, which **no `recover()` can catch**.

Evidence from 30 days of crash dumps on one testnet node:

```
crash dumps containing callExport: 28
  ...with 2+ goroutines inside the SAME *Instance: 15  (53%)

by signature (concurrent-entry ones only):
   14  fatal error: runtime: split stack overflow
    1  fatal error: fault

goroutine-ID gap within each concurrent pair:
   5, 5, 6, 6, 11, 14, 18, 21, 21, 25, 27, 32, 44, 53, 63
```

Every pair is a near-adjacent goroutine ID — the HTTP handler and the `Run` goroutine it spawns. The window is widest when frames are slow, which is exactly when clients give up and disconnect.

**Fix:** one mutex around every module entry, plus a bounded wait for the frame loop before teardown.

**Third bug found while testing this:** `Close` closed the inbound channel while `Submit` could still be sending on it (the closed-flag check and the send are not atomic) — a send-on-closed-channel panic in the WebSocket read loop. The drain goroutine that motivated the close was unnecessary; `Submit` is non-blocking. Caught by the race detector.

## Also fixed

- **Gateway boot panic.** gorqlite indexes `wra[0]` without a length check, so a transient rqlite condition panics instead of erroring. From schema migrations at startup this crash-looped the gateway (16 boot-path, 3 runtime occurrences on one devnet node). Added `WaitForLeader` gating on the real readiness signal — systemd's `After=`/`Requires=` only orders process *start*, not usability — and routed migration calls through panic-guarded wrappers.

- **`db_transaction` returning an empty buffer.** Over the 100-statement cap it returned `0`, which surfaced as `host returned empty envelope` with no reason. A namespace outage was diagnosed by deploying a probe and counting statements by hand, because the reason existed only in the gateway journal that tenants can't read. Now returns a `BatchResult` with `error` set. `docs/SERVERLESS.md` pointed at a "Database Transactions" section that did not exist — it does now, with the limits documented.

- **`last_contact` type mismatch.** rqlite emits a duration string on followers and a **number** on the leader. The string-typed field aborted the entire status decode on a leader, so the freshness gate fail-safed and silently disabled local reads there — its own "a leader is always fresh" branch was unreachable in production. 80 degradation events in 6h on the leader, 0 on followers.

- **Log rotation.** Service logs use systemd `append:` and never rotated: `node.log` observed at **2.7 GB**, `gateway.log` at 861 MB. `copytruncate` is required because systemd holds the fd open with no reopen signal.

## Testing

- Reconciler add/remove matrix, including the empty-set and local-fallback guarantees
- Concurrency probes asserting only one goroutine is ever inside an instance, incl. `Close` racing an in-flight frame
- Readiness polling, timeout wording, cancellation, driver-panic recovery
- `last_contact` decoding for both raft roles
- Logrotate policy contents

Full suite passes; `-race` clean on every changed package.

## Deployment

devnet only. **Not deployed to testnet** in this change.
