### PR TITLE
fix(systemd): CHG-232 RAM-to-disk hygiene

### DIFF
--- a/core/pkg/environments/production/firewall.go
+++ b/core/pkg/environments/production/firewall.go
@@ -156,6 +156,9 @@ func (fp *FirewallProvisioner) Setup() error {
 	if err := fp.persistIPv6Disable(); err != nil {
 		return fmt.Errorf("failed to persist IPv6 disable: %w", err)
 	}
+	if err := fp.persistRAMHygiene(); err != nil {
+		return fmt.Errorf("failed to persist RAM hygiene: %w", err)
+	}
 
 	return nil
 }
@@ -167,6 +170,32 @@ func (fp *FirewallProvisioner) persistIPv6Disable() error {
 	cmd.Stdin = strings.NewReader(content)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write sysctl config: %w\n%s", err, string(output))
+	}
+	return nil
+}
+
+// persistRAMHygiene turns off swap, disables suid core dumps, and stops
+// systemd-coredump from writing crash images to disk (bugboard #233).
+func (fp *FirewallProvisioner) persistRAMHygiene() error {
+	_ = exec.Command("swapoff", "-a").Run()
+	_ = exec.Command("systemctl", "mask", "swap.target").Run()
+
+	sysctl := "# Orama: keep secret-bearing pages off the block device\nfs.suid_dumpable = 0\n"
+	cmd := exec.Command("tee", "/etc/sysctl.d/99-orama-ram-hygiene.conf")
+	cmd.Stdin = strings.NewReader(sysctl)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write ram-hygiene sysctl: %w\n%s", err, string(output))
+	}
+	_ = exec.Command("sysctl", "--system").Run()
+
+	if err := exec.Command("mkdir", "-p", "/etc/systemd/coredump.conf.d").Run(); err != nil {
+		return fmt.Errorf("mkdir coredump.conf.d: %w", err)
+	}
+	coredump := "[Coredump]\nStorage=none\nProcessSizeMax=0\n"
+	cmd = exec.Command("tee", "/etc/systemd/coredump.conf.d/orama.conf")
+	cmd.Stdin = strings.NewReader(coredump)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write coredump.conf: %w\n%s", err, string(output))
 	}
 	return nil
 }

--- a/core/pkg/environments/production/services.go
+++ b/core/pkg/environments/production/services.go
@@ -74,6 +74,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=4G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -177,6 +178,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -260,6 +262,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=4G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -297,6 +300,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=8G
+MemorySwapMax=0
 OOMScoreAdjust=-500
 
 [Install]
@@ -340,6 +344,7 @@ SyslogIdentifier=orama-vault
 PrivateTmp=yes
 LimitMEMLOCK=67108864
 MemoryMax=512M
+MemorySwapMax=0
 TimeoutStopSec=30
 KillMode=mixed
 
@@ -374,6 +379,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=4G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -406,6 +412,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -436,6 +443,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
@@ -472,6 +480,7 @@ RestartSec=5
 SyslogIdentifier=caddy
 KillMode=mixed
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-anyone-client@.service
+++ b/core/systemd/orama-namespace-anyone-client@.service
@@ -21,6 +21,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-caddy@.service
+++ b/core/systemd/orama-namespace-caddy@.service
@@ -36,6 +36,7 @@ RestartSec=5
 SyslogIdentifier=orama-caddy-%i
 KillMode=mixed
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-coredns@.service
+++ b/core/systemd/orama-namespace-coredns@.service
@@ -30,6 +30,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-gateway@.service
+++ b/core/systemd/orama-namespace-gateway@.service
@@ -28,6 +28,7 @@ SyslogIdentifier=orama-gateway-%i
 PrivateTmp=yes
 LimitNOFILE=65536
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-ipfs-cluster@.service
+++ b/core/systemd/orama-namespace-ipfs-cluster@.service
@@ -34,6 +34,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-ipfs@.service
+++ b/core/systemd/orama-namespace-ipfs@.service
@@ -31,6 +31,7 @@ LimitNOFILE=65536
 TimeoutStopSec=30
 KillMode=mixed
 MemoryMax=4G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-ntfy@.service
