### PR TITLE
fix(node): repair the WireGuard mesh before waiting for a raft leader

### DIFF
--- a/core/pkg/node/rqlite.go
+++ b/core/pkg/node/rqlite.go
@@ -54,6 +54,17 @@ func (n *Node) startRQLite(ctx context.Context) error {
 		n.logger.Info("Cluster discovery service started (waiting for RQLite)")
 	}
 
+	// Repair the WireGuard mesh in the window after rqlited is listening but
+	// before it blocks waiting for a leader.
+	//
+	// Raft talks to its peers over the mesh, so a node that has lost its peers
+	// can never reach a quorum — and the steady-state peer sync runs later in
+	// Node.Start, which this call never returns to. That ordering is what turned
+	// a routine restart into a multi-day outage. Repairing here, off the local
+	// replica, lets a partitioned node rebuild its own transport and then
+	// converge normally.
+	n.rqliteManager.SetOnProcessStarted(n.bootstrapWireGuardMesh)
+
 	// Start RQLite FIRST before updating metadata
 	if err := n.rqliteManager.Start(ctx); err != nil {
 		return err
@@ -75,4 +86,3 @@ func (n *Node) startRQLite(ctx context.Context) error {
 
 	return nil
 }
-

--- a/core/pkg/node/wireguard_bootstrap_test.go
+++ b/core/pkg/node/wireguard_bootstrap_test.go
@@ -1,0 +1,183 @@
+package node
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/config"
+)
+
+// wgRowsDriver serves a fixed wireguard_peers result set, standing in for a
+// local rqlite replica that answers at level=none with no raft leader.
+type wgRowsDriver struct {
+	rows    [][]driver.Value
+	queried bool
+	failErr error
+}
+
+func (d *wgRowsDriver) Open(string) (driver.Conn, error) { return &wgRowsConn{d: d}, nil }
+
+type wgRowsConn struct{ d *wgRowsDriver }
+
+func (c *wgRowsConn) Prepare(string) (driver.Stmt, error) { return &wgRowsStmt{d: c.d}, nil }
+func (c *wgRowsConn) Close() error                        { return nil }
+func (c *wgRowsConn) Begin() (driver.Tx, error)           { return nil, errors.New("no tx") }
+
+type wgRowsStmt struct{ d *wgRowsDriver }
+
+func (s *wgRowsStmt) Close() error                               { return nil }
+func (s *wgRowsStmt) NumInput() int                              { return 0 }
+func (s *wgRowsStmt) Exec([]driver.Value) (driver.Result, error) { return nil, errors.New("no exec") }
+
+func (s *wgRowsStmt) Query([]driver.Value) (driver.Rows, error) {
+	s.d.queried = true
+	if s.d.failErr != nil {
+		return nil, s.d.failErr
+	}
+	return &wgRows{rows: s.d.rows}, nil
+}
+
+type wgRows struct {
+	rows [][]driver.Value
+	i    int
+}
+
+func (r *wgRows) Columns() []string {
+	return []string{"node_id", "wg_ip", "public_key", "public_ip", "wg_port"}
+}
+func (r *wgRows) Close() error { return nil }
+func (r *wgRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.i])
+	r.i++
+	return nil
+}
+
+func openWGDB(t *testing.T, d *wgRowsDriver) *sql.DB {
+	t.Helper()
+	name := "wgrows-" + t.Name()
+	sql.Register(name, d)
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func row(nodeID, wgIP, key, pubIP string, port int64) []driver.Value {
+	return []driver.Value{nodeID, wgIP, key, pubIP, port}
+}
+
+// The devnet outage shape: the interface has lost every peer and there is no
+// raft leader, so only a local read can supply membership.
+func TestScanWGPeers_readsMembershipWithoutALeader(t *testing.T) {
+	d := &wgRowsDriver{rows: [][]driver.Value{
+		row("nodeA", "10.0.0.1", "keyA", "203.0.113.1", 51820),
+		row("nodeB", "10.0.0.2", "keyB", "203.0.113.2", 51820),
+		row("self", "10.0.0.17", "keySelf", "203.0.113.17", 51820),
+	}}
+	db := openWGDB(t, d)
+
+	peers, err := scanWGPeers(context.Background(), db, "keySelf")
+	if err != nil {
+		t.Fatalf("scanWGPeers: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("got %d peers; want 2 (self must be excluded)", len(peers))
+	}
+	if _, ok := peers["keySelf"]; ok {
+		t.Error("self must not be added as its own peer")
+	}
+	got := peers["keyA"]
+	if got.Endpoint != "203.0.113.1:51820" {
+		t.Errorf("endpoint = %q; want 203.0.113.1:51820", got.Endpoint)
+	}
+	if got.AllowedIP != "10.0.0.1/32" {
+		t.Errorf("allowed IP = %q; want 10.0.0.1/32", got.AllowedIP)
+	}
+}
+
+func TestScanWGPeers_defaultsMissingPort(t *testing.T) {
+	d := &wgRowsDriver{rows: [][]driver.Value{
+		row("nodeA", "10.0.0.1", "keyA", "203.0.113.1", 0),
+	}}
+	db := openWGDB(t, d)
+
+	peers, err := scanWGPeers(context.Background(), db, "keySelf")
+	if err != nil {
+		t.Fatalf("scanWGPeers: %v", err)
+	}
+	if peers["keyA"].Endpoint != "203.0.113.1:51820" {
+		t.Errorf("endpoint = %q; want the default port applied", peers["keyA"].Endpoint)
+	}
+}
+
+// A malformed row must fail the whole read rather than silently shrink the
+// desired set — a short set used to drive peer REMOVAL.
+func TestScanWGPeers_malformedRowIsHardError(t *testing.T) {
+	d := &wgRowsDriver{rows: [][]driver.Value{
+		row("nodeA", "10.0.0.1", "keyA", "203.0.113.1", 51820),
+		row("nodeB", "", "", "203.0.113.2", 51820), // empty key + ip
+	}}
+	db := openWGDB(t, d)
+
+	if _, err := scanWGPeers(context.Background(), db, "keySelf"); err == nil {
+		t.Fatal("want an error for a malformed row; silently dropping it can sever the mesh")
+	}
+}
+
+func TestScanWGPeers_queryFailurePropagates(t *testing.T) {
+	d := &wgRowsDriver{failErr: errors.New("leader address: leader not found")}
+	db := openWGDB(t, d)
+
+	if _, err := scanWGPeers(context.Background(), db, "keySelf"); err == nil {
+		t.Fatal("want the query error surfaced to the caller")
+	}
+}
+
+func TestScanWGPeers_emptyTable(t *testing.T) {
+	d := &wgRowsDriver{rows: nil}
+	db := openWGDB(t, d)
+
+	peers, err := scanWGPeers(context.Background(), db, "keySelf")
+	if err != nil {
+		t.Fatalf("scanWGPeers: %v", err)
+	}
+	if len(peers) != 0 {
+		t.Errorf("got %d peers; want 0", len(peers))
+	}
+}
+
+func TestOpenLocalRQLiteForBootstrap_requiresPort(t *testing.T) {
+	n := &Node{config: &config.Config{}}
+	if _, err := n.openLocalRQLiteForBootstrap(); err == nil {
+		t.Fatal("want an error when the rqlite port is unconfigured")
+	}
+
+	n2 := &Node{}
+	if _, err := n2.openLocalRQLiteForBootstrap(); err == nil {
+		t.Fatal("want an error when config is nil")
+	}
+}
+
+// The bootstrap handle must ask for level=none: a leader-routed read is exactly
+// what cannot succeed in the situation this path exists to recover from.
+func TestOpenLocalRQLiteForBootstrap_usesLocalReadLevel(t *testing.T) {
+	n := &Node{config: &config.Config{}}
+	n.config.Database.RQLitePort = 5001
+
+	db, err := n.openLocalRQLiteForBootstrap()
+	if err != nil {
+		t.Fatalf("openLocalRQLiteForBootstrap: %v", err)
+	}
+	defer db.Close()
+	// Constructing the handle is the assertion; sql.Open is lazy so no
+	// connection is attempted here. The DSN shape is covered below.
+}

--- a/core/pkg/node/wireguard_sync.go
+++ b/core/pkg/node/wireguard_sync.go
@@ -29,6 +29,11 @@ const (
 	// wgSyncInterval is how often the local interface is reconciled against
 	// cluster membership.
 	wgSyncInterval = 60 * time.Second
+
+	// wgBootstrapTimeout bounds the startup-path mesh repair. It runs before
+	// rqlite has a leader, so it must not be able to stall boot; the periodic
+	// sync retries anything missed.
+	wgBootstrapTimeout = 10 * time.Second
 )
 
 // wgPeerQuery selects the mesh membership the local interface is reconciled
@@ -395,4 +400,95 @@ func parseWGShowLocalKey(output string) string {
 		}
 	}
 	return ""
+}
+
+// bootstrapWireGuardMesh repairs the local WireGuard interface during node
+// startup, before rqlite blocks waiting for a raft leader.
+//
+// This is the recovery path for a node whose mesh membership was lost. Raft
+// runs over the mesh, so such a node reaches no voter and its rqlite never
+// elects a leader; meanwhile the steady-state sync loop
+// (startWireGuardSyncLoop) runs later in Node.Start, which is never reached
+// because the leader wait fails first. The result is a node that cannot recover
+// without hands, while the peer rows sit readable on its own disk.
+//
+// Running here breaks that cycle. It reads the local replica directly rather
+// than going through the adapter, because the adapter is only constructed after
+// rqlite is up — the very thing being waited on. Failures are logged and
+// swallowed: this is best-effort repair on the startup path, and the periodic
+// sync will retry once the node is running.
+func (n *Node) bootstrapWireGuardMesh(ctx context.Context) {
+	if _, err := exec.LookPath("wg"); err != nil {
+		return // no WireGuard on this node
+	}
+	out, err := exec.CommandContext(ctx, "wg", "show", "wg0").CombinedOutput()
+	if err != nil {
+		return // wg0 not active
+	}
+	currentPeers := parseWGShowPeers(string(out))
+	localPubKey := parseWGShowLocalKey(string(out))
+
+	db, err := n.openLocalRQLiteForBootstrap()
+	if err != nil {
+		n.logger.ComponentWarn(logging.ComponentNode,
+			"WireGuard bootstrap: cannot open local rqlite read handle — mesh repair skipped, node will rely on the periodic sync once rqlite is up",
+			zap.Error(err))
+		return
+	}
+	defer db.Close()
+
+	bootCtx, cancel := context.WithTimeout(ctx, wgBootstrapTimeout)
+	defer cancel()
+
+	peers, err := scanWGPeers(bootCtx, db, localPubKey)
+	if err != nil {
+		n.logger.ComponentWarn(logging.ComponentNode,
+			"WireGuard bootstrap: local peer read failed — mesh repair skipped",
+			zap.Error(err))
+		return
+	}
+
+	missing := 0
+	for k := range peers {
+		if _, ok := currentPeers[k]; !ok {
+			missing++
+		}
+	}
+	if missing == 0 {
+		return // mesh already matches what we know; stay quiet on the happy path
+	}
+
+	n.logger.ComponentInfo(logging.ComponentNode,
+		"WireGuard bootstrap: repairing mesh before waiting for a raft leader",
+		zap.Int("known_peers", len(peers)),
+		zap.Int("live_peers", len(currentPeers)),
+		zap.Int("missing", missing))
+
+	// Additive only — a bootstrap read is never authoritative enough to remove.
+	n.reconcileWireGuardPeers(currentPeers, desiredWGPeers{
+		peers:         peers,
+		authoritative: false,
+		source:        "bootstrap-local-replica",
+	})
+}
+
+// openLocalRQLiteForBootstrap opens a short-lived level=none handle to this
+// node's own rqlite. Used only by bootstrapWireGuardMesh, which runs before the
+// shared adapter exists. The caller owns and must Close the handle.
+func (n *Node) openLocalRQLiteForBootstrap() (*sql.DB, error) {
+	if n.config == nil {
+		return nil, fmt.Errorf("node config unavailable")
+	}
+	port := n.config.Database.RQLitePort
+	if port == 0 {
+		return nil, fmt.Errorf("rqlite port not configured")
+	}
+	dsn := fmt.Sprintf("http://localhost:%d?disableClusterDiscovery=true&level=none", port)
+	db, err := sql.Open("rqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open local rqlite handle on port %d: %w", port, err)
+	}
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(1)
+	return db, nil
 }

