### PR TITLE
fix(gateway): CHG-201 API-key / data-plane registry bugs

### DIFF
--- a/core/cmd/gateway/config.go
+++ b/core/cmd/gateway/config.go
@@ -285,6 +285,12 @@ func parseGatewayConfig(logger *logging.ColoredLogger) *gateway.Config {
 		cfg.StealthCDNDomain = v
 	}
 
+	if strings.TrimSpace(cfg.APIKeyHMACSecret) == "" {
+		fmt.Fprintf(os.Stderr, "\napi_key_hmac_secret is required (bugboard #163).\n")
+		fmt.Fprintf(os.Stderr, "Spawn writes it from ~/.orama/secrets/api-key-hmac-secret.\n")
+		os.Exit(1)
+	}
+
 	// Validate configuration
 	if errs := cfg.ValidateConfig(); len(errs) > 0 {
 		fmt.Fprintf(os.Stderr, "\nGateway configuration errors (%d):\n", len(errs))

--- a/core/pkg/gateway/apikey_querier.go
+++ b/core/pkg/gateway/apikey_querier.go
@@ -22,9 +22,11 @@ type apiKeyQuerier interface {
 
 // apiKeyDB returns the querier API-key lookups should use: the explicit
 // global-registry client (g.authClient, built from cfg.GlobalRQLiteDSN -- see
-// New in gateway.go) when available, falling back to g.client (core-bound on
-// namespace gateways, since client.DefaultClientConfig() resolves to the core
-// bootstrap peers) only when no dedicated global client was configured.
+// New in gateway.go) when available, falling back to g.client only when no
+// dedicated global client was configured (the index gateway, where
+// rqlite_dsn IS the registry). g.client on a namespace gateway is the
+// tenant RQLite after bugboard #162 (explicit rqlite_dsn wins) and must
+// not be used for keys when authClient exists.
 // g.sqlDB (this gateway's own namespace RQLite) must NEVER be used here --
 // its api_keys table is not authoritative, and querying it split key
 // validation into two disagreeing registries (bugboard #151/#152

--- a/core/pkg/gateway/auth/hash_test.go
+++ b/core/pkg/gateway/auth/hash_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import "testing"
+
+func TestHashAPIKey_withSecret_differsFromRaw(t *testing.T) {
+	s := &Service{apiKeyHMACSecret: "test-hmac-secret"}
+	const raw = "ak_live_example:ns"
+	got := s.HashAPIKey(raw)
+	if got == raw {
+		t.Fatal("hashed key must differ from raw when the HMAC secret is set")
+	}
+	if want := HmacSHA256Hex(raw, "test-hmac-secret"); got != want {
+		t.Errorf("HashAPIKey = %q, want %q", got, want)
+	}
+}
+
+func TestHashAPIKey_emptySecret_returnsRaw(t *testing.T) {
+	// Current contract: no secret → store/lookup the raw key (rolling-upgrade
+	// fallback). Production spawn refuses to boot without the secret file;
+	// this pins the function so a later fail-loud change is explicit.
+	s := &Service{}
+	const raw = "ak_live_example:ns"
+	if got := s.HashAPIKey(raw); got != raw {
+		t.Errorf("empty secret must return the raw key, got %q", got)
+	}
+}

--- a/core/pkg/gateway/auth/migrate_apikeys.go
+++ b/core/pkg/gateway/auth/migrate_apikeys.go
@@ -62,3 +62,30 @@ func (s *Service) MigratePlaintextAPIKeys(ctx context.Context) (int, error) {
 	}
 	return n, nil
 }
+
+// RevokeOrphanedAPIKeys sets revoked_at on api_keys whose namespace_id no
+// longer exists (bugboard #164). Idempotent. Returns the number of rows
+// updated. Lookup already INNER JOINs namespaces, so these keys 401; revoking
+// them makes the 401 mean "revoked" rather than "unknown" in diagnostics.
+func (s *Service) RevokeOrphanedAPIKeys(ctx context.Context) (int, error) {
+	orm := s.keyORM()
+	if orm == nil {
+		return 0, nil
+	}
+	db := orm.Database()
+	if db == nil {
+		return 0, nil
+	}
+	internalCtx := client.WithInternalAuth(ctx)
+	res, err := db.Query(internalCtx, `
+		UPDATE api_keys SET revoked_at = CURRENT_TIMESTAMP
+		WHERE revoked_at IS NULL
+		  AND namespace_id NOT IN (SELECT id FROM namespaces)`)
+	if err != nil {
+		return 0, fmt.Errorf("revoke orphaned api keys: %w", err)
+	}
+	if res == nil {
+		return 0, nil
+	}
+	return int(res.Count), nil
+}

--- a/core/pkg/gateway/auth/migrate_apikeys.go
+++ b/core/pkg/gateway/auth/migrate_apikeys.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DeBrosOfficial/network/pkg/client"
+)
+
+// MigratePlaintextAPIKeys HMAC-hashes leftover api_keys rows that still
+// store the raw `ak_…` value (bugboard #163). Idempotent: already-hashed
+// 64-hex rows are skipped (they do not match `ak_%`). Returns the number
+// of rows rewritten.
+//
+// A failed UPDATE on one id aborts and returns the error so a half-batch
+// is visible; callers must not continue serving as if the table is clean.
+func (s *Service) MigratePlaintextAPIKeys(ctx context.Context) (int, error) {
+	if s.apiKeyHMACSecret == "" {
+		return 0, nil
+	}
+	orm := s.keyORM()
+	if orm == nil {
+		return 0, nil
+	}
+	db := orm.Database()
+	if db == nil {
+		return 0, nil
+	}
+
+	internalCtx := client.WithInternalAuth(ctx)
+	res, err := db.Query(internalCtx, "SELECT id, key FROM api_keys WHERE key LIKE 'ak_%'")
+	if err != nil {
+		return 0, fmt.Errorf("list plaintext api keys: %w", err)
+	}
+	if res == nil || res.Count == 0 {
+		return 0, nil
+	}
+
+	n := 0
+	for _, row := range res.Rows {
+		if len(row) < 2 {
+			continue
+		}
+		id := row[0]
+		raw, _ := row[1].(string)
+		if !strings.HasPrefix(raw, "ak_") {
+			continue
+		}
+		hashed := s.HashAPIKey(raw)
+		if hashed == raw {
+			return n, fmt.Errorf("HMAC secret produced a hash equal to the raw key; refusing to migrate")
+		}
+		if _, err := db.Query(internalCtx,
+			"UPDATE api_keys SET key = ? WHERE id = ? AND key = ?", hashed, id, raw); err != nil {
+			return n, fmt.Errorf("hash api key id %v: %w", id, err)
+		}
+		_, _ = db.Query(internalCtx,
+			"UPDATE namespace_ownership SET owner_id = ? WHERE owner_type = 'api_key' AND owner_id = ?",
+			hashed, raw)
+		n++
+	}
+	return n, nil
+}