+++ b/core/systemd/orama-namespace-ntfy@.service
@@ -28,6 +28,7 @@ LockPersonality=true
 MemoryDenyWriteExecute=true
 SystemCallArchitectures=native
 LimitNOFILE=65536
+MemorySwapMax=0
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=orama-ntfy-%i

--- a/core/systemd/orama-namespace-olric@.service
+++ b/core/systemd/orama-namespace-olric@.service
@@ -28,6 +28,7 @@ SyslogIdentifier=orama-olric-%i
 PrivateTmp=yes
 LimitNOFILE=65536
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-pubsub@.service
+++ b/core/systemd/orama-namespace-pubsub@.service
@@ -19,6 +19,7 @@ StandardError=journal
 SyslogIdentifier=orama-pubsub-%i
 PrivateTmp=yes
 LimitNOFILE=65536
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-rqlite@.service
+++ b/core/systemd/orama-namespace-rqlite@.service
@@ -40,6 +40,7 @@ SyslogIdentifier=orama-rqlite-%i
 PrivateTmp=yes
 LimitNOFILE=65536
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-sfu@.service
+++ b/core/systemd/orama-namespace-sfu@.service
@@ -27,6 +27,7 @@ SyslogIdentifier=orama-sfu-%i
 PrivateTmp=yes
 LimitNOFILE=65536
 MemoryMax=2G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-sni-router@.service
+++ b/core/systemd/orama-namespace-sni-router@.service
@@ -22,6 +22,7 @@ ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
 LimitNOFILE=65536
+MemorySwapMax=0
 
 TimeoutStopSec=15s
 KillMode=mixed

--- a/core/systemd/orama-namespace-turn@.service
+++ b/core/systemd/orama-namespace-turn@.service
@@ -26,6 +26,7 @@ SyslogIdentifier=orama-turn-%i
 PrivateTmp=yes
 LimitNOFILE=65536
 MemoryMax=1G
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/core/systemd/orama-namespace-vault@.service
+++ b/core/systemd/orama-namespace-vault@.service
@@ -27,6 +27,7 @@ SyslogIdentifier=orama-vault-%i
 PrivateTmp=yes
 LimitMEMLOCK=67108864
 MemoryMax=512M
+MemorySwapMax=0
 TimeoutStopSec=30
 KillMode=mixed
 

--- a/core/systemd/orama-sni-router.service
+++ b/core/systemd/orama-sni-router.service
@@ -22,6 +22,7 @@ ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
 LimitNOFILE=65536
+MemorySwapMax=0
 
 TimeoutStopSec=15s
 KillMode=mixed

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -149,6 +149,12 @@ Note: CLONE_NEWPID is intentionally omitted — it makes services PID 1 in their
 - All commands are logged and auditable
 - No root access, no console access, no file system access
 
+## RAM-to-disk (swap and cores)
+
+Guest `mlock`/`mlockall` is **not** used in the Go services. `mlock(2)` does not survive `execve`, so a launcher that locks then execs `rqlited`/`caddy`/`olric-server` gives those binaries zero locked pages. Go `string` values are also unzeroable. Against a hosting-provider RAM snapshot, mlock buys nothing.
+
+The control that keeps secrets off the **block device** is cgroup `MemorySwapMax=0` on secret-bearing units, plus install-time `swapoff` / `fs.suid_dumpable=0` / systemd-coredump `Storage=none`. That does **not** stop a RAM snapshot or provider VM-suspend.
+
 ## What this does not defend against today
 
 Stated so the gaps above are known positions, not implied protections:


### PR DESCRIPTION
## Summary

CHG-232 (0.123.2) on top of #106. systemd/sysctl only. No Go mlock.

Merge order: **#101 → #102 → #103 → #104 → #105 → #106 → this**.

## What landed

| Bug | Change |
|---|---|
| **#233** | `MemorySwapMax=0` on secret-bearing units. Install: `swapoff -a`, mask `swap.target`, `fs.suid_dumpable=0`, systemd-coredump `Storage=none`. |
| **#234** | Documented: do **not** add Go mlock (does not survive execve; does not beat RAM snapshot). |

Does not stop a RAM snapshot or provider VM-suspend.

## Test plan

- [x] `go test ./pkg/environments/production/ ./pkg/systemd/`
- [x] Pre-push full suite
- [ ] Human review