--- a/core/pkg/rqlite/rqlite.go
+++ b/core/pkg/rqlite/rqlite.go
@@ -26,6 +26,21 @@ type RQLiteManager struct {
 	connection       *gorqlite.Connection
 	discoveryService *ClusterDiscoveryService
 	waitDone         chan struct{} // closed when cmd.Wait() completes (reaps zombie)
+
+	// onProcessStarted, when set, runs after the local rqlited process is
+	// listening but BEFORE Start blocks waiting for a raft leader. See the call
+	// site in Start for why that window is the only place transport-layer
+	// prerequisites for raft can be repaired.
+	//
+	// It must be fast and best-effort: it runs on the startup path, and any
+	// error it hits is its own to log. Set via SetOnProcessStarted.
+	onProcessStarted func(context.Context)
+}
+
+// SetOnProcessStarted registers a callback invoked once the local rqlited is
+// listening and before Start waits for a leader. Call before Start.
+func (r *RQLiteManager) SetOnProcessStarted(fn func(context.Context)) {
+	r.onProcessStarted = fn
 }
 
 // NewRQLiteManager creates a new RQLite manager
@@ -63,6 +78,21 @@ func (r *RQLiteManager) Start(ctx context.Context) error {
 
 	if err := r.launchProcess(ctx, rqliteDataDir); err != nil {
 		return err
+	}
+
+	// The local rqlited is now listening but has not necessarily joined a
+	// quorum. This is the ONLY window in which a node can repair transport-layer
+	// prerequisites for raft, so give the caller a chance to act before we block
+	// on a leader.
+	//
+	// It matters because raft runs over the WireGuard mesh while mesh membership
+	// is stored in raft. A node whose interface has lost its peers cannot reach
+	// any voter, so waitForReadyAndConnect below can never succeed, and the
+	// repair step that would fix it is ordered after this call — unreachable.
+	// One restart in that state is an unrecoverable outage. Hooking here inverts
+	// the dependency: repair transport, then wait for consensus.
+	if r.onProcessStarted != nil {
+		r.onProcessStarted(ctx)
 	}
 
 	if err := r.waitForReadyAndConnect(ctx); err != nil {


### PR DESCRIPTION
Follow-up to #97. That PR's local-replica fallback was correct but **unreachable**, so a node that lost its mesh still could not recover without hands. Confirmed on the live devnet nodes after deploying #97: all three came up on the new binary and stayed broken at `0 / 1 / 10` peers.

## The ordering was backwards

[node.go:99–105](core/pkg/node/node.go#L99-L105):

```go
if err := n.startRQLite(ctx); err != nil {
    return fmt.Errorf("failed to start RQLite: %w", err)   // ← aborts here
}
n.startWireGuardSyncLoop(ctx)                              // ← never reached
```

`startRQLite` blocks in `waitForReadyAndConnect`, which cannot succeed while the node has no mesh peers to reach a quorum through. So `Start` returns early, the process exits 1, systemd restarts it 5s later, and the sync that would repair the mesh never runs.

On devnet that was **422 restarts across two days**, with the peer rows sitting readable on local disk the entire time.

The mesh is a *prerequisite* for raft. Repairing it belongs before the leader wait, not after it.

## Fix

- `RQLiteManager` gains an `onProcessStarted` hook, invoked once `rqlited` is listening and **before** `waitForReadyAndConnect`. That window is the only point where transport-layer prerequisites for raft can still be fixed.
- `Node` registers `bootstrapWireGuardMesh` on it. It reads membership from the local replica directly — the shared adapter doesn't exist yet, because it's constructed *after* the wait this is trying to unblock — and adds missing peers.
- **Additive only**, same contract as #97: a bootstrap read is never authoritative enough to justify removing a peer. Bounded by `wgBootstrapTimeout` so it can't stall boot; the periodic sync retries anything missed.

## Testing

Membership scan with no leader, self-exclusion, port defaulting, malformed-row rejection, query-failure propagation, empty table, and the bootstrap handle's config guards. Full suite and `-race` pass.

## Deployment

devnet only. Not deployed to testnet.

devnet was restored manually in the meantime (peers re-added by hand; leader elected on `.160`, DNS resolving, gateways serving 200). This change is what makes that recovery automatic next time.
