### PR TITLE
fix: CHG-235 data minimization and retention

### DIFF
--- a/core/pkg/cli/production/clean/clean.go
+++ b/core/pkg/cli/production/clean/clean.go
@@ -115,7 +115,8 @@ func execute(flags *Flags) error {
 	}
 
 	fmt.Printf("✓ Clean complete (%d nodes)\n", len(nodes))
-	fmt.Printf("  Anyone relay keys preserved at /var/lib/anon/\n")
+	fmt.Printf("  Anyone relay keys preserved at /var/lib/anon/ (not erased; DESTROY_ANON=1 to remove)\n")
+	fmt.Printf("  rm -rf is unlink, not cryptographic erase. Decommissioned provider disks remain readable.\n")
 	fmt.Printf("  To reinstall: orama node install --vps-ip <ip> ...\n")
 	return nil
 }
@@ -162,6 +163,10 @@ ufw --force enable 2>/dev/null || true
 
 # Remove data
 rm -rf /opt/orama
+rm -rf /var/lib/ntfy /run/ntfy
+rm -rf /var/log/journal
+rm -rf /etc/anon
+swapoff -a 2>/dev/null || true
 
 # Clean configs
 rm -rf /etc/coredns
@@ -177,8 +182,11 @@ if [ -n "$NUCLEAR" ]; then
     rm -f /usr/bin/caddy
 fi
 
-# Verify Anyone keys preserved
-if [ -d /var/lib/anon ]; then
+# Anyone identity: preserved unless DESTROY_ANON=1
+if [ -n "$DESTROY_ANON" ]; then
+    rm -rf /var/lib/anon
+    echo "  Anyone relay keys destroyed"
+elif [ -d /var/lib/anon ]; then
     echo "  Anyone relay keys preserved at /var/lib/anon/"
 fi
 

--- a/core/pkg/environments/production/installers/ntfy.go
+++ b/core/pkg/environments/production/installers/ntfy.go
@@ -415,8 +415,8 @@ behind-proxy: true
 # per-instance, so a client recovering missed messages across the round-robin
 # fan-out must use since=<unix-timestamp>/<duration>, NOT since=<message-id>
 # (IDs differ between nodes). Each node's cache holds every fanned-out message.
-cache-file: "%s/cache.db"
-cache-duration: "12h"
+cache-file: "/run/ntfy/cache.db"
+cache-duration: "15m"
 
 # Keepalive (bugboard #858): ntfy's 45s default is too long for aggressive
 # carrier/mobile NATs, which silently drop idle long-lived /json streams — the
@@ -445,5 +445,5 @@ web-root: "disable"
 # Logs to stdout so systemd-journald captures them.
 log-level: "info"
 log-format: "json"
-`, publicBaseURL, NtfyListenPort, NtfyListenPort, ntfyDataDir)
+`, publicBaseURL, NtfyListenPort, NtfyListenPort)
 }

--- a/core/pkg/gateway/request_log_batcher.go
+++ b/core/pkg/gateway/request_log_batcher.go
@@ -161,6 +161,10 @@ func (b *requestLogBatcher) flush() {
 		if _, err := db.Query(client.WithInternalAuth(ctx), sb.String(), args...); err != nil && b.gw.logger != nil {
 			b.gw.logger.ComponentWarn(logging.ComponentGeneral, "failed to flush request logs", zap.Error(err))
 		}
+		if _, err := db.Query(client.WithInternalAuth(ctx),
+			"DELETE FROM request_logs WHERE created_at < datetime('now', '-7 days')"); err != nil && b.gw.logger != nil {
+			b.gw.logger.ComponentWarn(logging.ComponentGeneral, "failed to prune request_logs", zap.Error(err))
+		}
 	}
 
 	// Batch UPDATE last_used_at for all API keys seen in this batch

--- a/core/pkg/rqlite/backup.go
+++ b/core/pkg/rqlite/backup.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultBackupInterval = 1 * time.Hour
-	maxBackupRetention    = 24
+	maxBackupRetention    = 3
 	backupDirName         = "backups/rqlite"
 	backupPrefix          = "rqlite-backup-"
 	backupSuffix          = ".db"