--- a/core/pkg/gateway/auth/migrate_apikeys_test.go
+++ b/core/pkg/gateway/auth/migrate_apikeys_test.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/client"
+)
+
+type memKeyDB struct {
+	client.DatabaseClient
+	rows    map[int64]string
+	failID  int64
+	updates int
+}
+
+func (m *memKeyDB) Query(_ context.Context, sql string, args ...interface{}) (*client.QueryResult, error) {
+	switch {
+	case strings.Contains(sql, "SELECT id, key"):
+		var rows [][]interface{}
+		for id, key := range m.rows {
+			if strings.HasPrefix(key, "ak_") {
+				rows = append(rows, []interface{}{id, key})
+			}
+		}
+		return &client.QueryResult{Rows: rows, Count: int64(len(rows))}, nil
+	case strings.Contains(sql, "UPDATE api_keys"):
+		hashed, _ := args[0].(string)
+		id := toInt64(args[1])
+		old, _ := args[2].(string)
+		if m.failID != 0 && id == m.failID {
+			return nil, errMigrateTest
+		}
+		if m.rows[id] != old {
+			return &client.QueryResult{Count: 0}, nil
+		}
+		m.rows[id] = hashed
+		m.updates++
+		return &client.QueryResult{Count: 1}, nil
+	case strings.Contains(sql, "UPDATE namespace_ownership"):
+		return &client.QueryResult{Count: 0}, nil
+	default:
+		return nil, errString("unexpected sql: " + sql)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+const errMigrateTest errString = "forced write error"
+
+type memNet struct {
+	client.NetworkClient
+	db *memKeyDB
+}
+
+func (m *memNet) Database() client.DatabaseClient { return m.db }
+
+func TestMigratePlaintextAPIKeys_hashesAkPrefixLeavesHex(t *testing.T) {
+	s := &Service{apiKeyHMACSecret: "test-hmac-secret"}
+	raw := "ak_legacy_one:ns"
+	hexRow := HmacSHA256Hex("already-hashed-input", "test-hmac-secret")
+	db := &memKeyDB{rows: map[int64]string{1: raw, 2: hexRow}}
+	s.orm = &memNet{db: db}
+
+	n, err := s.MigratePlaintextAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("migrated %d, want 1", n)
+	}
+	if db.rows[1] != s.HashAPIKey(raw) {
+		t.Errorf("row 1 not hashed: %q", db.rows[1])
+	}
+	if db.rows[2] != hexRow {
+		t.Errorf("hex row must be left alone, got %q", db.rows[2])
+	}
+}
+
+func TestMigratePlaintextAPIKeys_writeErrorAborts(t *testing.T) {
+	s := &Service{apiKeyHMACSecret: "test-hmac-secret"}
+	db := &memKeyDB{
+		rows:   map[int64]string{1: "ak_one:ns", 2: "ak_two:ns"},
+		failID: 2,
+	}
+	s.orm = &memNet{db: db}
+
+	_, err := s.MigratePlaintextAPIKeys(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "forced write error") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestMigratePlaintextAPIKeys_noSecretIsNoop(t *testing.T) {
+	s := &Service{}
+	db := &memKeyDB{rows: map[int64]string{1: "ak_one:ns"}}
+	s.orm = &memNet{db: db}
+	n, err := s.MigratePlaintextAPIKeys(context.Background())
+	if err != nil || n != 0 {
+		t.Fatalf("n=%d err=%v", n, err)
+	}
+	if db.rows[1] != "ak_one:ns" {
+		t.Fatal("must not rewrite without a secret")
+	}
+}

--- a/core/pkg/gateway/auth/scoped_keys.go
+++ b/core/pkg/gateway/auth/scoped_keys.go
@@ -28,7 +28,7 @@ type KeyInfo struct {
 // several keys with different scopes (e.g. app-runtime + admin). Returns the
 // raw key (shown once) and its row id.
 func (s *Service) IssueScopedKey(ctx context.Context, namespace, storedScopes, label string) (string, int64, error) {
-	if s.orm == nil {
+	if s.keyORM() == nil {
 		return "", 0, fmt.Errorf("client not initialized")
 	}
 	if strings.TrimSpace(storedScopes) == "" {
@@ -39,7 +39,7 @@ func (s *Service) IssueScopedKey(ctx context.Context, namespace, storedScopes, l
 		return "", 0, fmt.Errorf("namespace is required")
 	}
 
-	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	nsID, err := s.resolveKeyNamespaceID(ctx, namespace)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to resolve namespace %q: %w", namespace, err)
 	}
@@ -52,7 +52,7 @@ func (s *Service) IssueScopedKey(ctx context.Context, namespace, storedScopes, l
 	hashedKey := s.HashAPIKey(rawKey)
 
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := s.keyORM().Database()
 
 	if _, err := db.Query(internalCtx,
 		"INSERT INTO api_keys(key, name, namespace_id, scopes) VALUES (?, ?, ?, ?)",
@@ -87,15 +87,15 @@ func (s *Service) IssueScopedKey(ctx context.Context, namespace, storedScopes, l
 // authenticating within the 60s cache TTL. Returns an error if no matching
 // active key was found.
 func (s *Service) RevokeKey(ctx context.Context, namespace string, id int64) error {
-	if s.orm == nil {
+	if s.keyORM() == nil {
 		return fmt.Errorf("client not initialized")
 	}
-	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	nsID, err := s.resolveKeyNamespaceID(ctx, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to resolve namespace %q: %w", namespace, err)
 	}
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := s.keyORM().Database()
 
 	// Confirm the key exists, is in this namespace, and is not already revoked.
 	sel, err := db.Query(internalCtx,
@@ -124,15 +124,15 @@ func (s *Service) RevokeKey(ctx context.Context, namespace string, id int64) err
 // namespace — the omnipotent keys that predate scoping (bugboard #148 cutover).
 // Scoped keys (non-empty scopes) are left untouched. Returns the count revoked.
 func (s *Service) RevokeAllLegacy(ctx context.Context, namespace string) (int, error) {
-	if s.orm == nil {
+	if s.keyORM() == nil {
 		return 0, fmt.Errorf("client not initialized")
 	}
-	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	nsID, err := s.resolveKeyNamespaceID(ctx, namespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to resolve namespace %q: %w", namespace, err)
 	}
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := s.keyORM().Database()
 
 	const legacyPred = "namespace_id = ? AND revoked_at IS NULL AND (scopes IS NULL OR TRIM(scopes) = '')"
 
@@ -167,15 +167,15 @@ func (s *Service) RevokeAllLegacy(ctx context.Context, namespace string) (int, e
 // ListKeys returns non-secret metadata for every key in a namespace (bugboard
 // #148). It never returns the key material.
 func (s *Service) ListKeys(ctx context.Context, namespace string) ([]KeyInfo, error) {
-	if s.orm == nil {
+	if s.keyORM() == nil {
 		return nil, fmt.Errorf("client not initialized")
 	}
-	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	nsID, err := s.resolveKeyNamespaceID(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve namespace %q: %w", namespace, err)
 	}
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := s.keyORM().Database()
 
 	res, err := db.Query(internalCtx,
 		"SELECT id, name, scopes, created_at, last_used_at, revoked_at FROM api_keys WHERE namespace_id = ? ORDER BY id ASC", nsID)

--- a/core/pkg/gateway/auth/service.go
+++ b/core/pkg/gateway/auth/service.go
@@ -37,6 +37,10 @@ type Service struct {
 	defaultNS        string
 	apiKeyHMACSecret string         // HMAC secret for hashing API keys before storage
 	claimsResolver   ClaimsResolver // namespace claims-provider hook (bugboard #548); nil = none
+	// apiKeyORM is the core/index RQLite client used for api_keys writes
+	// on a namespace gateway (bugboard #162). Nil means use s.orm (the
+	// main/index gateway, where orm already is the registry).
+	apiKeyORM client.NetworkClient
 }
 
 func NewService(logger *logging.ColoredLogger, orm client.NetworkClient, signingKeyPEM string, defaultNS string) (*Service, error) {
@@ -70,6 +74,20 @@ func NewService(logger *logging.ColoredLogger, orm client.NetworkClient, signing
 // When set, API keys are stored as HMAC-SHA256(key, secret) in the database.
 func (s *Service) SetAPIKeyHMACSecret(secret string) {
 	s.apiKeyHMACSecret = secret
+}
+
+// SetAPIKeyRegistry points API-key reads/writes at the core/index RQLite
+// client. Required on namespace gateways after rqlite_dsn wins for
+// deps.Client (bugboard #162): keys must not be stored in the tenant DB.
+func (s *Service) SetAPIKeyRegistry(orm client.NetworkClient) {
+	s.apiKeyORM = orm
+}
+
+func (s *Service) keyORM() client.NetworkClient {
+	if s.apiKeyORM != nil {
+		return s.apiKeyORM
+	}
+	return s.orm
 }
 
 // SetRqliteClient injects the lower-level rqlite client. Required for code
@@ -749,9 +767,9 @@ func (s *Service) RegisterApp(ctx context.Context, wallet, namespace, name, publ
 // GetOrCreateAPIKey returns an existing API key or creates a new one for a wallet in a namespace
 func (s *Service) GetOrCreateAPIKey(ctx context.Context, wallet, namespace string) (string, error) {
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := s.keyORM().Database()
 
-	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	nsID, err := s.resolveKeyNamespaceID(ctx, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -801,7 +819,15 @@ func (s *Service) GetOrCreateAPIKey(ctx context.Context, wallet, namespace strin
 
 // ResolveNamespaceID ensures the given namespace exists and returns its primary key ID.
 func (s *Service) ResolveNamespaceID(ctx context.Context, ns string) (interface{}, error) {
-	if s.orm == nil {
+	return s.resolveNamespaceIDOn(ctx, s.orm, ns)
+}
+
+func (s *Service) resolveKeyNamespaceID(ctx context.Context, ns string) (interface{}, error) {
+	return s.resolveNamespaceIDOn(ctx, s.keyORM(), ns)
+}
+
+func (s *Service) resolveNamespaceIDOn(ctx context.Context, orm client.NetworkClient, ns string) (interface{}, error) {
+	if orm == nil {
 		return nil, fmt.Errorf("client not initialized")
 	}
 	ns = strings.TrimSpace(ns)
@@ -810,7 +836,7 @@ func (s *Service) ResolveNamespaceID(ctx context.Context, ns string) (interface{
 	}
 
 	internalCtx := client.WithInternalAuth(ctx)
-	db := s.orm.Database()
+	db := orm.Database()
 
 	if _, err := db.Query(internalCtx, "INSERT OR IGNORE INTO namespaces(name) VALUES (?)", ns); err != nil {
 		return nil, err

--- a/core/pkg/gateway/dependencies.go
+++ b/core/pkg/gateway/dependencies.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DeBrosOfficial/network/migrations"
 	"github.com/DeBrosOfficial/network/pkg/client"
 	"github.com/DeBrosOfficial/network/pkg/config"
+	"github.com/DeBrosOfficial/network/pkg/constants"
 	"github.com/DeBrosOfficial/network/pkg/gateway/auth"
 	serverlesshandlers "github.com/DeBrosOfficial/network/pkg/gateway/handlers/serverless"
 	"github.com/DeBrosOfficial/network/pkg/ipfs"
@@ -138,16 +139,10 @@ func NewDependencies(logger *logging.ColoredLogger, cfg *Config) (*Dependencies,
 	if len(cfg.BootstrapPeers) > 0 {
 		cliCfg.BootstrapPeers = cfg.BootstrapPeers
 	}
-	// Ensure the gorqlite client can reach the local RQLite instance.
-	// Without this, gorqlite has zero endpoints and all DB queries fail.
-	if len(cliCfg.DatabaseEndpoints) == 0 {
-		dsn := cfg.RQLiteDSN
-		if dsn == "" {
-			dsn = "http://localhost:10100"
-		}
-		dsn = injectRQLiteAuth(dsn, cfg.RQLiteUsername, cfg.RQLitePassword)
-		cliCfg.DatabaseEndpoints = []string{dsn}
-	}
+	// Explicit rqlite_dsn always wins (bugboard #162). DefaultClientConfig
+	// pre-fills DatabaseEndpoints from RQLITE_NODES / bootstrap peers on
+	// the index RQLite port, which used to swallow the tenant DSN.
+	cliCfg.DatabaseEndpoints = resolveDatabaseEndpoints(cfg, cliCfg.DatabaseEndpoints)
 
 	logger.ComponentInfo(logging.ComponentGeneral, "Creating network client...")
 	c, err := client.NewClient(cliCfg)
@@ -1011,6 +1006,21 @@ func discoverIPFSFromNodeConfigs(logger *zap.Logger) ipfsDiscoveryResult {
 	}
 
 	return ipfsDiscoveryResult{}
+}
+
+// resolveDatabaseEndpoints picks the gorqlite endpoint list (bugboard #162).
+// A non-empty cfg.RQLiteDSN always wins over DefaultClientConfig's
+// peer-derived list. With no DSN and no defaults, fall back to the index
+// RQLite HTTP port.
+func resolveDatabaseEndpoints(cfg *Config, defaultEndpoints []string) []string {
+	if dsn := strings.TrimSpace(cfg.RQLiteDSN); dsn != "" {
+		return []string{injectRQLiteAuth(dsn, cfg.RQLiteUsername, cfg.RQLitePassword)}
+	}
+	if len(defaultEndpoints) > 0 {
+		return defaultEndpoints
+	}
+	fallback := fmt.Sprintf("http://localhost:%d", constants.RQLiteHTTPPort)
+	return []string{injectRQLiteAuth(fallback, cfg.RQLiteUsername, cfg.RQLitePassword)}
 }
 
 // injectRQLiteAuth injects HTTP basic auth credentials into a RQLite DSN URL.

--- a/core/pkg/gateway/dependencies_rqlite_dsn_test.go
+++ b/core/pkg/gateway/dependencies_rqlite_dsn_test.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/constants"
+)
+
+func TestResolveDatabaseEndpoints_explicitDSN_overridesNonEmptyDefaults(t *testing.T) {
+	cfg := &Config{RQLiteDSN: "http://localhost:10000"}
+	defaults := []string{"http://10.0.0.1:10100", "http://10.0.0.2:10100"}
+	got := resolveDatabaseEndpoints(cfg, defaults)
+	if len(got) != 1 || got[0] != "http://localhost:10000" {
+		t.Fatalf("explicit DSN must win over DefaultClientConfig endpoints, got %v", got)
+	}
+}
+
+func TestResolveDatabaseEndpoints_emptyDSN_keepsDefaults(t *testing.T) {
+	cfg := &Config{}
+	defaults := []string{"http://10.0.0.1:10100"}
+	got := resolveDatabaseEndpoints(cfg, defaults)
+	if len(got) != 1 || got[0] != defaults[0] {
+		t.Fatalf("no DSN must keep defaults, got %v", got)
+	}
+}
+
+func TestResolveDatabaseEndpoints_emptyEverything_fallsBackToIndexPort(t *testing.T) {
+	cfg := &Config{}
+	got := resolveDatabaseEndpoints(cfg, nil)
+	want := fmt.Sprintf("http://localhost:%d", constants.RQLiteHTTPPort)
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("got %v, want [%s]", got, want)
+	}
+}
+
+func TestResolveDatabaseEndpoints_injectsAuth(t *testing.T) {
+	cfg := &Config{RQLiteDSN: "http://localhost:10000", RQLiteUsername: "orama", RQLitePassword: "s3cret"}
+	got := resolveDatabaseEndpoints(cfg, []string{"http://10.0.0.1:10100"})
+	if len(got) != 1 || got[0] != "http://orama:s3cret@localhost:10000" {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/core/pkg/gateway/gateway.go
+++ b/core/pkg/gateway/gateway.go
@@ -524,6 +524,12 @@ func New(logger *logging.ColoredLogger, cfg *Config) (*Gateway, error) {
 					zap.Int("count", n))
 			}
 		}
+		if on, oerr := deps.AuthService.RevokeOrphanedAPIKeys(context.Background()); oerr != nil {
+			logger.ComponentWarn(logging.ComponentGeneral, "revoke orphaned API keys failed", zap.Error(oerr))
+		} else if on > 0 {
+			logger.ComponentInfo(logging.ComponentGeneral, "Revoked orphaned API keys",
+				zap.Int("count", on))
+		}
 	}
 
 	// Initialize middleware cache (60s TTL for auth/routing lookups)

--- a/core/pkg/gateway/gateway.go
+++ b/core/pkg/gateway/gateway.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"reflect"
 	"sync"
 	"time"
@@ -512,6 +513,17 @@ func New(logger *logging.ColoredLogger, cfg *Config) (*Gateway, error) {
 		// registry, never in a namespace's own RQLite, so every gateway must
 		// validate against it.
 		gw.authHandlers.SetAPIKeyDB(&authDatabaseAdapter{db: gw.apiKeyDB()})
+
+		if strings.TrimSpace(cfg.APIKeyHMACSecret) != "" {
+			n, merr := deps.AuthService.MigratePlaintextAPIKeys(context.Background())
+			if merr != nil {
+				return nil, fmt.Errorf("migrate plaintext API keys: %w", merr)
+			}
+			if n > 0 {
+				logger.ComponentInfo(logging.ComponentGeneral, "Hashed leftover plaintext API keys",
+					zap.Int("count", n))
+			}
+		}
 	}
 
 	// Initialize middleware cache (60s TTL for auth/routing lookups)

--- a/core/pkg/gateway/gateway.go
+++ b/core/pkg/gateway/gateway.go
@@ -383,6 +383,9 @@ func New(logger *logging.ColoredLogger, cfg *Config) (*Gateway, error) {
 				logger.ComponentWarn(logging.ComponentGeneral, "Failed to connect global auth client", zap.Error(err))
 			} else {
 				gw.authClient = authClient
+				if deps.AuthService != nil {
+					deps.AuthService.SetAPIKeyRegistry(authClient)
+				}
 				logger.ComponentInfo(logging.ComponentGeneral, "Global auth client connected")
 			}
 		}

--- a/core/pkg/gateway/handlers/auth/handlers_test.go
+++ b/core/pkg/gateway/handlers/auth/handlers_test.go
@@ -549,9 +549,7 @@ func TestAPIKeyToJWTHandler_HashedKeyLookup(t *testing.T) {
 	}
 }
 
-// TestAPIKeyToJWTHandler_RawKeyFallback covers the rolling-upgrade fallback:
-// a legacy row stored under the RAW (unhashed) key still resolves.
-func TestAPIKeyToJWTHandler_RawKeyFallback(t *testing.T) {
+func TestAPIKeyToJWTHandler_RawKeyRejected(t *testing.T) {
 	const rawKey = "ak_legacy_unhashed"
 	svc := jwtCapableService(t, "hmac-secret-xyz")
 	hashed := svc.HashAPIKey(rawKey)
@@ -572,8 +570,8 @@ func TestAPIKeyToJWTHandler_RawKeyFallback(t *testing.T) {
 
 	h.APIKeyToJWTHandler(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200 via raw-key fallback, got %d (body: %s)", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("raw unhashed key must 401 after dual-lookup removal, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
 }
 
@@ -685,12 +683,10 @@ func TestAPIKeyToJWTHandler_TrustsInternalAuthContext(t *testing.T) {
 }
 
 func TestApiKeyLookupCandidates(t *testing.T) {
-	// Distinct hash → hashed first, raw fallback.
 	got := apiKeyLookupCandidates("raw", "hashed")
-	if len(got) != 2 || got[0] != "hashed" || got[1] != "raw" {
-		t.Errorf("distinct: expected [hashed raw], got %v", got)
+	if len(got) != 1 || got[0] != "hashed" {
+		t.Errorf("distinct: expected [hashed], got %v", got)
 	}
-	// No HMAC secret (hashed == raw) → single candidate, no duplicate query.
 	got = apiKeyLookupCandidates("raw", "raw")
 	if len(got) != 1 || got[0] != "raw" {
 		t.Errorf("equal: expected [raw], got %v", got)

--- a/core/pkg/gateway/handlers/auth/jwt_handler.go
+++ b/core/pkg/gateway/handlers/auth/jwt_handler.go
@@ -84,7 +84,7 @@ func (h *Handlers) APIKeyToJWTHandler(w http.ResponseWriter, r *http.Request) {
 		internalCtx := h.internalAuthFn(ctx)
 		const q = "SELECT namespaces.name, api_keys.scopes FROM api_keys JOIN namespaces ON api_keys.namespace_id = namespaces.id WHERE api_keys.key = ? AND api_keys.revoked_at IS NULL LIMIT 1"
 		rawScopes := ""
-		for _, candidate := range apiKeyLookupCandidates(key, h.authService.HashAPIKey(key)) {
+		for _, candidate := range apiKeyLookupCandidates(key, h.authService.HashAPIKey(key)) { // hashed only; raw fallback removed (bugboard #163)
 			res, err := db.Query(internalCtx, q, candidate)
 			if err != nil || res == nil || res.Count == 0 || len(res.Rows) == 0 {
 				continue
@@ -241,10 +241,10 @@ func (h *Handlers) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 // fallback for legacy unhashed rows. The raw fallback is skipped when hashing
 // is a no-op (hashedKey == rawKey) so we never issue a duplicate query.
 func apiKeyLookupCandidates(rawKey, hashedKey string) []string {
-	if hashedKey == rawKey {
+	if hashedKey == "" || hashedKey == rawKey {
 		return []string{rawKey}
 	}
-	return []string{hashedKey, rawKey}
+	return []string{hashedKey}
 }
 
 // extractAPIKey extracts API key from Authorization, X-API-Key header, or query parameters

--- a/core/pkg/gateway/handlers/deployments/list_handler.go
+++ b/core/pkg/gateway/handlers/deployments/list_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DeBrosOfficial/network/pkg/deployments"
 	"github.com/DeBrosOfficial/network/pkg/deployments/process"
+	"github.com/DeBrosOfficial/network/pkg/gateway/handlers/storage"
 	"github.com/DeBrosOfficial/network/pkg/ipfs"
 	"go.uber.org/zap"
 )
@@ -236,10 +237,8 @@ func (h *ListHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 3. Unpin IPFS content
-	if deployment.ContentCID != "" {
-		if err := h.ipfsClient.Unpin(ctx, deployment.ContentCID); err != nil {
-			h.logger.Warn("Failed to unpin IPFS content", zap.Error(err), zap.String("cid", deployment.ContentCID))
-		}
+	if err := storage.UnpinIfLastPinner(ctx, h.service.db, h.ipfsClient, deployment.ContentCID, namespace); err != nil {
+		h.logger.Warn("Failed to unpin IPFS content", zap.Error(err), zap.String("cid", deployment.ContentCID))
 	}
 
 	// 4. Delete subdomain registry

--- a/core/pkg/gateway/handlers/deployments/update_handler.go
+++ b/core/pkg/gateway/handlers/deployments/update_handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DeBrosOfficial/network/pkg/deployments"
+	"github.com/DeBrosOfficial/network/pkg/gateway/handlers/storage"
 	"go.uber.org/zap"
 )
 
@@ -164,7 +165,7 @@ func (h *UpdateHandler) updateStatic(ctx context.Context, existing *deployments.
 
 	// Unpin old IPFS content (best-effort)
 	if oldContentCID != "" && oldContentCID != cid {
-		if unpinErr := h.staticHandler.ipfsClient.Unpin(ctx, oldContentCID); unpinErr != nil {
+		if unpinErr := storage.UnpinIfLastPinner(ctx, h.service.db, h.staticHandler.ipfsClient, oldContentCID, existing.Namespace); unpinErr != nil {
 			h.logger.Warn("Failed to unpin old content CID", zap.String("cid", oldContentCID), zap.Error(unpinErr))
 		}
 	}
@@ -277,7 +278,7 @@ func (h *UpdateHandler) updateDynamic(ctx context.Context, existing *deployments
 
 	// Unpin old IPFS build (best-effort)
 	if oldBuildCID != "" && oldBuildCID != cid {
-		if unpinErr := h.nextjsHandler.ipfsClient.Unpin(ctx, oldBuildCID); unpinErr != nil {
+		if unpinErr := storage.UnpinIfLastPinner(ctx, h.service.db, h.nextjsHandler.ipfsClient, oldBuildCID, existing.Namespace); unpinErr != nil {
 			h.logger.Warn("Failed to unpin old build CID", zap.String("cid", oldBuildCID), zap.Error(unpinErr))
 		}
 	}

--- a/core/pkg/gateway/handlers/namespace/delete_handler.go
+++ b/core/pkg/gateway/handlers/namespace/delete_handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DeBrosOfficial/network/pkg/gateway/ctxkeys"
+	"github.com/DeBrosOfficial/network/pkg/gateway/handlers/storage"
 	"github.com/DeBrosOfficial/network/pkg/ipfs"
 	"github.com/DeBrosOfficial/network/pkg/rqlite"
 	"go.uber.org/zap"
@@ -153,19 +154,15 @@ func (h *DeleteHandler) cleanupDeployments(ctx context.Context, ns string) {
 	// 2. Unpin deployment IPFS content
 	if h.ipfsClient != nil {
 		for _, dep := range deps {
-			if dep.ContentCID != "" {
-				if err := h.ipfsClient.Unpin(ctx, dep.ContentCID); err != nil {
-					h.logger.Warn("Failed to unpin deployment content CID",
-						zap.String("deployment_id", dep.ID),
-						zap.String("cid", dep.ContentCID), zap.Error(err))
-				}
+			if err := storage.UnpinIfLastPinner(ctx, h.ormClient, h.ipfsClient, dep.ContentCID, ns); err != nil {
+				h.logger.Warn("Failed to unpin deployment content CID",
+					zap.String("deployment_id", dep.ID),
+					zap.String("cid", dep.ContentCID), zap.Error(err))
 			}
-			if dep.BuildCID != "" {
-				if err := h.ipfsClient.Unpin(ctx, dep.BuildCID); err != nil {
-					h.logger.Warn("Failed to unpin deployment build CID",
-						zap.String("deployment_id", dep.ID),
-						zap.String("cid", dep.BuildCID), zap.Error(err))
-				}
+			if err := storage.UnpinIfLastPinner(ctx, h.ormClient, h.ipfsClient, dep.BuildCID, ns); err != nil {
+				h.logger.Warn("Failed to unpin deployment build CID",
+					zap.String("deployment_id", dep.ID),
+					zap.String("cid", dep.BuildCID), zap.Error(err))
 			}
 		}
 	}
@@ -280,7 +277,7 @@ func (h *DeleteHandler) unpinNamespaceContent(ctx context.Context, ns string) {
 		zap.Int("cid_count", len(rows)))
 
 	for _, row := range rows {
-		if err := h.ipfsClient.Unpin(ctx, row.CID); err != nil {
+		if err := storage.UnpinIfLastPinner(ctx, h.ormClient, h.ipfsClient, row.CID, ns); err != nil {
 			h.logger.Warn("Failed to unpin CID (best-effort)",
 				zap.String("cid", row.CID),
 				zap.String("namespace", ns),

--- a/core/pkg/gateway/handlers/namespace/delete_handler.go
+++ b/core/pkg/gateway/handlers/namespace/delete_handler.go
@@ -102,11 +102,13 @@ func (h *DeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// 4. Clean up global tables that use namespace TEXT (not FK cascade)
 	h.cleanupGlobalTables(r.Context(), ns)
 
-	// 5. Delete API keys, ownership records, and namespace record
-	h.ormClient.Exec(r.Context(), "DELETE FROM wallet_api_keys WHERE namespace_id = ?", namespaceID)
-	h.ormClient.Exec(r.Context(), "DELETE FROM api_keys WHERE namespace_id = ?", namespaceID)
-	h.ormClient.Exec(r.Context(), "DELETE FROM namespace_ownership WHERE namespace_id = ?", namespaceID)
-	h.ormClient.Exec(r.Context(), "DELETE FROM namespaces WHERE id = ?", namespaceID)
+	// 5. Delete FK children explicitly (ON DELETE CASCADE is decorative:
+	// rqlited is not started with -fk, bugboard #164). Check every error.
+	if err := h.deleteNamespaceRows(r.Context(), namespaceID); err != nil {
+		h.logger.Error("Failed to delete namespace rows", zap.Error(err))
+		writeDeleteResponse(w, http.StatusInternalServerError, map[string]interface{}{"error": err.Error()})
+		return
+	}
 
 	h.logger.Info("Namespace deleted successfully", zap.String("namespace", ns))
 
@@ -285,6 +287,33 @@ func (h *DeleteHandler) unpinNamespaceContent(ctx context.Context, ns string) {
 				zap.Error(err))
 		}
 	}
+}
+
+// namespaceFKChildren are tables that declare REFERENCES namespaces(id)
+// ON DELETE CASCADE. CASCADE does not fire (foreign_keys=0 / no -fk), so
+// deleteNamespaceRows must empty them first. Order: children, then namespaces.
+var namespaceFKChildren = []string{
+	"wallet_api_keys",
+	"api_keys",
+	"namespace_ownership",
+	"apps",
+	"nonces",
+	"subscriptions",
+	"refresh_tokens",
+	"audit_events",
+	"namespace_clusters",
+}
+
+func (h *DeleteHandler) deleteNamespaceRows(ctx context.Context, namespaceID int64) error {
+	for _, table := range namespaceFKChildren {
+		if _, err := h.ormClient.Exec(ctx, "DELETE FROM "+table+" WHERE namespace_id = ?", namespaceID); err != nil {
+			return fmt.Errorf("delete %s for namespace %d: %w", table, namespaceID, err)
+		}
+	}
+	if _, err := h.ormClient.Exec(ctx, "DELETE FROM namespaces WHERE id = ?", namespaceID); err != nil {
+		return fmt.Errorf("delete namespaces id %d: %w", namespaceID, err)
+	}
+	return nil
 }
 
 // cleanupGlobalTables deletes orphaned records from global tables that reference

--- a/core/pkg/gateway/handlers/namespace/delete_handler_test.go
+++ b/core/pkg/gateway/handlers/namespace/delete_handler_test.go
@@ -1,0 +1,80 @@
+package namespace
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/rqlite"
+	_ "github.com/mattn/go-sqlite3"
+	"go.uber.org/zap"
+)
+
+type stubDeprov struct{}
+
+func (stubDeprov) DeprovisionCluster(context.Context, int64) error { return nil }
+
+func TestDeleteNamespaceRows_removesKeysAndNamespace(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:delns?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	stmts := []string{
+		`CREATE TABLE namespaces (id INTEGER PRIMARY KEY, name TEXT)`,
+		`CREATE TABLE api_keys (id INTEGER PRIMARY KEY, key TEXT, namespace_id INTEGER, revoked_at TEXT)`,
+		`CREATE TABLE wallet_api_keys (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE namespace_ownership (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE apps (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE nonces (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE subscriptions (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE refresh_tokens (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE audit_events (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`CREATE TABLE namespace_clusters (id INTEGER PRIMARY KEY, namespace_id INTEGER)`,
+		`INSERT INTO namespaces(id, name) VALUES (42, 'gone'), (1, 'keep')`,
+		`INSERT INTO api_keys(id, key, namespace_id) VALUES (1, 'ak_x:gone', 42), (2, 'ak_y:keep', 1)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("%s: %v", s, err)
+		}
+	}
+
+	h := NewDeleteHandler(stubDeprov{}, rqlite.NewClient(db), nil, zap.NewNop())
+	if err := h.deleteNamespaceRows(context.Background(), 42); err != nil {
+		t.Fatal(err)
+	}
+
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM namespaces WHERE id = 42").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("namespace 42 still present")
+	}
+	if err := db.QueryRow("SELECT count(*) FROM api_keys WHERE namespace_id = 42").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("api_keys for 42 still present")
+	}
+	if err := db.QueryRow("SELECT count(*) FROM namespaces WHERE id = 1").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("unrelated namespace was deleted")
+	}
+}
+
+func TestDeleteNamespaceRows_execErrorSurfaces(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:delnserr?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	h := NewDeleteHandler(stubDeprov{}, rqlite.NewClient(db), nil, zap.NewNop())
+	if err := h.deleteNamespaceRows(context.Background(), 1); err == nil {
+		t.Fatal("expected error when child tables are missing")
+	}
+}

--- a/core/pkg/gateway/handlers/storage/evict_handler.go
+++ b/core/pkg/gateway/handlers/storage/evict_handler.go
@@ -70,21 +70,7 @@ func (h *Handlers) remainingPinsForCID(ctx context.Context, cid string) (int, er
 // while another namespace still references the content — doing so orphans that
 // namespace's data at the next GC. Used to gate the cluster-pin removal.
 func (h *Handlers) cidPinnedByOtherNamespace(ctx context.Context, cid, namespace string) (bool, error) {
-	if h.db == nil {
-		return false, nil
-	}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	var result []map[string]interface{}
-	query := `SELECT COUNT(*) as count FROM ipfs_content_ownership WHERE cid = ? AND namespace != ? AND is_pinned = 1`
-	if err := h.db.Query(ctx, &result, query, cid, namespace); err != nil {
-		return false, err
-	}
-	if len(result) == 0 {
-		return false, nil
-	}
-	return countFromRow(result[0]["count"]) > 0, nil
+	return CIDInUseByOtherNamespace(ctx, h.db, cid, namespace)
 }
 
 // countFromRow coerces a COUNT(*) cell (rqlite returns float64 or int64) to int.

--- a/core/pkg/gateway/handlers/storage/refcount.go
+++ b/core/pkg/gateway/handlers/storage/refcount.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/DeBrosOfficial/network/pkg/rqlite"
+)
+
+// ClusterUnpinner is the IPFS unpin surface shared by storage, deployments,
+// and namespace-delete (bugboard #157).
+type ClusterUnpinner interface {
+	Unpin(ctx context.Context, cid string) error
+}
+
+// CIDInUseByOtherNamespace reports whether any namespace OTHER than the
+// given one still holds this CID — either as a live ipfs_content_ownership
+// pin or as a deployment content/build CID. IPFS-Cluster dedups to one pin
+// per CID, so the last remaining user is the only one that may Unpin.
+func CIDInUseByOtherNamespace(ctx context.Context, db rqlite.Client, cid, namespace string) (bool, error) {
+	if db == nil || cid == "" {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var result []map[string]interface{}
+	q := `SELECT COUNT(*) as count FROM ipfs_content_ownership WHERE cid = ? AND namespace != ? AND is_pinned = 1`
+	if err := db.Query(ctx, &result, q, cid, namespace); err != nil {
+		return false, err
+	}
+	if len(result) > 0 && countFromRow(result[0]["count"]) > 0 {
+		return true, nil
+	}
+
+	result = nil
+	q = `SELECT COUNT(*) as count FROM deployments WHERE namespace != ? AND (content_cid = ? OR build_cid = ?)`
+	if err := db.Query(ctx, &result, q, namespace, cid, cid); err != nil {
+		return false, err
+	}
+	if len(result) == 0 {
+		return false, nil
+	}
+	return countFromRow(result[0]["count"]) > 0, nil
+}
+
+// UnpinIfLastPinner removes the cluster pin only when no other namespace
+// still references the CID. On a refcount error it leaves the pin (a leak
+// is recoverable; deleting live shared data is not). Empty cid or nil
+// client is a no-op.
+func UnpinIfLastPinner(ctx context.Context, db rqlite.Client, ipfs ClusterUnpinner, cid, namespace string) error {
+	if cid == "" || ipfs == nil {
+		return nil
+	}
+	inUse, err := CIDInUseByOtherNamespace(ctx, db, cid, namespace)
+	if err != nil || inUse {
+		return nil
+	}
+	return ipfs.Unpin(ctx, cid)
+}

--- a/core/pkg/gateway/handlers/storage/refcount_test.go
+++ b/core/pkg/gateway/handlers/storage/refcount_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestUnpinIfLastPinner_sharedOwnershipSkipsUnpin(t *testing.T) {
+	ipfs := &mockIPFSClient{}
+	db := &mockStorageDB{otherPinCount: 1}
+	if err := UnpinIfLastPinner(context.Background(), db, ipfs, "QmX", "ns-a"); err != nil {
+		t.Fatal(err)
+	}
+	if ipfs.unpinCalls != 0 {
+		t.Fatalf("must not unpin a CID another namespace still pins, unpins=%d", ipfs.unpinCalls)
+	}
+}
+
+func TestUnpinIfLastPinner_lastPinnerUnpins(t *testing.T) {
+	ipfs := &mockIPFSClient{}
+	db := &mockStorageDB{otherPinCount: 0}
+	if err := UnpinIfLastPinner(context.Background(), db, ipfs, "QmX", "ns-a"); err != nil {
+		t.Fatal(err)
+	}
+	if ipfs.unpinCalls != 1 {
+		t.Fatalf("last pinner must unpin, unpins=%d", ipfs.unpinCalls)
+	}
+}
+
+func TestUnpinIfLastPinner_emptyCIDNoop(t *testing.T) {
+	ipfs := &mockIPFSClient{}
+	if err := UnpinIfLastPinner(context.Background(), &mockStorageDB{}, ipfs, "", "ns-a"); err != nil {
+		t.Fatal(err)
+	}
+	if ipfs.unpinCalls != 0 {
+		t.Fatal("empty cid must not unpin")
+	}
+}
+
+func TestUnpinIfLastPinner_refcountErrorLeavesPin(t *testing.T) {
+	ipfs := &mockIPFSClient{}
+	db := &mockStorageDB{otherQueryErr: errors.New("db down")}
+	if err := UnpinIfLastPinner(context.Background(), db, ipfs, "QmX", "ns-a"); err != nil {
+		t.Fatal(err)
+	}
+	if ipfs.unpinCalls != 0 {
+		t.Fatal("refcount error must leave the cluster pin")
+	}
+}

--- a/core/pkg/gateway/middleware.go
+++ b/core/pkg/gateway/middleware.go
@@ -605,20 +605,10 @@ func (g *Gateway) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Look up API key → namespace against THIS gateway's own database.
-		//
-		// A namespace gateway owns its namespace's key registry: `orama namespace
-		// keys create` writes scoped keys into the namespace rqlite, so that is
-		// where they must be verified. Validating against the GLOBAL database
-		// instead (the old g.authClient path) meant a key could be valid,
-		// unrevoked and correctly scoped yet still 401 — because auth never
-		// looked in the database it lived in. Whether a key worked depended on
-		// which gateway happened to mint it, which is why devnet and testnet
-		// behaved differently with the identical command.
-		//
-		// Each gateway now verifies against the registry it owns. A namespace
-		// gateway therefore cannot authenticate a key belonging to a different
-		// namespace, which is the correct tenant boundary anyway.
+		// Look up API key → namespace against the core/index registry
+		// (g.apiKeyDB(): authClient when GlobalRQLiteDSN is set, else
+		// g.client). Keys are created only in that registry (bugboard #162).
+		// A namespace gateway's own RQLite is never authoritative for keys.
 		ns, rawScopes, err := g.lookupAPIKeyEntry(r.Context(), key, g.apiKeyDB())
 		if err != nil {
 			if isPublic {

--- a/core/pkg/gateway/middleware.go
+++ b/core/pkg/gateway/middleware.go
@@ -290,7 +290,6 @@ func (g *Gateway) lookupAPIKeyEntry(ctx context.Context, key string, q apiKeyQue
 	// the 60s cache TTL). scopes is nullable — a NULL means a legacy key.
 	sqlQuery := "SELECT namespaces.name, api_keys.scopes FROM api_keys JOIN namespaces ON api_keys.namespace_id = namespaces.id WHERE api_keys.key = ? AND api_keys.revoked_at IS NULL LIMIT 1"
 
-	// Try HMAC-hashed lookup first (new keys stored as hashes)
 	hashedKey := g.authService.HashAPIKey(key)
 	res, err := q.Query(internalCtx, sqlQuery, hashedKey)
 	if err != nil {
@@ -309,24 +308,10 @@ func (g *Gateway) lookupAPIKeyEntry(ctx context.Context, key string, q apiKeyQue
 		}
 	}
 
-	// Fallback: try raw key lookup (existing unhashed keys during rolling upgrade)
-	if hashedKey != key {
-		res, err = q.Query(internalCtx, sqlQuery, key)
-		if err != nil {
-			return "", "", fmt.Errorf("lookupAPIKeyEntry: raw-key query failed: %w", err)
-		}
-		if res != nil && res.Count > 0 && len(res.Rows) > 0 && len(res.Rows[0]) > 0 {
-			if ns := getString(res.Rows[0][0]); ns != "" {
-				scopes := ""
-				if len(res.Rows[0]) > 1 {
-					scopes = getString(res.Rows[0][1])
-				}
-				if g.mwCache != nil {
-					g.mwCache.SetAPIKeyEntry(key, ns, scopes)
-				}
-				return ns, scopes, nil
-			}
-		}
+	orphanSQL := "SELECT api_keys.id FROM api_keys LEFT JOIN namespaces ON api_keys.namespace_id = namespaces.id WHERE api_keys.key = ? AND namespaces.id IS NULL LIMIT 1"
+	if ores, oerr := q.Query(internalCtx, orphanSQL, hashedKey); oerr == nil && ores != nil && ores.Count > 0 && g.logger != nil {
+		g.logger.ComponentWarn("gateway", "API key row exists but namespace is gone (orphaned key)",
+			zap.Int64("hits", ores.Count))
 	}
 
 	return "", "", fmt.Errorf("invalid API key")

--- a/core/pkg/gateway/middleware_apikey_lookup_test.go
+++ b/core/pkg/gateway/middleware_apikey_lookup_test.go
@@ -76,7 +76,8 @@ func TestLookupAPIKeyEntry_HashedKeyHappyPath(t *testing.T) {
 	}
 }
 
-func TestLookupAPIKeyEntry_RawKeyFallback(t *testing.T) {
+func TestLookupAPIKeyEntry_RawKeyNoLongerAccepted(t *testing.T) {
+	// Bugboard #163: after the hash-in-place migrator, lookup is hashed-only.
 	g := hashingGatewayFixture(t)
 	const rawKey = "ak_legacy_unhashed"
 	hashed := g.authService.HashAPIKey(rawKey)
@@ -90,15 +91,9 @@ func TestLookupAPIKeyEntry_RawKeyFallback(t *testing.T) {
 		return &client.QueryResult{Count: 0}, nil
 	}}
 
-	ns, _, err := g.lookupAPIKeyEntry(context.Background(), rawKey, q)
-	if err != nil {
-		t.Fatalf("expected raw-key fallback to succeed, got error: %v", err)
-	}
-	if ns != "vrf708" {
-		t.Errorf("expected namespace vrf708, got %q", ns)
-	}
-	if q.calls != 2 {
-		t.Errorf("expected 2 queries (hashed miss, then raw-key fallback hit), got %d", q.calls)
+	_, _, err := g.lookupAPIKeyEntry(context.Background(), rawKey, q)
+	if err == nil {
+		t.Fatal("raw (unhashed) key must not authenticate after dual-lookup removal")
 	}
 }
 
@@ -111,8 +106,8 @@ func TestLookupAPIKeyEntry_RevokedKeyRejected(t *testing.T) {
 	// perspective. Assert the query text carries the filter and that a
 	// revoked key resolves to the same "invalid API key" outcome as no rows.
 	q := &fakeAPIKeyQuerier{queryFn: func(_ context.Context, sql string, _ ...interface{}) (*client.QueryResult, error) {
-		if !strings.Contains(sql, "revoked_at IS NULL") {
-			t.Errorf("expected query to filter revoked keys, got: %s", sql)
+		if strings.Contains(sql, "api_keys.scopes") && !strings.Contains(sql, "revoked_at IS NULL") {
+			t.Errorf("expected lookup query to filter revoked keys, got: %s", sql)
 		}
 		return &client.QueryResult{Count: 0}, nil
 	}}

--- a/core/pkg/namespace/reconcile_gateway_test.go
+++ b/core/pkg/namespace/reconcile_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/DeBrosOfficial/network/pkg/gateway"
@@ -91,60 +92,144 @@ func TestGatewayWebRTCInSync_bothDisabled_returnsTrue(t *testing.T) {
 	}
 }
 
-// Bugboard #837 follow-up (drift on the secrets encryption key) —
-// gatewayConfigInSync extends the bug-25 WebRTC drift check with the
-// serverless secrets key. A namespace gateway spawned before the key was
-// plumbed has an empty on-disk key; once the desired key is non-empty we
-// want a rewrite+restart so secrets management turns on. But both-empty must
-// stay a no-op so non-secrets hosts don't restart-loop.
+func cfgInSync(onDisk gateway.GatewayYAMLConfig, cfg gateway.InstanceConfig, hmac string) bool {
+	return gatewayConfigInSync(onDisk, cfg, hmac, "")
+}
 
 func TestGatewayConfigInSync_secretsKeyMissingOnDisk_returnsFalse(t *testing.T) {
-	// On-disk YAML has no secrets key (pre-#837 gateway), desired has one.
-	// MUST drift so ReconcileGateway rewrites + restarts to enable secrets.
-	onDisk := gateway.GatewayYAMLConfig{} // empty secrets_encryption_key
-	desired := gateway.InstanceConfig{SecretsEncryptionKey: "the-key"}
-	if gatewayConfigInSync(onDisk, desired) {
+	cfg := gateway.InstanceConfig{SecretsEncryptionKey: "the-key"}
+	onDisk := gatewayYAMLFromInstance(cfg, "", "")
+	onDisk.SecretsEncryptionKey = ""
+	if cfgInSync(onDisk, cfg, "") {
 		t.Fatal("empty on-disk secrets key vs non-empty desired must be out-of-sync (needs restart to enable secrets)")
 	}
 }
 
 func TestGatewayConfigInSync_secretsKeyMatches_returnsTrue(t *testing.T) {
-	// After a reconcile, on-disk key matches desired. MUST be in-sync so the
-	// next boot does not restart again (no loop).
-	onDisk := gateway.GatewayYAMLConfig{SecretsEncryptionKey: "the-key"}
-	desired := gateway.InstanceConfig{SecretsEncryptionKey: "the-key"}
-	if !gatewayConfigInSync(onDisk, desired) {
+	cfg := gateway.InstanceConfig{SecretsEncryptionKey: "the-key"}
+	onDisk := gatewayYAMLFromInstance(cfg, "", "")
+	if !cfgInSync(onDisk, cfg, "") {
 		t.Error("matching secrets key must be in-sync (no restart) — else restart loop on every boot")
 	}
 }
 
 func TestGatewayConfigInSync_bothSecretsKeysEmpty_returnsTrue(t *testing.T) {
-	// A host with no secrets key (empty desired) and an on-disk config also
-	// without one MUST be in-sync — otherwise every boot would restart a
-	// namespace gateway that legitimately has no secrets key.
-	if !gatewayConfigInSync(gateway.GatewayYAMLConfig{}, gateway.InstanceConfig{}) {
+	cfg := gateway.InstanceConfig{}
+	onDisk := gatewayYAMLFromInstance(cfg, "", "")
+	if !cfgInSync(onDisk, cfg, "") {
 		t.Error("empty on-disk + empty desired secrets key must be in-sync (no restart loop)")
 	}
 }
 
 func TestGatewayConfigInSync_secretsKeyRotated_returnsFalse(t *testing.T) {
-	// A rotated key (both non-empty but different) must drift so the rewrite
-	// propagates the new key.
-	onDisk := gateway.GatewayYAMLConfig{SecretsEncryptionKey: "old-key"}
-	desired := gateway.InstanceConfig{SecretsEncryptionKey: "new-key"}
-	if gatewayConfigInSync(onDisk, desired) {
+	cfg := gateway.InstanceConfig{SecretsEncryptionKey: "new-key"}
+	onDisk := gatewayYAMLFromInstance(cfg, "", "")
+	onDisk.SecretsEncryptionKey = "old-key"
+	if cfgInSync(onDisk, cfg, "") {
 		t.Error("rotated secrets key (old != new) must be out-of-sync")
 	}
 }
 
 func TestGatewayConfigInSync_webrtcDriftStillDetected(t *testing.T) {
-	// The combined check must not lose the bug-25 WebRTC surface: WebRTC
-	// drift with matching (empty) secrets keys must still report out-of-sync.
-	onDisk := gateway.GatewayYAMLConfig{WebRTC: gateway.GatewayYAMLWebRTC{}}
-	desired := gateway.InstanceConfig{WebRTCEnabled: true, SFUPort: 30000}
-	if gatewayConfigInSync(onDisk, desired) {
+	cfg := gateway.InstanceConfig{WebRTCEnabled: true, SFUPort: 30000}
+	onDisk := gatewayYAMLFromInstance(gateway.InstanceConfig{}, "", "")
+	if cfgInSync(onDisk, cfg, "") {
 		t.Error("WebRTC drift must still be detected by the combined in-sync check")
 	}
+}
+
+func TestGatewayConfigInSync_hmacSecretMissingOnDisk_returnsFalse(t *testing.T) {
+	cfg := gateway.InstanceConfig{Namespace: "ns", HTTPPort: 6101}
+	onDisk := gatewayYAMLFromInstance(cfg, "the-hmac", "")
+	onDisk.APIKeyHMACSecret = ""
+	if cfgInSync(onDisk, cfg, "the-hmac") {
+		t.Fatal("empty on-disk HMAC secret vs non-empty desired must be out-of-sync (bugboard #165)")
+	}
+}
+
+func TestGatewayConfigInSync_hmacSecretMatches_returnsTrue(t *testing.T) {
+	cfg := gateway.InstanceConfig{Namespace: "ns", HTTPPort: 6101}
+	onDisk := gatewayYAMLFromInstance(cfg, "the-hmac", "")
+	if !cfgInSync(onDisk, cfg, "the-hmac") {
+		t.Error("matching HMAC secret must be in-sync (no restart loop)")
+	}
+}
+
+func TestGatewayConfigInSync_bothHmacSecretsEmpty_returnsTrue(t *testing.T) {
+	cfg := gateway.InstanceConfig{Namespace: "ns", HTTPPort: 6101}
+	onDisk := gatewayYAMLFromInstance(cfg, "", "")
+	if !cfgInSync(onDisk, cfg, "") {
+		t.Error("empty on-disk + empty desired HMAC must be in-sync")
+	}
+}
+
+func TestGatewayConfigInSync_hmacSecretRotated_returnsFalse(t *testing.T) {
+	cfg := gateway.InstanceConfig{Namespace: "ns", HTTPPort: 6101}
+	onDisk := gatewayYAMLFromInstance(cfg, "new-hmac", "")
+	onDisk.APIKeyHMACSecret = "old-hmac"
+	if cfgInSync(onDisk, cfg, "new-hmac") {
+		t.Error("rotated HMAC secret must be out-of-sync")
+	}
+}
+
+func TestGatewayYAMLEqual_anyFieldChangeIsDrift(t *testing.T) {
+	// Exhaustive-by-construction (bugboard #165): mutating any exported
+	// GatewayYAMLConfig / GatewayYAMLWebRTC field must make equality fail.
+	// A newly added YAML field that is not compared will fail this test.
+	base := gatewayYAMLFromInstance(gateway.InstanceConfig{
+		Namespace:            "ns",
+		HTTPPort:             6101,
+		SecretsEncryptionKey: "k",
+	}, "hmac", "/cluster-secret")
+	if !gatewayYAMLEqual(base, base) {
+		t.Fatal("a config must equal itself")
+	}
+
+	checkStruct := func(prefix string, sample any) {
+		t.Helper()
+		typ := reflect.TypeOf(sample)
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			t.Run(prefix+f.Name, func(t *testing.T) {
+				mutated := base
+				mv := reflect.ValueOf(&mutated).Elem()
+				var fv reflect.Value
+				if prefix == "WebRTC." {
+					fv = mv.FieldByName("WebRTC").FieldByName(f.Name)
+				} else {
+					fv = mv.FieldByName(f.Name)
+				}
+				if !fv.IsValid() || !fv.CanSet() {
+					t.Fatalf("cannot set %s%s", prefix, f.Name)
+				}
+				switch fv.Kind() {
+				case reflect.String:
+					fv.SetString(fv.String() + "-mutated")
+				case reflect.Bool:
+					fv.SetBool(!fv.Bool())
+				case reflect.Int:
+					fv.SetInt(fv.Int() + 1)
+				case reflect.Slice:
+					fv.Set(reflect.ValueOf([]string{"mutated"}))
+				case reflect.Struct:
+					if prefix == "" && f.Name == "WebRTC" {
+						t.Skip("nested WebRTC fields covered separately")
+					}
+					t.Fatalf("unhandled struct %s%s — add nested coverage", prefix, f.Name)
+				default:
+					t.Fatalf("unhandled kind %s for %s%s", fv.Kind(), prefix, f.Name)
+				}
+				if gatewayYAMLEqual(base, mutated) {
+					t.Errorf("mutating %s%s was not detected — add it to gatewayYAMLEqual", prefix, f.Name)
+				}
+			})
+		}
+	}
+	checkStruct("", gateway.GatewayYAMLConfig{})
+	checkStruct("WebRTC.", gateway.GatewayYAMLWebRTC{})
 }
 
 // ReconcileGateway I/O paths that DON'T restart (the restart path needs
@@ -165,19 +250,30 @@ func writeGatewayConfig(t *testing.T, base, ns, nodeID string, wr gateway.Gatewa
 }
 
 func TestReconcileGateway_inSyncIsNoOpNoError(t *testing.T) {
-	base := t.TempDir()
+	root, nsBase := setupOramaDirs(t)
+	writeAPIKeyHMACSecret(t, root, "the-hmac-secret\n")
 	ns, node := "anchat-test", "node-1"
-	writeGatewayConfig(t, base, ns, node, gateway.GatewayYAMLWebRTC{
-		Enabled: true, SFUPort: 30000,
-		TURNDomain: "turn.ns-anchat-test.orama-devnet.network", TURNSecret: "the-secret",
-	})
-	s := NewSystemdSpawner(base, "", zap.NewNop())
+	s := NewSystemdSpawner(nsBase, "", zap.NewNop())
+	cfg := desiredEnabled()
+	cfg.Namespace = ns
 
-	// Desired == on-disk → must return nil WITHOUT attempting a restart
-	// (RestartGateway would error here since there's no real systemd, so
-	// a nil return proves we never reached it).
-	err := s.ReconcileGateway(context.Background(), ns, node, desiredEnabled())
+	hmac, err := s.readAPIKeyHMACSecret()
 	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(nsBase, ns, "configs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := yaml.Marshal(gatewayYAMLFromInstance(cfg, hmac, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "gateway-"+node+".yaml"), b, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.ReconcileGateway(context.Background(), ns, node, cfg); err != nil {
 		t.Errorf("in-sync config must be a clean no-op; got %v (did it try to restart?)", err)
 	}
 }

--- a/core/pkg/namespace/systemd_spawner.go
+++ b/core/pkg/namespace/systemd_spawner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -261,52 +262,12 @@ func (s *SystemdSpawner) SpawnGateway(ctx context.Context, namespace, nodeID str
 	// issues itself in plaintext. A namespace gateway with no secret can
 	// never authenticate anything, so booting one without it is never the
 	// right outcome — fail loud instead of silently degrading.
-	apiKeyHMACSecretPath := filepath.Join(s.oramaDir(), "secrets", apiKeyHMACSecretFileName)
-	secretBytes, err := os.ReadFile(apiKeyHMACSecretPath)
+	apiKeyHMACSecret, err := s.readAPIKeyHMACSecret()
 	if err != nil {
-		return fmt.Errorf("read API-key HMAC secret at %s (required for namespace gateway auth): %w", apiKeyHMACSecretPath, err)
-	}
-	apiKeyHMACSecret := strings.TrimSpace(string(secretBytes))
-	if apiKeyHMACSecret == "" {
-		return fmt.Errorf("API-key HMAC secret file %s is empty; namespace gateway cannot authenticate without it", apiKeyHMACSecretPath)
+		return err
 	}
 
-	// Build Gateway YAML config using the shared type from gateway package
-	gatewayConfig := gateway.GatewayYAMLConfig{
-		ListenAddr:            fmt.Sprintf(":%d", cfg.HTTPPort),
-		ClientNamespace:       cfg.Namespace,
-		RQLiteDSN:             cfg.RQLiteDSN,
-		GlobalRQLiteDSN:       cfg.GlobalRQLiteDSN,
-		DomainName:            cfg.BaseDomain,
-		OlricServers:          cfg.OlricServers,
-		OlricTimeout:          cfg.OlricTimeout.String(),
-		IPFSClusterAPIURL:     cfg.IPFSClusterAPIURL,
-		IPFSAPIURL:            cfg.IPFSAPIURL,
-		IPFSTimeout:           cfg.IPFSTimeout.String(),
-		IPFSReplicationFactor: cfg.IPFSReplicationFactor,
-		// Bug #215 fix: forward the host's cluster secret path so the
-		// spawned namespace gateway can derive the cluster-wide JWT
-		// signing key. Without this, namespace gateways used per-node
-		// random Ed25519 keys and host functions saw empty
-		// caller_jwt_subject.
-		ClusterSecretPath: s.clusterSecretPath,
-		// Bugboard #837 follow-up: forward the host's serverless secrets
-		// encryption key so the spawned namespace gateway can manage function
-		// secrets. Without this, `function secrets list` returned 501 on
-		// namespace gateways even though the host gateway had the key.
-		SecretsEncryptionKey: cfg.SecretsEncryptionKey,
-		// Bugboard #160 fix: forward the API-key HMAC secret read above so
-		// this namespace gateway hashes/verifies API keys identically to
-		// the main gateway.
-		APIKeyHMACSecret: apiKeyHMACSecret,
-		WebRTC: gateway.GatewayYAMLWebRTC{
-			Enabled:           cfg.WebRTCEnabled,
-			SFUPort:           cfg.SFUPort,
-			TURNDomain:        cfg.TURNDomain,
-			TURNSecret:        cfg.TURNSecret,
-			TURNStealthDomain: cfg.TURNStealthDomain,
-		},
-	}
+	gatewayConfig := gatewayYAMLFromInstance(cfg, apiKeyHMACSecret, s.clusterSecretPath)
 
 	configBytes, err := yaml.Marshal(gatewayConfig)
 	if err != nil {
@@ -414,21 +375,113 @@ func gatewayWebRTCInSync(onDisk gateway.GatewayYAMLWebRTC, cfg gateway.InstanceC
 		onDisk.TURNStealthDomain == cfg.TURNStealthDomain
 }
 
-// gatewayConfigInSync reports whether the full reconcile-relevant config on
-// disk matches the desired config — i.e. no rewrite+restart is needed.
-// Combines the WebRTC drift surface (bugboard #25) with the secrets
-// encryption key (bugboard #837): a gateway that was spawned before the key
-// was plumbed has an empty on-disk key and `function secrets list` returns
-// 501; once the desired key is non-empty we want a rewrite+restart so the
-// running gateway picks it up.
-//
-// Plain string equality keeps the "both empty → in sync" case a no-op: a
-// namespace on a host with no secrets key (empty desired) whose on-disk key
-// is also empty is in-sync, so it never restart-loops. Only a genuine
-// difference (empty on-disk vs non-empty desired, or a rotated key) drifts.
-func gatewayConfigInSync(onDisk gateway.GatewayYAMLConfig, cfg gateway.InstanceConfig) bool {
-	return gatewayWebRTCInSync(onDisk.WebRTC, cfg) &&
-		onDisk.SecretsEncryptionKey == cfg.SecretsEncryptionKey
+func (s *SystemdSpawner) readAPIKeyHMACSecret() (string, error) {
+	path := filepath.Join(s.oramaDir(), "secrets", apiKeyHMACSecretFileName)
+	secretBytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read API-key HMAC secret at %s (required for namespace gateway auth): %w", path, err)
+	}
+	secret := strings.TrimSpace(string(secretBytes))
+	if secret == "" {
+		return "", fmt.Errorf("API-key HMAC secret file %s is empty; namespace gateway cannot authenticate without it", path)
+	}
+	return secret, nil
+}
+
+// gatewayYAMLFromInstance is the single builder SpawnGateway and
+// ReconcileGateway share. Adding a field to GatewayYAMLConfig without
+// putting it here makes spawn and reconcile diverge; the field-coverage
+// test in reconcile_gateway_test.go fails when that happens.
+func gatewayYAMLFromInstance(cfg gateway.InstanceConfig, hmacSecret, clusterSecretPath string) gateway.GatewayYAMLConfig {
+	return gateway.GatewayYAMLConfig{
+		ListenAddr:            fmt.Sprintf(":%d", cfg.HTTPPort),
+		ClientNamespace:       cfg.Namespace,
+		RQLiteDSN:             cfg.RQLiteDSN,
+		GlobalRQLiteDSN:       cfg.GlobalRQLiteDSN,
+		DomainName:            cfg.BaseDomain,
+		OlricServers:          cfg.OlricServers,
+		OlricTimeout:          cfg.OlricTimeout.String(),
+		IPFSClusterAPIURL:     cfg.IPFSClusterAPIURL,
+		IPFSAPIURL:            cfg.IPFSAPIURL,
+		IPFSTimeout:           cfg.IPFSTimeout.String(),
+		IPFSReplicationFactor: cfg.IPFSReplicationFactor,
+		ClusterSecretPath:     clusterSecretPath,
+		SecretsEncryptionKey:  cfg.SecretsEncryptionKey,
+		APIKeyHMACSecret:      hmacSecret,
+		WebRTC: gateway.GatewayYAMLWebRTC{
+			Enabled:           cfg.WebRTCEnabled,
+			SFUPort:           cfg.SFUPort,
+			TURNDomain:        cfg.TURNDomain,
+			TURNSecret:        cfg.TURNSecret,
+			TURNStealthDomain: cfg.TURNStealthDomain,
+		},
+	}
+}
+
+func timeoutEqual(a, b string) bool {
+	return normalizeTimeout(a) == normalizeTimeout(b)
+}
+
+func normalizeTimeout(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" || s == "0s" {
+		return ""
+	}
+	return s
+}
+
+func stringSetEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// gatewayYAMLEqual compares every spawn-written GatewayYAMLConfig field.
+// Olric server order is ignored (discovery can reshuffle). Empty / "0s"
+// timeouts compare equal so omitempty on-disk values match a zero duration.
+func gatewayYAMLEqual(a, b gateway.GatewayYAMLConfig) bool {
+	return a.ListenAddr == b.ListenAddr &&
+		a.ClientNamespace == b.ClientNamespace &&
+		a.RQLiteDSN == b.RQLiteDSN &&
+		a.GlobalRQLiteDSN == b.GlobalRQLiteDSN &&
+		stringSetEqual(a.BootstrapPeers, b.BootstrapPeers) &&
+		a.EnableHTTPS == b.EnableHTTPS &&
+		a.DomainName == b.DomainName &&
+		a.TLSCacheDir == b.TLSCacheDir &&
+		stringSetEqual(a.OlricServers, b.OlricServers) &&
+		timeoutEqual(a.OlricTimeout, b.OlricTimeout) &&
+		a.IPFSClusterAPIURL == b.IPFSClusterAPIURL &&
+		a.IPFSAPIURL == b.IPFSAPIURL &&
+		timeoutEqual(a.IPFSTimeout, b.IPFSTimeout) &&
+		a.IPFSReplicationFactor == b.IPFSReplicationFactor &&
+		a.WebRTC.Enabled == b.WebRTC.Enabled &&
+		a.WebRTC.SFUPort == b.WebRTC.SFUPort &&
+		a.WebRTC.TURNDomain == b.WebRTC.TURNDomain &&
+		a.WebRTC.TURNSecret == b.WebRTC.TURNSecret &&
+		a.WebRTC.TURNStealthDomain == b.WebRTC.TURNStealthDomain &&
+		a.SecretsEncryptionKey == b.SecretsEncryptionKey &&
+		a.ClusterSecretPath == b.ClusterSecretPath &&
+		a.APIKeyHMACSecret == b.APIKeyHMACSecret
+}
+
+// gatewayConfigInSync reports whether on-disk YAML matches what spawn would
+// write for cfg. Comparison is exhaustive over GatewayYAMLConfig (bugboard
+// #165): a new YAML field that spawn writes cannot silently skip reconcile.
+func gatewayConfigInSync(onDisk gateway.GatewayYAMLConfig, cfg gateway.InstanceConfig, hmacSecret, clusterSecretPath string) bool {
+	return gatewayYAMLEqual(onDisk, gatewayYAMLFromInstance(cfg, hmacSecret, clusterSecretPath))
 }
 
 // ReconcileGateway is the WARM counterpart to SpawnGateway: when a
@@ -464,14 +517,21 @@ func (s *SystemdSpawner) ReconcileGateway(ctx context.Context, namespace, nodeID
 		return fmt.Errorf("parse gateway config for reconcile: %w", err)
 	}
 
-	if gatewayConfigInSync(onDisk, cfg) {
-		// Already in sync — nothing to do, no restart.
+	hmacSecret, err := s.readAPIKeyHMACSecret()
+	if err != nil {
+		// Host has no usable secret file. Compare as empty so we do not
+		// restart-loop; SpawnGateway on the restart path still fails loud
+		// if the file is required and missing.
+		hmacSecret = ""
+	}
+
+	if gatewayConfigInSync(onDisk, cfg, hmacSecret, s.clusterSecretPath) {
 		return nil
 	}
 
-	// secretsKeyDrifted is logged (as a bool, never the key material) so
-	// operators can see when a #837 rewrite fires vs a #25 WebRTC rewrite.
+	// Drift flags are bools — never log secret material (bugboard #165 / #837).
 	secretsKeyDrifted := onDisk.SecretsEncryptionKey != cfg.SecretsEncryptionKey
+	hmacSecretDrifted := onDisk.APIKeyHMACSecret != hmacSecret
 	s.logger.Info("Gateway config drifted from desired; reconciling (rewrite + restart)",
 		zap.String("namespace", namespace),
 		zap.String("node_id", nodeID),
@@ -479,7 +539,8 @@ func (s *SystemdSpawner) ReconcileGateway(ctx context.Context, namespace, nodeID
 		zap.Int("ondisk_sfu_port", onDisk.WebRTC.SFUPort),
 		zap.Bool("desired_enabled", cfg.WebRTCEnabled),
 		zap.Int("desired_sfu_port", cfg.SFUPort),
-		zap.Bool("secrets_key_drifted", secretsKeyDrifted))
+		zap.Bool("secrets_key_drifted", secretsKeyDrifted),
+		zap.Bool("hmac_secret_drifted", hmacSecretDrifted))
 	return s.RestartGateway(ctx, namespace, nodeID, cfg)
 }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -54,9 +54,10 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 **API Key Hashing (Step 1.6)**
 - API keys stored as HMAC-SHA256 hashes using a server-side secret
 - HMAC secret generated at cluster genesis, stored in `~/.orama/secrets/api-key-hmac-secret`
-- On lookup: compute HMAC, query by hash — fast enough for every request (unlike bcrypt)
+- Namespace and index gateway spawn refuse to start if that file is missing or empty
+- On lookup: compute HMAC, query by hash against the **core/index** RQLite registry (never a tenant RQLite)
 - In-memory cache uses raw key as cache key (never persisted)
-- During rolling upgrade: dual lookup (HMAC first, then raw as fallback) until all nodes upgraded
+- Startup migrates leftover plaintext `ak_…` rows to HMAC in place; lookup is hashed-only after that
 
 **TURN Secret Encryption (Step 1.15)**
 - TURN shared secrets encrypted at rest in RQLite using AES-256-GCM


### PR DESCRIPTION
## Summary

Implements CHG-201 (Bugboard change 201) on top of the 0.200.0 → factory (#101) → website (#102) stack. Five live gateway/registry bugs from July 2026, each in its own commit.

Merge order: **#101 factory → #102 website → this**. Do not merge this into `0.200.0` directly.

## What landed

| Bug | Commit | Fix |
|---|---|---|
| **#165** | `99e1299` | Warm `ReconcileGateway` compares every spawn-written YAML field, including `api_key_hmac_secret`. Spawn and reconcile share one builder. |
| **#162** | `a2d5a7d` | Explicit `rqlite_dsn` always wins over `DefaultClientConfig` endpoints. API-key writes go through the core `authClient` when `GlobalRQLiteDSN` is set, so tenant `g.client` does not split the key registry. |
| **#163** | `ca6fae8` | Startup migrator HMAC-hashes leftover `ak_…` rows. Lookup is hashed-only. Standalone gateway refuses to boot without `api_key_hmac_secret`. |
| **#164** | `25591dc` | Namespace delete issues explicit DELETEs for every `namespaces(id)` child table and fails if Exec errors. Startup revokes `api_keys` whose namespace row is gone. `-fk` is **not** flipped (needs an insert-order audit). |
| **#157** | `ab0e39b` | Namespace delete, deployment update, and deployment delete go through `UnpinIfLastPinner`. Refcount error leaves the cluster pin. |

Also: pin tests for `HashAPIKey`, `docs/SECURITY.md` updated to match.

## Out of scope

- Enabling rqlited `-fk`
- Live/testnet cutover
- VERSION bump
- The later 0.123.x–0.128.0 security train (CHG-202+)

## Test plan

- [x] `go test ./pkg/gateway/... ./pkg/gateway/auth/... ./pkg/namespace/... ./pkg/gateway/handlers/{namespace,storage,deployments,auth}/... ./cmd/gateway/`
- [x] Pre-push full `./pkg/...` suite on each push
- [x] Human review of the five Bugboard items (status: **review**, parent CHG-201 not marked done)