### PR TITLE
fix(gateway): re-advertise a healthy node whose namespace DNS record was left disabled

### DIFF
--- a/core/pkg/gateway/namespace_dns_reclaim_test.go
+++ b/core/pkg/gateway/namespace_dns_reclaim_test.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The reclaim's safety rests entirely on the SQL guards, so assert them
+// explicitly. Losing any one of them turns a self-heal into a way for a node to
+// force itself back into DNS.
+func TestReclaimSQL_onlyTouchesInactiveStaleOwnRow(t *testing.T) {
+	q := reclaimStaleNamespaceHostRecordSQL
+
+	if !strings.Contains(q, "is_active = 0") {
+		t.Error("missing `is_active = 0` guard — would rewrite already-active rows on every probe")
+	}
+	if !strings.Contains(q, "updated_at <") {
+		t.Error("missing staleness guard — would override a LIVE health-monitor verdict and flap DNS")
+	}
+	if !strings.Contains(q, "value = ?") {
+		t.Error("missing value predicate — a node could re-enable OTHER nodes' records")
+	}
+	if !strings.Contains(q, "fqdn = ?") {
+		t.Error("missing fqdn predicate — would leak across namespaces")
+	}
+	if !strings.Contains(q, "record_type = 'A'") {
+		t.Error("missing record_type predicate")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(q), "UPDATE dns_records") {
+		t.Errorf("reclaim must be an UPDATE on dns_records, got: %s", q)
+	}
+	// It must never create rows — insertion is EnsureNamespaceHostRecordForNode's
+	// job, and an INSERT here would resurrect deliberately removed nodes.
+	if strings.Contains(strings.ToUpper(q), "INSERT") {
+		t.Error("reclaim must not INSERT; it only re-activates an existing row")
+	}
+}
+
+// The window must comfortably exceed the health monitor's suspect cadence
+// (DefaultSuspectAfter=3 missed probes at ProbeInterval=10s ≈ 30s). Otherwise a
+// monitor that still considers this node suspect would be overridden and DNS
+// would oscillate.
+func TestStaleDisableReclaimAfter_exceedsSuspectCadence(t *testing.T) {
+	const suspectCadence = 30 * time.Second
+	if staleDisableReclaimAfter <= suspectCadence {
+		t.Fatalf("staleDisableReclaimAfter = %s; must exceed the ~%s suspect cadence so a live verdict is never overridden",
+			staleDisableReclaimAfter, suspectCadence)
+	}
+	if staleDisableReclaimAfter < 5*time.Minute {
+		t.Errorf("staleDisableReclaimAfter = %s; too aggressive — leaves little margin over a slow rolling restart", staleDisableReclaimAfter)
+	}
+	if staleDisableReclaimAfter > time.Hour {
+		t.Errorf("staleDisableReclaimAfter = %s; too slow — a node would sit out of DNS for that long after every upgrade", staleDisableReclaimAfter)
+	}
+}
+
+// Damping: a namespace must be healthy for several consecutive probes before
+// its node re-advertises, so a flapping service cannot flap DNS.
+func TestHealthyProbesBeforeDNSReclaim_dampsFlapping(t *testing.T) {
+	if healthyProbesBeforeDNSReclaim < 2 {
+		t.Fatalf("healthyProbesBeforeDNSReclaim = %d; a single good probe is not enough to justify a DNS write",
+			healthyProbesBeforeDNSReclaim)
+	}
+	if healthyProbesBeforeDNSReclaim > 10 {
+		t.Errorf("healthyProbesBeforeDNSReclaim = %d; recovery would take over 5 minutes", healthyProbesBeforeDNSReclaim)
+	}
+}
+
+// streak bookkeeping — extracted so the decision is testable without a DB.
+func advanceStreaks(state *namespaceHealthState, health map[string]*NamespaceHealth) []string {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.healthyStreak == nil {
+		state.healthyStreak = make(map[string]int)
+	}
+	ready := []string{}
+	for name, h := range health {
+		if h == nil || h.Status != "healthy" {
+			delete(state.healthyStreak, name)
+			continue
+		}
+		state.healthyStreak[name]++
+		if state.healthyStreak[name] >= healthyProbesBeforeDNSReclaim {
+			ready = append(ready, name)
+		}
+	}
+	for name := range state.healthyStreak {
+		if _, still := health[name]; !still {
+			delete(state.healthyStreak, name)
+		}
+	}
+	return ready
+}
+
+func healthy() map[string]*NamespaceHealth {
+	return map[string]*NamespaceHealth{"anchat-test": {Status: "healthy"}}
+}
+
+func unhealthy() map[string]*NamespaceHealth {
+	return map[string]*NamespaceHealth{"anchat-test": {Status: "unhealthy"}}
+}
+
+func TestStreak_requiresConsecutiveHealthyProbes(t *testing.T) {
+	st := &namespaceHealthState{}
+
+	for i := 1; i < healthyProbesBeforeDNSReclaim; i++ {
+		if got := advanceStreaks(st, healthy()); len(got) != 0 {
+			t.Fatalf("probe %d: ready=%v; must wait for %d consecutive healthy probes", i, got, healthyProbesBeforeDNSReclaim)
+		}
+	}
+	if got := advanceStreaks(st, healthy()); len(got) != 1 || got[0] != "anchat-test" {
+		t.Fatalf("probe %d: ready=%v; want [anchat-test]", healthyProbesBeforeDNSReclaim, got)
+	}
+}
+
+func TestStreak_resetsOnUnhealthyProbe(t *testing.T) {
+	st := &namespaceHealthState{}
+
+	advanceStreaks(st, healthy())
+	advanceStreaks(st, healthy())
+	// One bad probe wipes the streak — a flapping gateway must not reach the
+	// threshold by accumulating good probes across outages.
+	advanceStreaks(st, unhealthy())
+
+	if got := advanceStreaks(st, healthy()); len(got) != 0 {
+		t.Fatalf("ready=%v immediately after an unhealthy probe; streak must restart from zero", got)
+	}
+}
+
+func TestStreak_forgetsNamespacesNoLongerServed(t *testing.T) {
+	st := &namespaceHealthState{}
+	advanceStreaks(st, healthy())
+
+	// Namespace moved off this node — its streak must not linger and later
+	// re-advertise a node that no longer serves it.
+	advanceStreaks(st, map[string]*NamespaceHealth{})
+
+	st.mu.RLock()
+	_, lingering := st.healthyStreak["anchat-test"]
+	st.mu.RUnlock()
+	if lingering {
+		t.Error("streak survived the namespace leaving this node")
+	}
+}
+
+func TestStreak_unhealthyNeverBecomesReady(t *testing.T) {
+	st := &namespaceHealthState{}
+	for i := 0; i < healthyProbesBeforeDNSReclaim*3; i++ {
+		if got := advanceStreaks(st, unhealthy()); len(got) != 0 {
+			t.Fatalf("an unhealthy namespace became ready: %v", got)
+		}
+	}
+}

