### PR TITLE
fix: CHG-224 secret hygiene

### DIFF
--- a/core/migrations/036_phantom_auth_null_keys.sql
+++ b/core/migrations/036_phantom_auth_null_keys.sql
@@ -1,0 +1,12 @@
+-- Null leftover plaintext API keys in phantom_auth_sessions and drop expired rows.
+-- The status endpoint is unauthenticated; completed rows previously served the
+-- key forever. Application code now nulls after first read.
+
+BEGIN;
+
+UPDATE phantom_auth_sessions SET api_key = NULL WHERE api_key IS NOT NULL AND api_key != '';
+DELETE FROM phantom_auth_sessions WHERE expires_at < datetime('now');
+
+INSERT OR IGNORE INTO schema_migrations(version) VALUES (36);
+
+COMMIT;

--- a/core/pkg/cli/db/commands.go
+++ b/core/pkg/cli/db/commands.go
@@ -351,7 +351,6 @@ func backupDatabase(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\n✅ Backup successful!\n\n")
 	fmt.Printf("Database:   %s\n", result["database_name"])
 	fmt.Printf("Backup CID: %s\n", result["backup_cid"])
-	fmt.Printf("IPFS URL:   %s\n", result["ipfs_url"])
 	fmt.Printf("Backed up:  %s\n", result["backed_up_at"])
 
 	return nil

--- a/core/pkg/cli/production/push/push.go
+++ b/core/pkg/cli/production/push/push.go
@@ -160,11 +160,16 @@ func pushFanout(archivePath string, nodes []inspector.Node) error {
 	// ALL node keys — which the target's sshd rejects with "too many
 	// authentication failures" once the offered-key count exceeds MaxAuthTries
 	// (default 6). Keys are chmod 600 and removed (defer) when the fanout ends.
-	const fanoutKeyDir = "/tmp/.orama-fanout-keys"
+	const fanoutKeyDir = "/dev/shm/.orama-fanout-keys"
 	if err := remotessh.RunSSHStreaming(hub, "rm -rf "+fanoutKeyDir+" && mkdir -p "+fanoutKeyDir+" && chmod 700 "+fanoutKeyDir); err != nil {
 		return fmt.Errorf("prepare fanout key dir on hub: %w", err)
 	}
-	defer func() { _ = remotessh.RunSSHStreaming(hub, "rm -rf "+fanoutKeyDir) }()
+	defer func() {
+		wipe := "for f in " + fanoutKeyDir + "/*; do [ -f \"$f\" ] && dd if=/dev/zero of=\"$f\" bs=8192 count=1 conv=notrunc status=none 2>/dev/null; done; rm -rf " + fanoutKeyDir
+		if err := remotessh.RunSSHStreaming(hub, wipe); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to wipe fanout keys on hub: %v\n", err)
+		}
+	}()
 	for _, t := range remaining {
 		dst := fanoutKeyDir + "/" + t.Host
 		if err := remotessh.UploadFile(hub, t.SSHKey, dst); err != nil {

--- a/core/pkg/config/database_config.go
+++ b/core/pkg/config/database_config.go
@@ -67,7 +67,7 @@ type IPFSConfig struct {
 	// If zero, defaults to 3
 	ReplicationFactor int `yaml:"replication_factor"`
 
-	// EnableEncryption enables client-side encryption before upload
-	// Defaults to true
+	// EnableEncryption is accepted in node.yaml for DecodeStrict compatibility.
+	// No code path encrypts IPFS uploads; the value is ignored.
 	EnableEncryption bool `yaml:"enable_encryption"`
 }

--- a/core/pkg/environments/production/config.go
+++ b/core/pkg/environments/production/config.go
@@ -379,8 +379,12 @@ func (cg *ConfigGenerator) readExistingWebRTC() *existingWebRTC {
 // and correct ownership, making it durable across future config regenerations.
 func (cg *ConfigGenerator) persistTURNSecret(secret string) error {
 	secretPath := filepath.Join(cg.oramaDir, "secrets", "turn-secret")
-	if err := os.MkdirAll(filepath.Dir(secretPath), 0700); err != nil {
+	secretDir := filepath.Dir(secretPath)
+	if err := os.MkdirAll(secretDir, 0700); err != nil {
 		return fmt.Errorf("failed to create secrets directory: %w", err)
+	}
+	if err := os.Chmod(secretDir, 0700); err != nil {
+		return fmt.Errorf("failed to set secrets directory permissions: %w", err)
 	}
 	if err := os.WriteFile(secretPath, []byte(secret), 0600); err != nil {
 		return fmt.Errorf("failed to persist TURN secret: %w", err)

--- a/core/pkg/environments/production/installers/ipfs_cluster.go
+++ b/core/pkg/environments/production/installers/ipfs_cluster.go
@@ -1,6 +1,7 @@
 package installers
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -242,8 +243,8 @@ func (ici *IPFSClusterInstaller) verifySecret(clusterPath, expectedSecret string
 
 	if cluster, ok := config["cluster"].(map[string]interface{}); ok {
 		if secret, ok := cluster["secret"].(string); ok {
-			if secret != expectedSecret {
-				return fmt.Errorf("secret mismatch: expected %s, got %s", expectedSecret, secret)
+			if subtle.ConstantTimeCompare([]byte(secret), []byte(expectedSecret)) != 1 {
+				return fmt.Errorf("secret mismatch in service.json")
 			}
 			return nil
 		}

--- a/core/pkg/environments/production/provisioner.go
+++ b/core/pkg/environments/production/provisioner.go
@@ -48,6 +48,9 @@ func (fp *FilesystemProvisioner) EnsureDirectoryStructure() error {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
 	}
+	if err := os.Chmod(filepath.Join(fp.oramaDir, "secrets"), 0700); err != nil {
+		return fmt.Errorf("failed to set secrets directory permissions: %w", err)
+	}
 
 	// Remove any stray cluster-secret file from root .orama directory
 	// The correct location is .orama/secrets/cluster-secret

--- a/core/pkg/environments/production/services.go
+++ b/core/pkg/environments/production/services.go
@@ -461,7 +461,7 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ExecStartPre=/bin/sh -c 'for i in $$(seq 1 30); do curl -so /dev/null http://localhost:10104/health 2>/dev/null && exit 0; sleep 2; done; echo "Gateway not ready after 60s"; exit 1'
 ExecStartPre=/bin/sh -c 'DOMAIN=$$(grep -oP "^\*\\.\K[^ {]+" /etc/caddy/Caddyfile | tail -1); [ -z "$$DOMAIN" ] && exit 0; for i in $$(seq 1 30); do dig +short +timeout=2 "$$DOMAIN" SOA 2>/dev/null | grep -q . && exit 0; sleep 2; done; echo "DNS not resolving $$DOMAIN after 60s (ACME may fail)"; exit 0'
 TimeoutStartSec=180
-ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
 TimeoutStopSec=5s
 LimitNOFILE=1048576

--- a/core/pkg/gateway/config.go
+++ b/core/pkg/gateway/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	IPFSAPIURL            string        // IPFS HTTP API URL for content retrieval (e.g., "http://localhost:4501"). If empty, gateway will discover from node configs
 	IPFSTimeout           time.Duration // Timeout for IPFS operations (default: 60s)
 	IPFSReplicationFactor int           // Replication factor for pins (default: 3)
-	IPFSEnableEncryption  bool          // Config flag only — no code path encrypts before upload today
 
 	// RQLite authentication (basic auth credentials embedded in DSN)
 	RQLiteUsername string // RQLite HTTP basic auth username (default: "orama")

--- a/core/pkg/gateway/dependencies.go
+++ b/core/pkg/gateway/dependencies.go
@@ -452,7 +452,6 @@ func initializeIPFS(logger *logging.ColoredLogger, cfg *Config, deps *Dependenci
 	ipfsAPIURL := cfg.IPFSAPIURL
 	ipfsTimeout := cfg.IPFSTimeout
 	ipfsReplicationFactor := cfg.IPFSReplicationFactor
-	ipfsEnableEncryption := cfg.IPFSEnableEncryption
 
 	if ipfsClusterURL == "" {
 		logger.ComponentInfo(logging.ComponentGeneral, "IPFS Cluster URL not configured, discovering from node configs...")
@@ -466,16 +465,13 @@ func initializeIPFS(logger *logging.ColoredLogger, cfg *Config, deps *Dependenci
 			if discovered.replicationFactor > 0 {
 				ipfsReplicationFactor = discovered.replicationFactor
 			}
-			ipfsEnableEncryption = discovered.enableEncryption
 			logger.ComponentInfo(logging.ComponentGeneral, "Discovered IPFS endpoints from node configs",
 				zap.String("cluster_url", ipfsClusterURL),
-				zap.String("api_url", ipfsAPIURL),
-				zap.Bool("encryption_enabled", ipfsEnableEncryption))
+				zap.String("api_url", ipfsAPIURL))
 		} else {
 			// Fallback to localhost defaults
 			ipfsClusterURL = "http://localhost:10108"
 			ipfsAPIURL = "http://localhost:10107"
-			ipfsEnableEncryption = true // Default to true
 			logger.ComponentInfo(logging.ComponentGeneral, "No IPFS config found in node configs, using localhost defaults")
 		}
 	}
@@ -488,13 +484,6 @@ func initializeIPFS(logger *logging.ColoredLogger, cfg *Config, deps *Dependenci
 	}
 	if ipfsReplicationFactor == 0 {
 		ipfsReplicationFactor = 3
-	}
-	if !cfg.IPFSEnableEncryption && !ipfsEnableEncryption {
-		// Only disable if explicitly set to false in both places
-		ipfsEnableEncryption = false
-	} else {
-		// Default to true if not explicitly disabled
-		ipfsEnableEncryption = true
 	}
 
 	ipfsCfg := ipfs.Config{
@@ -534,13 +523,11 @@ func initializeIPFS(logger *logging.ColoredLogger, cfg *Config, deps *Dependenci
 		zap.String("ipfs_api_url", ipfsAPIURL),
 		zap.Duration("timeout", ipfsCfg.Timeout),
 		zap.Int("replication_factor", ipfsReplicationFactor),
-		zap.Bool("encryption_enabled", ipfsEnableEncryption),
 	)
 
 	// Store IPFS settings back in config for use by handlers
 	cfg.IPFSAPIURL = ipfsAPIURL
 	cfg.IPFSReplicationFactor = ipfsReplicationFactor
-	cfg.IPFSEnableEncryption = ipfsEnableEncryption
 }
 
 // initializeServerless sets up the serverless function engine and related components
@@ -940,7 +927,6 @@ type ipfsDiscoveryResult struct {
 	apiURL            string
 	timeout           time.Duration
 	replicationFactor int
-	enableEncryption  bool
 }
 
 // discoverIPFSFromNodeConfigs discovers IPFS configuration from node.yaml files.
@@ -978,7 +964,6 @@ func discoverIPFSFromNodeConfigs(logger *zap.Logger) ipfsDiscoveryResult {
 				apiURL:            nodeCfg.Database.IPFS.APIURL,
 				timeout:           nodeCfg.Database.IPFS.Timeout,
 				replicationFactor: nodeCfg.Database.IPFS.ReplicationFactor,
-				enableEncryption:  nodeCfg.Database.IPFS.EnableEncryption,
 			}
 
 			if result.apiURL == "" {
@@ -990,16 +975,11 @@ func discoverIPFSFromNodeConfigs(logger *zap.Logger) ipfsDiscoveryResult {
 			if result.replicationFactor == 0 {
 				result.replicationFactor = 3
 			}
-			// Default encryption to true if not set
-			if !result.enableEncryption {
-				result.enableEncryption = true
-			}
 
 			logger.Info("Discovered IPFS config from node config",
 				zap.String("file", filename),
 				zap.String("cluster_url", result.clusterURL),
-				zap.String("api_url", result.apiURL),
-				zap.Bool("encryption_enabled", result.enableEncryption))
+				zap.String("api_url", result.apiURL))
 
 			return result
 		}

--- a/core/pkg/gateway/handlers/auth/phantom_handler.go
+++ b/core/pkg/gateway/handlers/auth/phantom_handler.go
@@ -123,17 +123,14 @@ func (h *Handlers) PhantomSessionStatusHandler(w http.ResponseWriter, r *http.Re
 	expiresAtStr := getString(row[6])
 	namespace := getString(row[1])
 
-	// Check expiration if still pending
-	if status == "pending" {
-		if expiresAt, err := time.Parse("2006-01-02 15:04:05", expiresAtStr); err == nil {
-			if time.Now().UTC().After(expiresAt) {
-				status = "expired"
-				// Update in DB
-				_, _ = db.Query(internalCtx,
-					"UPDATE phantom_auth_sessions SET status = 'expired' WHERE id = ? AND status = 'pending'",
-					sessionID,
-				)
-			}
+	if expiresAt, err := time.Parse("2006-01-02 15:04:05", expiresAtStr); err == nil {
+		if time.Now().UTC().After(expiresAt) {
+			status = "expired"
+			apiKey = ""
+			_, _ = db.Query(internalCtx,
+				"UPDATE phantom_auth_sessions SET status = 'expired', api_key = NULL WHERE id = ?",
+				sessionID,
+			)
 		}
 	}
 
@@ -147,6 +144,11 @@ func (h *Handlers) PhantomSessionStatusHandler(w http.ResponseWriter, r *http.Re
 	}
 	if apiKey != "" {
 		resp["api_key"] = apiKey
+		// One-shot: do not leave the plaintext key in RQLite after first read.
+		_, _ = db.Query(internalCtx,
+			"UPDATE phantom_auth_sessions SET api_key = NULL WHERE id = ?",
+			sessionID,
+		)
 	}
 	if errorMsg != "" {
 		resp["error"] = errorMsg

--- a/core/pkg/gateway/handlers/sqlite/backup_handler.go
+++ b/core/pkg/gateway/handlers/sqlite/backup_handler.go
@@ -120,7 +120,6 @@ func (h *BackupHandler) BackupDatabase(w http.ResponseWriter, r *http.Request) {
 		"database_name":  req.DatabaseName,
 		"backup_cid":     cid,
 		"backed_up_at":   now,
-		"ipfs_url":       "https://ipfs.io/ipfs/" + cid,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -193,7 +192,6 @@ func (h *BackupHandler) ListBackups(w http.ResponseWriter, r *http.Request) {
 			"backup_cid":   row.BackupCID,
 			"backed_up_at": row.BackedUpAt,
 			"size_bytes":   row.SizeBytes,
-			"ipfs_url":     "https://ipfs.io/ipfs/" + row.BackupCID,
 		}
 	}
 

--- a/core/pkg/gateway/storage_handlers_test.go
+++ b/core/pkg/gateway/storage_handlers_test.go
@@ -108,7 +108,6 @@ func newTestGatewayWithIPFS(t *testing.T, ipfsClient ipfs.IPFSClient) *Gateway {
 		ListenAddr:            ":6001",
 		ClientNamespace:       "test",
 		IPFSReplicationFactor: 3,
-		IPFSEnableEncryption:  true,
 		IPFSAPIURL:            "http://localhost:5001",
 	}
 

--- a/core/systemd/orama-namespace-caddy@.service
+++ b/core/systemd/orama-namespace-caddy@.service
@@ -25,7 +25,7 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -so /dev/null http://localhost:10104/health 2>/dev/null && exit 0; sleep 2; done; echo "Gateway not ready after 60s"; exit 1'
 ExecStartPre=/bin/sh -c 'DOMAIN=$(grep -oP "^\*\.\K[^ {]+" /etc/caddy/Caddyfile | tail -1); [ -z "$DOMAIN" ] && exit 0; for i in $(seq 1 30); do dig +short +timeout=2 "$DOMAIN" SOA 2>/dev/null | grep -q . && exit 0; sleep 2; done; echo "DNS not resolving $DOMAIN after 60s (ACME may fail)"; exit 0'
 TimeoutStartSec=180
-ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
 TimeoutStopSec=5s
 LimitNOFILE=1048576


### PR DESCRIPTION
## Summary

Implements CHG-224 (0.123.1 secret hygiene) on top of #105 (`feat-chg-208`). Permission, log, and string changes. No VERSION bump.

Merge order: **#101 → #102 → #103 → #104 → #105 → this**.

## What landed

| Bug | Commit | Change |
|---|---|---|
| **#225** | `dce25d8` | Cluster-secret mismatch error no longer prints either secret. |
| **#226** | `b4b8060` | Caddy `ExecStart` drops `--environ`. |
| **#227** | `1624433` | Fanout SSH keys on `/dev/shm`, overwrite then unlink; wipe errors logged. Not a WireGuard-mesh redesign. |
| **#228** | `6d6949c` | Drop dead `ipfs.io` backup URL. **Not** envelope-encrypting backups (needs key escrow). |
| **#229** | `863e50a` | Phantom API key nulled after first read; expiry applies to every status; migration 036. |
| **#230** | `81297a1` | Stop logging `enable_encryption` as live. Gateway field removed. |
| **#231** | `f8f1ee6` | `persistTURNSecret` and provisioner `chmod` secrets dir 0700. |

## Test plan

- [x] Focused package tests
- [x] Pre-push `go test ./...`
- [ ] Human review (Bugboard **review**, not done)