@@ -69,12 +69,13 @@ func (r *RQLiteManager) performBackup() {
 	}
 
 	backupDir := r.backupDir()
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
+	if err := os.MkdirAll(backupDir, 0700); err != nil {
 		r.logger.Error("Failed to create backup directory",
 			zap.String("dir", backupDir),
 			zap.Error(err))
 		return
 	}
+	_ = os.Chmod(backupDir, 0700)
 
 	timestamp := time.Now().UTC().Format(backupTimestampFormat)
 	filename := fmt.Sprintf("%s%s%s", backupPrefix, timestamp, backupSuffix)
@@ -135,7 +136,7 @@ func (r *RQLiteManager) downloadBackup(destPath string) error {
 		return fmt.Errorf("backup endpoint returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	outFile, err := os.Create(destPath)
+	outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("create backup file: %w", err)
 	}
@@ -184,6 +185,10 @@ func (r *RQLiteManager) pruneOldBackups(backupDir string) {
 	toDelete := backupFiles[:len(backupFiles)-maxBackupRetention]
 	for _, entry := range toDelete {
 		path := filepath.Join(backupDir, entry.Name())
+		if f, err := os.OpenFile(path, os.O_WRONLY, 0); err == nil {
+			_, _ = f.Write(make([]byte, 64*1024))
+			_ = f.Close()
+		}
 		if err := os.Remove(path); err != nil {
 			r.logger.Warn("Failed to delete old backup",
 				zap.String("path", path),

--- a/core/systemd/orama-namespace-ntfy@.service
+++ b/core/systemd/orama-namespace-ntfy@.service
@@ -19,6 +19,7 @@ ProtectHome=true
 PrivateTmp=true
 PrivateDevices=true
 ReadWritePaths=/var/lib/ntfy
+RuntimeDirectory=ntfy
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/docs/CLEAN_NODE.md
+++ b/docs/CLEAN_NODE.md
@@ -46,6 +46,12 @@ sudo ufw --force enable
 
 # 5. Remove orama data directory
 sudo rm -rf /opt/orama
+sudo rm -rf /var/lib/ntfy /run/ntfy
+sudo rm -rf /etc/anon
+# /var/lib/anon (Anyone identity) is preserved unless you also:
+#   sudo rm -rf /var/lib/anon
+sudo swapoff -a 2>/dev/null || true
+# rm -rf is unlink, not cryptographic erase. Assume decommissioned provider disks are readable.
 
 # 6. Remove orama system user (created by every install; services run as it,
 #    so services must be stopped first or userdel fails with "user in use")

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -166,6 +166,7 @@ Stated so the gaps above are known positions, not implied protections:
 - **RQLite HTTP auth** — `rqlited -auth` is not enabled; overlay + firewall are the control
 - **ntfy** — no auth-file in v1; listen-localhost is the control
 - **A captured disk snapshot of RQLite** — plaintext application data, including `deployment_env_vars`
+- **Immediate erase of deleted rows** — a SQL `DELETE` is a Raft log entry; the original INSERT remains in `raft.db` until size-driven compaction, not a privacy TTL
 
 ## Rollout Strategy
 


### PR DESCRIPTION
## Summary

CHG-235 on top of #107. Retention and clean-path changes. Not a VERSION bump.

Merge order: **#101 → #102 → #103 → #104 → #105 → #106 → #107 → this**.

## What landed

| Bug | Change |
|---|---|
| **#236** | Keep 3 RQLite backups, 0700/0600, overwrite before unlink. **Not** age-encrypted (needs escrow). |
| **#237** | Delete `request_logs` older than 7 days on flush. Documented that DELETE is not Raft erase. No IP HMAC. |
| **#238** | Clean also ntfy, journal, `/etc/anon`, swapoff. `rm` is not erase. Anyone keys preserved unless `DESTROY_ANON=1`. |
| **#239** | ntfy cache 15m on tmpfs `/run/ntfy`. **No auth-file** (would break push without per-topic ACLs). |

## Test plan

- [x] Focused tests + pre-push `go test ./...`
- [ ] Human review