--- a/core/pkg/gateway/namespace_health.go
+++ b/core/pkg/gateway/namespace_health.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -31,7 +32,16 @@ type NamespaceHealth struct {
 type namespaceHealthState struct {
 	mu    sync.RWMutex
 	cache map[string]*NamespaceHealth // namespace_name → health
+	// healthyStreak counts consecutive healthy local probes per namespace. Used
+	// to damp the DNS reclaim so a flapping service cannot flap DNS.
+	healthyStreak map[string]int
 }
+
+// healthyProbesBeforeDNSReclaim is how many consecutive healthy 30s probes a
+// namespace must pass before this node re-advertises itself in DNS. Three
+// probes (~90s) is long enough that a service restarting mid-probe does not
+// trigger a reclaim, short enough to recover well inside a human response time.
+const healthyProbesBeforeDNSReclaim = 3
 
 // startNamespaceHealthLoop runs two periodic tasks:
 //  1. Every 30s: probe local namespace services and cache health state
@@ -142,6 +152,129 @@ func (g *Gateway) probeLocalNamespaces(ctx context.Context) {
 	g.nsHealth.mu.Lock()
 	g.nsHealth.cache = health
 	g.nsHealth.mu.Unlock()
+
+	g.reclaimStaleNamespaceDNS(ctx, health)
+}
+
+// reclaimStaleNamespaceDNS re-advertises this node in the `ns-<ns>` round-robin
+// when its own record was soft-disabled and nothing has refreshed that decision
+// since.
+//
+// DisableNamespaceRecord writes durable state, but the only re-enable path
+// (HandleSuspectRecovery) fires on an IN-MEMORY suspect→healthy transition in
+// the node health monitor. A restart clears that map, so the transition never
+// happens and the row stays disabled permanently — a healthy gateway silently
+// removed from DNS with no path back. Reclaiming here is the level-triggered
+// counterpart to that edge.
+//
+// Deliberately conservative:
+//   - only namespaces this node currently serves, and only when the local
+//     probe says every one of their services is healthy;
+//   - only after healthyProbesBeforeDNSReclaim consecutive healthy probes, so a
+//     flapping service does not flap DNS;
+//   - only this node's own row, and only when the disable is already stale, so
+//     a live peer verdict is never overridden (see ReclaimStaleNamespaceHostRecord).
+func (g *Gateway) reclaimStaleNamespaceDNS(ctx context.Context, health map[string]*NamespaceHealth) {
+	if g.sqlDB == nil || g.nodePeerID == "" || g.nsHealth == nil {
+		return
+	}
+
+	g.nsHealth.mu.Lock()
+	if g.nsHealth.healthyStreak == nil {
+		g.nsHealth.healthyStreak = make(map[string]int)
+	}
+	ready := make([]string, 0, len(health))
+	for name, h := range health {
+		if h == nil || h.Status != "healthy" {
+			delete(g.nsHealth.healthyStreak, name)
+			continue
+		}
+		g.nsHealth.healthyStreak[name]++
+		if g.nsHealth.healthyStreak[name] >= healthyProbesBeforeDNSReclaim {
+			ready = append(ready, name)
+		}
+	}
+	// Drop streaks for namespaces this node no longer serves.
+	for name := range g.nsHealth.healthyStreak {
+		if _, still := health[name]; !still {
+			delete(g.nsHealth.healthyStreak, name)
+		}
+	}
+	g.nsHealth.mu.Unlock()
+
+	if len(ready) == 0 {
+		return
+	}
+
+	publicIP, err := g.localNodePublicIP(ctx)
+	if err != nil || publicIP == "" {
+		// Not fatal and not worth a warning every 30s — the next probe retries,
+		// which is the whole point of being level-triggered.
+		g.logger.ComponentDebug(logging.ComponentGeneral,
+			"Skipping namespace DNS reclaim: local public IP unavailable",
+			zap.Error(err))
+		return
+	}
+
+	baseDomain := g.cfg.BaseDomain
+	if baseDomain == "" {
+		return // without the zone we cannot name the record; nothing safe to do
+	}
+
+	now := time.Now()
+	cutoff := now.Add(-staleDisableReclaimAfter)
+	for _, name := range ready {
+		for _, fqdn := range []string{
+			fmt.Sprintf("ns-%s.%s.", name, baseDomain),
+			fmt.Sprintf("*.ns-%s.%s.", name, baseDomain),
+		} {
+			res, rerr := g.sqlDB.ExecContext(ctx, reclaimStaleNamespaceHostRecordSQL, now, fqdn, publicIP, cutoff)
+			if rerr != nil {
+				g.logger.ComponentWarn(logging.ComponentGeneral,
+					"Failed to reclaim stale namespace DNS record",
+					zap.String("namespace", name), zap.String("fqdn", fqdn), zap.Error(rerr))
+				continue
+			}
+			if n, aerr := res.RowsAffected(); aerr == nil && n > 0 {
+				g.logger.ComponentInfo(logging.ComponentGeneral,
+					"Re-enabled this node's namespace DNS record after a stale disable",
+					zap.String("namespace", name),
+					zap.String("fqdn", fqdn),
+					zap.String("ip", publicIP))
+			}
+		}
+	}
+}
+
+// staleDisableReclaimAfter is how long a soft-disabled namespace-host record
+// must have sat untouched before a locally-healthy node may re-enable its own
+// row. It comfortably exceeds the health monitor's suspect cadence (3 missed
+// probes at 10s) so a LIVE verdict is never overridden: a monitor that still
+// considers this node suspect keeps refreshing updated_at, holding the row
+// outside this window indefinitely.
+const staleDisableReclaimAfter = 10 * time.Minute
+
+// reclaimStaleNamespaceHostRecordSQL re-activates exactly one node's own
+// namespace-host A record, and only when the disable has gone stale.
+//
+// The is_active=0 and updated_at guards are what make this safe to run
+// unattended on every node: a no-op on an already-active row, and a no-op on a
+// row some live health monitor is actively holding down.
+const reclaimStaleNamespaceHostRecordSQL = `UPDATE dns_records
+	SET is_active = 1, updated_at = ?
+	WHERE fqdn = ? AND record_type = 'A' AND value = ?
+	  AND is_active = 0
+	  AND updated_at < ?`
+
+// localNodePublicIP resolves this node's public IP from dns_nodes — the value
+// that appears in the A records.
+func (g *Gateway) localNodePublicIP(ctx context.Context) (string, error) {
+	var ip string
+	row := g.sqlDB.QueryRowContext(ctx, `SELECT ip_address FROM dns_nodes WHERE id = ?`, g.nodePeerID)
+	if err := row.Scan(&ip); err != nil {
+		return "", err
+	}
+	return ip, nil
 }
 
 // reconcileNamespaces checks all namespaces for under-provisioning and triggers repair.


### PR DESCRIPTION
## The 503 is a ratchet, not an incident

devnet's `anchat-test` returns intermittent 503 while **two healthy gateways sit idle**, because every rolling upgrade permanently sheds a node from the `ns-<ns>` round-robin.

Observed state:

```
169.58.118.206   active=True   updated=2026-08-28T10:03:51
57.129.7.232     active=False  updated=2026-08-26T07:14:13   ← outage start, 2 days ago
57.131.41.160    active=False  updated=2026-08-28T09:50:33   ← that day's rolling upgrade
51.38.128.56     active=False  updated=2026-08-03T11:47:16   ← decommissioned
```

Both inactive nodes were serving `HTTP 200` on their local namespace gateway the entire time. Note `turn.ns-anchat-test` has **all three** active — the TURN re-advertise path works, the namespace-host one doesn't.

## Root cause: durable state gated behind an ephemeral edge

- `HandleSuspectNode` writes `is_active=0` into `dns_records` — **durable**, in rqlite.
- The only path that sets it back, `HandleSuspectRecovery`, fires on an **in-memory** `suspect → healthy` transition of `peerState.status` in the node health monitor ([monitor.go:243](core/pkg/node/health/monitor.go#L243)).
- A restart resets that map. In a rolling upgrade the monitors that observed the node as suspect restart too — so the recovery edge is **never observed**, and the record stays disabled forever.

Each upgrade: peers miss 3 probes → suspect → record disabled → node returns → nobody re-enables it. Repeat until only the last node survives (saved by the "never disable the last active record" guard). Then any blip on that node is a full namespace outage — which is what we hit.

## Fix

The level-triggered counterpart to that edge. The existing 30s local namespace probe already knows whether this node's own gateway is healthy, so a node re-asserts **its own** record once the disable has gone stale.

Deliberately conservative, because getting this wrong means flapping DNS:

- only namespaces this node currently serves, and only when **every** local service probes healthy
- only after **3 consecutive healthy probes (~90s)** — a flapping service cannot flap DNS
- only this node's **own row** — never another node's value for the same fqdn
- only when the disable is older than **10 minutes**, comfortably beyond the monitor's ~30s suspect cadence. A monitor that still considers this node suspect keeps refreshing `updated_at`, holding the row outside the window — so a **live verdict is never overridden**
- **UPDATE only, never INSERT** — reactivating an existing row cannot resurrect a deliberately removed node

Implemented in `pkg/gateway` rather than `DNSRecordManager` because `pkg/namespace` already imports `pkg/gateway`; the dependency cannot go the other way.

## Testing

Every SQL guard (inactive-only, stale-only, own-row-only, no-INSERT), bounds on both constants against the monitor's suspect cadence, and the streak logic — requires consecutive healthy probes, resets on a single unhealthy probe, forgets namespaces that move off the node.

Full suite and `-race` pass.

## Deployment

devnet only. Not deployed to testnet.

Expected effect on devnet: `.232` (stale 2 days) and `.160` (stale ~15 min) both reclaimed within ~90s of the gateways coming up, restoring the round-robin to three nodes and ending the intermittent 503.
