### PR TITLE
fix: CHG-202 gateway authz and tenant isolation

### DIFF
--- a/core/pkg/environments/production/installers/ipfs_cluster.go
+++ b/core/pkg/environments/production/installers/ipfs_cluster.go
@@ -66,6 +66,9 @@ func (ici *IPFSClusterInstaller) Configure() error {
 // For existing installations, it ensures the cluster secret is up to date.
 // clusterPeers should be in format: ["/ip4/<ip>/tcp/9100/p2p/<cluster-peer-id>"]
 func (ici *IPFSClusterInstaller) InitializeConfig(clusterPath, clusterSecret string, ipfsAPIPort int, clusterPeers []string) error {
+	if strings.TrimSpace(clusterSecret) == "" {
+		return fmt.Errorf("CLUSTER_SECRET is empty; refusing to initialize IPFS Cluster")
+	}
 	serviceJSONPath := filepath.Join(clusterPath, "service.json")
 	configExists := false
 	if _, err := os.Stat(serviceJSONPath); err == nil {
@@ -91,31 +94,21 @@ func (ici *IPFSClusterInstaller) InitializeConfig(clusterPath, clusterSecret str
 		// This creates the service.json file with all required sections
 		fmt.Fprintf(ici.logWriter, "    Initializing IPFS Cluster config...\n")
 		cmd := exec.Command(clusterBinary, "init", "--force")
-		cmd.Env = append(os.Environ(), "IPFS_CLUSTER_PATH="+clusterPath)
-		// Pass CLUSTER_SECRET to init so it writes the correct secret to service.json directly
-		if clusterSecret != "" {
-			cmd.Env = append(cmd.Env, "CLUSTER_SECRET="+clusterSecret)
-		}
+		cmd.Env = append(os.Environ(), "IPFS_CLUSTER_PATH="+clusterPath, "CLUSTER_SECRET="+clusterSecret)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("failed to initialize IPFS Cluster config: %v\n%s", err, string(output))
 		}
 	}
 
-	// Always update the cluster secret, IPFS port, and peer addresses (for both new and existing configs)
-	// This ensures existing installations get the secret and port synchronized
-	// We do this AFTER init to ensure our secret takes precedence
-	if clusterSecret != "" {
-		fmt.Fprintf(ici.logWriter, "    Updating cluster secret, IPFS port, and peer addresses...\n")
-		if err := ici.updateConfig(clusterPath, clusterSecret, ipfsAPIPort, clusterPeers); err != nil {
-			return fmt.Errorf("failed to update cluster config: %w", err)
-		}
-
-		// Verify the secret was written correctly
-		if err := ici.verifySecret(clusterPath, clusterSecret); err != nil {
-			return fmt.Errorf("cluster secret verification failed: %w", err)
-		}
-		fmt.Fprintf(ici.logWriter, "    ✓ Cluster secret verified\n")
+	fmt.Fprintf(ici.logWriter, "    Updating cluster secret, IPFS port, and peer addresses...\n")
+	if err := ici.updateConfig(clusterPath, clusterSecret, ipfsAPIPort, clusterPeers); err != nil {
+		return fmt.Errorf("failed to update cluster config: %w", err)
 	}
+
+	if err := ici.verifySecret(clusterPath, clusterSecret); err != nil {
+		return fmt.Errorf("cluster secret verification failed: %w", err)
+	}
+	fmt.Fprintf(ici.logWriter, "    ✓ Cluster secret verified\n")
 
 	return nil
 }

--- a/core/pkg/environments/production/orchestrator.go
+++ b/core/pkg/environments/production/orchestrator.go
@@ -752,7 +752,10 @@ func (ps *ProductionSetup) Phase5CreateSystemdServices(enableHTTPS bool) error {
 	ps.logf("  ✓ IPFS GC service + timer created: orama-ipfs-gc.{service,timer}")
 
 	// IPFS Cluster service
-	clusterUnit := ps.serviceGenerator.GenerateIPFSClusterService(clusterBinary)
+	clusterUnit, err := ps.serviceGenerator.GenerateIPFSClusterService(clusterBinary)
+	if err != nil {
+		return fmt.Errorf("failed to generate IPFS Cluster service: %w", err)
+	}
 	if err := ps.serviceController.WriteServiceUnit("orama-ipfs-cluster.service", clusterUnit); err != nil {
 		return fmt.Errorf("failed to write IPFS Cluster service: %w", err)
 	}

--- a/core/pkg/environments/production/services.go
+++ b/core/pkg/environments/production/services.go
@@ -138,16 +138,20 @@ WantedBy=timers.target
 `, ipfsGCOnBootSec, ipfsGCInterval, ipfsGCRandomizedDelaySec)
 }
 
-// GenerateIPFSClusterService generates the IPFS Cluster systemd unit
-func (ssg *SystemdServiceGenerator) GenerateIPFSClusterService(clusterBinary string) string {
+// GenerateIPFSClusterService generates the IPFS Cluster systemd unit.
+// Refuses to emit a unit with an empty CLUSTER_SECRET (bugboard #109).
+func (ssg *SystemdServiceGenerator) GenerateIPFSClusterService(clusterBinary string) (string, error) {
 	clusterPath := filepath.Join(ssg.oramaDir, "data", "ipfs-cluster")
 	logFile := filepath.Join(ssg.oramaDir, "logs", "ipfs-cluster.log")
 
-	// Read cluster secret from file to pass to daemon
 	clusterSecretPath := filepath.Join(ssg.oramaDir, "secrets", "cluster-secret")
-	clusterSecret := ""
-	if data, err := os.ReadFile(clusterSecretPath); err == nil {
-		clusterSecret = strings.TrimSpace(string(data))
+	data, err := os.ReadFile(clusterSecretPath)
+	if err != nil {
+		return "", fmt.Errorf("read cluster-secret: %w", err)
+	}
+	clusterSecret := strings.TrimSpace(string(data))
+	if clusterSecret == "" {
+		return "", fmt.Errorf("cluster-secret is empty; refusing to start IPFS Cluster without CLUSTER_SECRET")
 	}
 
 	return fmt.Sprintf(`[Unit]
@@ -182,7 +186,7 @@ MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target
-`, ssg.oramaHome, clusterPath, logFile, clusterBinary, clusterSecret, oramaServiceHardening, ssg.oramaDir)
+`, ssg.oramaHome, clusterPath, logFile, clusterBinary, clusterSecret, oramaServiceHardening, ssg.oramaDir), nil
 }
 
 // GenerateRQLiteService generates the RQLite systemd unit

--- a/core/pkg/environments/production/services_cluster_secret_test.go
+++ b/core/pkg/environments/production/services_cluster_secret_test.go
@@ -1,0 +1,35 @@
+package production
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateIPFSClusterService_emptySecret(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "secrets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ssg := NewSystemdServiceGenerator("/opt/orama", dir)
+	if _, err := ssg.GenerateIPFSClusterService("/usr/bin/ipfs-cluster-service"); err == nil {
+		t.Fatal("missing cluster-secret must fail closed")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secrets", "cluster-secret"), []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ssg.GenerateIPFSClusterService("/usr/bin/ipfs-cluster-service"); err == nil {
+		t.Fatal("empty cluster-secret must fail closed")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secrets", "cluster-secret"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unit, err := ssg.GenerateIPFSClusterService("/usr/bin/ipfs-cluster-service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(unit, "Environment=CLUSTER_SECRET=deadbeef") {
+		t.Fatalf("unit missing CLUSTER_SECRET: %s", unit)
+	}
+}

--- a/core/pkg/gateway/handlers/serverless/handlers_test.go
+++ b/core/pkg/gateway/handlers/serverless/handlers_test.go
@@ -898,3 +898,33 @@ func TestGetCallerIsAdminFromRequest(t *testing.T) {
 		t.Error("no identity must not resolve to admin")
 	}
 }
+
+func TestGetCallerHasInvokeFromRequest(t *testing.T) {
+	h := newTestHandlers(nil)
+	withCtx := func(k, v any) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/v1/invoke/ns/fn", nil)
+		return r.WithContext(context.WithValue(r.Context(), k, v))
+	}
+
+	if !h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.Scopes, auth.ScopeSet{auth.ScopeInvoke: {}})) {
+		t.Error("invoke scope must resolve to hasInvoke")
+	}
+	if h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.Scopes, auth.ScopeSet{auth.ScopeStorage: {}})) {
+		t.Error("storage-only key must not resolve to hasInvoke")
+	}
+	if !h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.Scopes, auth.ScopeSet{auth.ScopeAdmin: {}})) {
+		t.Error("admin must resolve to hasInvoke")
+	}
+	if !h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.JWT, &auth.JWTClaims{Sub: "0xWALLET"})) {
+		t.Error("SIWE wallet JWT must resolve to hasInvoke")
+	}
+	if h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.JWT, &auth.JWTClaims{Sub: "ak_x:ns", Custom: map[string]string{"scopes": "storage"}})) {
+		t.Error("exchanged storage-only key must not resolve to hasInvoke")
+	}
+	if !h.getCallerHasInvokeFromRequest(withCtx(ctxkeys.JWT, &auth.JWTClaims{Sub: "ak_x:ns", Custom: map[string]string{"scopes": "invoke"}})) {
+		t.Error("exchanged invoke key must resolve to hasInvoke")
+	}
+	if h.getCallerHasInvokeFromRequest(httptest.NewRequest(http.MethodPost, "/v1/invoke/ns/fn", nil)) {
+		t.Error("anonymous must not resolve to hasInvoke")
+	}
+}

--- a/core/pkg/gateway/handlers/serverless/invoke_handler.go
+++ b/core/pkg/gateway/handlers/serverless/invoke_handler.go
@@ -106,6 +106,7 @@ func (h *ServerlessHandlers) InvokeFunction(w http.ResponseWriter, r *http.Reque
 		TriggerType:      serverless.TriggerTypeHTTP,
 		CallerWallet:     callerWallet,
 		CallerIsAdmin:    h.getCallerIsAdminFromRequest(r),
+		CallerHasInvoke:  h.getCallerHasInvokeFromRequest(r),
 		CallerIP:         extractRemoteIP(r),
 		CallerClaims:     h.getCallerClaimsFromRequest(r),
 		CallerJWTSubject: h.getJWTSubjectFromRequest(r),

--- a/core/pkg/gateway/handlers/serverless/types.go
+++ b/core/pkg/gateway/handlers/serverless/types.go
@@ -175,19 +175,43 @@ func (h *ServerlessHandlers) getJWTExpiryFromRequest(r *http.Request) int64 {
 	return claims.Exp
 }
 
-// getCallerIsAdminFromRequest reports whether the request's resolved scope
-// set holds the admin (control-plane) grant — the signal that gates invoking
-// an `internal: true` function (bugboard #152). It reads the same two sources
-// the gateway's scope policy trusts:
+// getCallerHasInvokeFromRequest reports whether the caller may invoke a
+// private function (bugboard #259). HTTP /invoke is a public path, so
+// scopeMiddleware never runs; this is the grant check.
 //
-//   - ctxkeys.Scopes: the auth.ScopeSet stashed by the auth middleware for an
-//     API-key (or API-key-exchanged JWT) request. Admin keys carry ScopeAdmin.
-//   - ctxkeys.OwnerConfirmed: set when a SIWE wallet JWT was verified to own
-//     the target namespace. A confirmed owner is admin for their namespace
-//     (mirrors Gateway.callerScopes, which returns {admin} in that case).
-//
-// A normal app-runtime key (data-plane scopes, no owner confirmation) is NOT
-// admin, so it cannot invoke an internal function by name.
+// True for: admin, an API key (or exchanged JWT) that holds ScopeInvoke,
+// or a SIWE wallet JWT (non-ak_ subject). Storage-only API keys are false.
+func (h *ServerlessHandlers) getCallerHasInvokeFromRequest(r *http.Request) bool {
+	if h.getCallerIsAdminFromRequest(r) {
+		return true
+	}
+	ctx := r.Context()
+	if v := ctx.Value(ctxkeys.Scopes); v != nil {
+		if s, ok := v.(auth.ScopeSet); ok && s.Has(auth.ScopeInvoke) {
+			return true
+		}
+	}
+	if v := ctx.Value(ctxkeys.JWT); v != nil {
+		if claims, ok := v.(*auth.JWTClaims); ok && claims != nil {
+			sub := strings.ToLower(strings.TrimSpace(claims.Sub))
+			if strings.HasPrefix(sub, "ak_") {
+				if claims.Custom != nil {
+					if raw := strings.TrimSpace(claims.Custom["scopes"]); raw != "" && auth.ParseScopes(raw).Has(auth.ScopeInvoke) {
+						return true
+					}
+				}
+				return false
+			}
+			if sub != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getCallerIsAdminFromRequest reports whether the request holds the admin
+// grant used to invoke `internal: true` functions (bugboard #152).
 func (h *ServerlessHandlers) getCallerIsAdminFromRequest(r *http.Request) bool {
 	ctx := r.Context()
 	if v := ctx.Value(ctxkeys.Scopes); v != nil {

--- a/core/pkg/gateway/handlers/serverless/ws_handler.go
+++ b/core/pkg/gateway/handlers/serverless/ws_handler.go
@@ -149,6 +149,7 @@ func (h *ServerlessHandlers) HandleWebSocket(w http.ResponseWriter, r *http.Requ
 
 	callerWallet := h.getWalletFromRequest(r)
 	callerIsAdmin := h.getCallerIsAdminFromRequest(r)
+	callerHasInvoke := h.getCallerHasInvokeFromRequest(r)
 	callerIP := extractRemoteIP(r)
 	// Capture custom claims at upgrade time and reuse for every frame —
 	// the JWT context is request-scoped and won't survive past upgrade.
@@ -177,6 +178,7 @@ func (h *ServerlessHandlers) HandleWebSocket(w http.ResponseWriter, r *http.Requ
 			TriggerType:      serverless.TriggerTypeWebSocket,
 			CallerWallet:     callerWallet,
 			CallerIsAdmin:    callerIsAdmin,
+			CallerHasInvoke:  callerHasInvoke,
 			CallerIP:         callerIP,
 			CallerClaims:     callerClaims,
 			CallerJWTSubject: callerJWTSubject,

--- a/core/pkg/gateway/handlers/sqlite/query_handler.go
+++ b/core/pkg/gateway/handlers/sqlite/query_handler.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -21,11 +20,11 @@ type QueryRequest struct {
 
 // QueryResponse represents a SQL query response
 type QueryResponse struct {
-	Columns []string        `json:"columns,omitempty"`
-	Rows    [][]interface{} `json:"rows,omitempty"`
-	RowsAffected int64       `json:"rows_affected,omitempty"`
-	LastInsertID int64       `json:"last_insert_id,omitempty"`
-	Error        string      `json:"error,omitempty"`
+	Columns      []string        `json:"columns,omitempty"`
+	Rows         [][]interface{} `json:"rows,omitempty"`
+	RowsAffected int64           `json:"rows_affected,omitempty"`
+	LastInsertID int64           `json:"last_insert_id,omitempty"`
+	Error        string          `json:"error,omitempty"`
 }
 
 // writeJSONError writes an error response as JSON for consistency
@@ -95,8 +94,12 @@ func (h *SQLiteHandler) QueryDatabase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Open database
-	db, err := sql.Open("sqlite3", filePath)
+	if err := rejectCrossDBSQL(req.Query); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	db, err := openTenantDB(filePath)
 	if err != nil {
 		h.logger.Error("Failed to open database", zap.Error(err))
 		writeJSONError(w, http.StatusInternalServerError, "Failed to open database")
@@ -191,7 +194,7 @@ func (h *SQLiteHandler) QueryDatabase(w http.ResponseWriter, r *http.Request) {
 func isWriteQuery(query string) bool {
 	upperQuery := strings.ToUpper(strings.TrimSpace(query))
 	writeKeywords := []string{
-		"INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "TRUNCATE", "REPLACE",
+		"INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "TRUNCATE", "REPLACE", "ATTACH", "DETACH",
 	}
 
 	for _, keyword := range writeKeywords {

--- a/core/pkg/gateway/handlers/sqlite/tenant_open.go
+++ b/core/pkg/gateway/handlers/sqlite/tenant_open.go
@@ -1,0 +1,54 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+const tenantDriver = "sqlite3_tenant_noattach"
+
+var tenantDriverOnce sync.Once
+
+var attachWord = regexp.MustCompile(`(?i)\b(ATTACH|DETACH)\b`)
+var sqlStringLit = regexp.MustCompile(`'([^']|'')*'|"([^"]|"")*"`)
+
+func registerTenantDriver() {
+	tenantDriverOnce.Do(func() {
+		sql.Register(tenantDriver, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				conn.SetLimit(sqlite3.SQLITE_LIMIT_ATTACHED, 0)
+				return nil
+			},
+		})
+	})
+}
+
+func openTenantDB(path string) (*sql.DB, error) {
+	registerTenantDriver()
+	return sql.Open(tenantDriver, path)
+}
+
+// rejectCrossDBSQL blocks ATTACH/DETACH and extra statements. Tenant SQL is
+// allowed against one file; multi-statement + ATTACH is the cross-namespace
+// escape (bugboard #252).
+func rejectCrossDBSQL(query string) error {
+	trimmed := strings.TrimSpace(query)
+	for strings.HasSuffix(trimmed, ";") {
+		trimmed = strings.TrimSpace(trimmed[:len(trimmed)-1])
+	}
+	if trimmed == "" {
+		return fmt.Errorf("empty query")
+	}
+	if strings.Contains(trimmed, ";") {
+		return fmt.Errorf("multiple SQL statements are not allowed")
+	}
+	if attachWord.MatchString(sqlStringLit.ReplaceAllString(trimmed, " ")) {
+		return fmt.Errorf("ATTACH/DETACH is not allowed")
+	}
+	return nil
+}

--- a/core/pkg/gateway/handlers/sqlite/tenant_open_test.go
+++ b/core/pkg/gateway/handlers/sqlite/tenant_open_test.go
@@ -1,0 +1,53 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRejectCrossDBSQL(t *testing.T) {
+	denied := []string{
+		"ATTACH DATABASE '/tmp/other.db' AS other",
+		"attach database 'x' as y",
+		"DETACH other",
+		"SELECT 1; SELECT 2",
+		"SELECT 1; ATTACH DATABASE 'x' AS y",
+		"",
+		"   ",
+		";",
+	}
+	for _, q := range denied {
+		if err := rejectCrossDBSQL(q); err == nil {
+			t.Errorf("rejectCrossDBSQL(%q) = nil, want error", q)
+		}
+	}
+	allowed := []string{
+		"SELECT * FROM users",
+		"INSERT INTO t (a) VALUES (1)",
+		"UPDATE t SET a = 1 WHERE id = 2",
+		"SELECT 'attach' AS label",
+		"SELECT * FROM t;",
+	}
+	for _, q := range allowed {
+		if err := rejectCrossDBSQL(q); err != nil {
+			t.Errorf("rejectCrossDBSQL(%q) = %v, want nil", q, err)
+		}
+	}
+}
+
+func TestOpenTenantDB_attachDenied(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tenant.db")
+	db, err := openTenantDB(path)
+	if err != nil {
+		t.Fatalf("openTenantDB: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("CREATE TABLE t (id INTEGER)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	other := filepath.Join(dir, "other.db")
+	if _, err := db.Exec("ATTACH DATABASE ? AS other", other); err == nil {
+		t.Fatal("ATTACH must fail when SQLITE_LIMIT_ATTACHED=0")
+	}
+}

--- a/core/pkg/gateway/scope_policy.go
+++ b/core/pkg/gateway/scope_policy.go
@@ -86,6 +86,20 @@ func requiredScope(method, path string) string {
 		return auth.ScopeCache
 	}
 
+	// Cluster node command/logs/leave/status: operator only (bugboard #54/#55).
+	// Enroll authenticates via invite token inside the handler, not an API-key
+	// admin grant (the CLI sends Bearer <invite>).
+	if strings.HasPrefix(path, "/v1/node/") {
+		if path == "/v1/node/enroll" {
+			return ""
+		}
+		return auth.ScopeAdmin
+	}
+	// Topology mutation: operator only (bugboard #56). Status/peers stay public.
+	if path == "/v1/network/connect" || path == "/v1/network/disconnect" {
+		return auth.ScopeAdmin
+	}
+
 	// --- Control-plane (admin only) ---
 	if path == "/rqlite" || path == "/v1/rqlite" || strings.HasPrefix(path, "/v1/rqlite/") {
 		return auth.ScopeAdmin

--- a/core/pkg/gateway/scope_policy_test.go
+++ b/core/pkg/gateway/scope_policy_test.go
@@ -18,8 +18,8 @@ func TestRequiredScope(t *testing.T) {
 		{"/health", ""},
 		{"/v1/invoke/ns/fn", ""},
 		{"/v1/functions/fn/invoke", ""},
-		{"/v1/auth/token", ""},   // not public, but any key may exchange
-		{"/v1/auth/whoami", ""},  // any valid credential
+		{"/v1/auth/token", ""},  // not public, but any key may exchange
+		{"/v1/auth/whoami", ""}, // any valid credential
 		// invoke transport
 		{"/v1/functions/fn/ws", auth.ScopeInvoke},
 		// functions control-plane
@@ -54,6 +54,15 @@ func TestRequiredScope(t *testing.T) {
 		{"/v1/namespace/rate-limit", auth.ScopeAdmin},
 		{"/v1/namespace/keys", auth.ScopeAdmin},
 		{"/v1/namespace/keys/5", auth.ScopeAdmin},
+		{"/v1/node/status", auth.ScopeAdmin},
+		{"/v1/node/command", auth.ScopeAdmin},
+		{"/v1/node/logs", auth.ScopeAdmin},
+		{"/v1/node/leave", auth.ScopeAdmin},
+		{"/v1/node/enroll", ""},
+		{"/v1/network/connect", auth.ScopeAdmin},
+		{"/v1/network/disconnect", auth.ScopeAdmin},
+		{"/v1/network/status", ""},
+		{"/v1/network/peers", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/core/pkg/serverless/engine.go
+++ b/core/pkg/serverless/engine.go
@@ -174,8 +174,13 @@ func NewEngine(cfg *Config, registry FunctionRegistry, hostServices HostServices
 	cfg.ApplyDefaults()
 
 	// Create wazero runtime with compilation cache
+	maxPages := uint32(cfg.MaxMemoryLimitMB * 16) // 1 MB = 16 WASM pages
+	if maxPages == 0 {
+		maxPages = 256 * 16
+	}
 	runtimeConfig := wazero.NewRuntimeConfig().
-		WithCloseOnContextDone(true)
+		WithCloseOnContextDone(true).
+		WithMemoryLimitPages(maxPages)
 
 	runtime := wazero.NewRuntimeWithConfig(context.Background(), runtimeConfig)
 
@@ -393,6 +398,7 @@ func (e *Engine) Execute(ctx context.Context, fn *Function, input []byte, invCtx
 	if moduleIsReactor(module) {
 		output, err = e.invokeReactor(execCtx, fn.WASMCID, fn.Name, input, instTiming)
 	} else {
+		execCtx = execution.WithNamespace(execCtx, fn.Namespace)
 		output, err = e.executor.ExecuteModule(execCtx, module, fn.Name, input, contextSetter, contextClearer)
 	}
 	executeDoneAt = time.Now()

--- a/core/pkg/serverless/execution/executor.go
+++ b/core/pkg/serverless/execution/executor.go
@@ -6,6 +6,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/tetratelabs/wazero"
@@ -36,25 +37,62 @@ func instantiateTimingFrom(ctx context.Context) *InstantiateTiming {
 	return t
 }
 
+type namespaceKey struct{}
+
+// WithNamespace tags an execution ctx so the limiter can cap one tenant
+// without letting it fill the process-wide semaphore (bugboard #85).
+func WithNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, namespaceKey{}, ns)
+}
+
+func namespaceFrom(ctx context.Context) string {
+	ns, _ := ctx.Value(namespaceKey{}).(string)
+	return ns
+}
+
 // Executor handles WASM module execution.
 type Executor struct {
 	runtime wazero.Runtime
 	logger  *zap.Logger
-	sem     chan struct{} // concurrency limiter
+	sem     chan struct{} // process-wide limiter
+	perNS   map[string]chan struct{}
+	perNSN  int
+	mu      sync.Mutex
 }
 
 // NewExecutor creates a new Executor.
 // maxConcurrent limits simultaneous module instantiations (0 = unlimited).
 func NewExecutor(runtime wazero.Runtime, logger *zap.Logger, maxConcurrent int) *Executor {
 	var sem chan struct{}
+	perNSN := 0
 	if maxConcurrent > 0 {
 		sem = make(chan struct{}, maxConcurrent)
+		perNSN = maxConcurrent / 2
+		if perNSN < 1 {
+			perNSN = 1
+		}
 	}
 	return &Executor{
 		runtime: runtime,
 		logger:  logger,
 		sem:     sem,
+		perNS:   make(map[string]chan struct{}),
+		perNSN:  perNSN,
 	}
+}
+
+func (e *Executor) nsSlot(ns string) chan struct{} {
+	if e.perNSN <= 0 || ns == "" {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ch := e.perNS[ns]
+	if ch == nil {
+		ch = make(chan struct{}, e.perNSN)
+		e.perNS[ns] = ch
+	}
+	return ch
 }
 
 // ExecuteModule instantiates and runs a WASM module with the given input.
@@ -115,13 +153,22 @@ func (e *Executor) ExecuteModule(ctx context.Context, compiled wazero.CompiledMo
 		// engine.go for the persistent-WS path.
 		WithRandSource(cryptorand.Reader)
 
-	// Acquire concurrency slot
 	if e.sem != nil {
 		select {
 		case e.sem <- struct{}{}:
 			defer func() { <-e.sem }()
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+	}
+	if ns := namespaceFrom(ctx); ns != "" {
+		if slot := e.nsSlot(ns); slot != nil {
+			select {
+			case slot <- struct{}{}:
+				defer func() { <-slot }()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 		}
 	}
 

--- a/core/pkg/serverless/hostfunctions/anyone_fetch_test.go
+++ b/core/pkg/serverless/hostfunctions/anyone_fetch_test.go
@@ -5,10 +5,29 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"go.uber.org/zap"
 )
+
+// publicURLClient wraps a httptest server so fetches use a public hostname
+// (denyInternalURL rejects loopback). The transport dials the test server.
+func publicURLClient(srv *httptest.Server) (*http.Client, string) {
+	publicURL := "https://example.com/fetch-test"
+	inner := srv.Client().Transport
+	return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		clone := req.Clone(req.Context())
+		u, _ := url.Parse(srv.URL)
+		clone.URL.Scheme = u.Scheme
+		clone.URL.Host = u.Host
+		return inner.RoundTrip(clone)
+	})}, publicURL
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // feat-11 — AnyoneFetch (Anyone-routed outbound HTTP for serverless fns).
 //
@@ -69,12 +88,13 @@ func TestAnyoneFetch_routesThroughConfiguredClient(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	client, publicURL := publicURLClient(srv)
 	h := &HostFunctions{
 		logger:           zap.NewNop(),
-		anyoneHTTPClient: srv.Client(), // stand-in for the SOCKS-routed client
+		anyoneHTTPClient: client, // stand-in for the SOCKS-routed client
 	}
 
-	raw, err := h.AnyoneFetch(context.Background(), "POST", srv.URL,
+	raw, err := h.AnyoneFetch(context.Background(), "POST", publicURL,
 		map[string]string{"Content-Type": "application/json"},
 		[]byte(`{"method":"getBalance"}`))
 	if err != nil {
@@ -102,14 +122,15 @@ func TestAnyoneFetch_andHTTPFetch_shareEnvelopeShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	client, publicURL := publicURLClient(srv)
 	h := &HostFunctions{
 		logger:           zap.NewNop(),
-		httpClient:       srv.Client(),
-		anyoneHTTPClient: srv.Client(),
+		httpClient:       client,
+		anyoneHTTPClient: client,
 	}
 
-	directRaw, _ := h.HTTPFetch(context.Background(), "GET", srv.URL, nil, nil)
-	anyoneRaw, _ := h.AnyoneFetch(context.Background(), "GET", srv.URL, nil, nil)
+	directRaw, _ := h.HTTPFetch(context.Background(), "GET", publicURL, nil, nil)
+	anyoneRaw, _ := h.AnyoneFetch(context.Background(), "GET", publicURL, nil, nil)
 
 	var d, a map[string]interface{}
 	_ = json.Unmarshal(directRaw, &d)
@@ -125,5 +146,24 @@ func TestAnyoneFetch_andHTTPFetch_shareEnvelopeShape(t *testing.T) {
 	}
 	if d["body"] != a["body"] || d["body"] != "hello" {
 		t.Errorf("bodies differ: direct=%v anyone=%v", d["body"], a["body"])
+	}
+}
+
+func TestHTTPFetch_deniesLoopback(t *testing.T) {
+	h := &HostFunctions{logger: zap.NewNop(), httpClient: http.DefaultClient}
+	raw, err := h.HTTPFetch(context.Background(), "GET", "http://127.0.0.1:10100/db/query", nil, nil)
+	if err != nil {
+		t.Fatalf("HTTPFetch: %v", err)
+	}
+	var env map[string]interface{}
+	if e := json.Unmarshal(raw, &env); e != nil {
+		t.Fatal(e)
+	}
+	if env["status"] != float64(0) {
+		t.Errorf("status = %v; want 0 (denied before dial)", env["status"])
+	}
+	msg, _ := env["error"].(string)
+	if msg == "" {
+		t.Error("denied fetch must return an error envelope")
 	}
 }

--- a/core/pkg/serverless/hostfunctions/http.go
+++ b/core/pkg/serverless/hostfunctions/http.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/DeBrosOfficial/network/pkg/serverless"
 	"go.uber.org/zap"
@@ -63,15 +66,23 @@ func (h *HostFunctions) AnyoneFetch(ctx context.Context, method, url string, hea
 // AnyoneFetch — identical except for which *http.Client (direct vs
 // SOCKS-routed) does the dialing and the function name used in logs +
 // HostFunctionError.
-func (h *HostFunctions) doFetch(ctx context.Context, fnName string, client *http.Client, method, url string, headers map[string]string, body []byte) ([]byte, error) {
+func (h *HostFunctions) doFetch(ctx context.Context, fnName string, client *http.Client, method, rawURL string, headers map[string]string, body []byte) ([]byte, error) {
+	if err := denyInternalURL(rawURL); err != nil {
+		errorResp := map[string]interface{}{
+			"error":  err.Error(),
+			"status": 0,
+		}
+		return json.Marshal(errorResp)
+	}
+
 	var bodyReader io.Reader
 	if len(body) > 0 {
 		bodyReader = bytes.NewReader(body)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, bodyReader)
 	if err != nil {
-		h.logger.Error(fnName+" request creation error", zap.Error(err), zap.String("url", url))
+		h.logger.Error(fnName+" request creation error", zap.Error(err), zap.String("url", rawURL))
 		errorResp := map[string]interface{}{
 			"error":  "failed to create request: " + err.Error(),
 			"status": 0,
@@ -85,7 +96,7 @@ func (h *HostFunctions) doFetch(ctx context.Context, fnName string, client *http
 
 	resp, err := client.Do(req)
 	if err != nil {
-		h.logger.Error(fnName+" transport error", zap.Error(err), zap.String("url", url))
+		h.logger.Error(fnName+" transport error", zap.Error(err), zap.String("url", rawURL))
 		errorResp := map[string]interface{}{
 			"error":  err.Error(),
 			"status": 0, // Transport error
@@ -96,7 +107,7 @@ func (h *HostFunctions) doFetch(ctx context.Context, fnName string, client *http
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		h.logger.Error(fnName+" response read error", zap.Error(err), zap.String("url", url))
+		h.logger.Error(fnName+" response read error", zap.Error(err), zap.String("url", rawURL))
 		errorResp := map[string]interface{}{
 			"error":  "failed to read response: " + err.Error(),
 			"status": resp.StatusCode,
@@ -117,4 +128,30 @@ func (h *HostFunctions) doFetch(ctx context.Context, fnName string, client *http
 	}
 
 	return data, nil
+}
+
+// denyInternalURL blocks fetches to loopback, private, link-local, and
+// unspecified addresses so tenant WASM cannot reach RQLite/agent/Olric
+// on the gateway host (bugboard #83).
+func denyInternalURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid url")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("url scheme not allowed")
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") || host == "metadata.google.internal" {
+		return fmt.Errorf("url host not allowed")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() || ip.IsMulticast() {
+		return fmt.Errorf("url host not allowed")
+	}
+	return nil
 }

--- a/core/pkg/serverless/hostfunctions/http_deny_test.go
+++ b/core/pkg/serverless/hostfunctions/http_deny_test.go
@@ -1,0 +1,39 @@
+package hostfunctions
+
+import "testing"
+
+func TestDenyInternalURL(t *testing.T) {
+	denied := []string{
+		"http://127.0.0.1/",
+		"http://127.0.0.1:10100/db/query",
+		"http://localhost/foo",
+		"http://foo.localhost/",
+		"http://[::1]/",
+		"http://0.0.0.0/",
+		"http://10.0.0.1/",
+		"http://192.168.1.1/",
+		"http://172.16.0.1/",
+		"http://169.254.169.254/",
+		"http://224.0.0.1/",
+		"http://metadata.google.internal/",
+		"file:///etc/passwd",
+		"ftp://example.com/",
+		"not-a-url",
+		"",
+	}
+	for _, u := range denied {
+		if err := denyInternalURL(u); err == nil {
+			t.Errorf("denyInternalURL(%q) = nil, want error", u)
+		}
+	}
+	allowed := []string{
+		"https://example.com/x",
+		"http://8.8.8.8/dns-query",
+		"https://1.1.1.1/",
+	}
+	for _, u := range allowed {
+		if err := denyInternalURL(u); err != nil {
+			t.Errorf("denyInternalURL(%q) = %v, want nil", u, err)
+		}
+	}
+}

--- a/core/pkg/serverless/invoke.go
+++ b/core/pkg/serverless/invoke.go
@@ -54,6 +54,9 @@ type InvokeRequest struct {
 	// is_internal (bugboard #152). Set by the HTTP/WS handlers from the
 	// request's resolved scope set.
 	CallerIsAdmin bool `json:"caller_is_admin,omitempty"`
+	// CallerHasInvoke is true when the caller holds the invoke grant (or admin).
+	// API keys without invoke must not run private functions (bugboard #259).
+	CallerHasInvoke bool `json:"caller_has_invoke,omitempty"`
 	// CallerIP is the source IP of the request, used by the multi-tier
 	// rate limiter as a fallback bucket for anonymous (no-wallet) callers.
 	CallerIP   string `json:"caller_ip,omitempty"`
@@ -123,7 +126,7 @@ func (i *Invoker) Invoke(ctx context.Context, req *InvokeRequest) (*InvokeRespon
 	// #264). The auth boundary for system triggers is at REGISTRATION
 	// time (HTTP `POST /v1/functions/{name}/triggers`, or deploy-time
 	// auto-register from function.yaml), not at firing time.
-	if !isSystemTrigger(req.TriggerType) && !canInvokeFn(fn, req.CallerWallet, req.CallerIsAdmin) {
+	if !isSystemTrigger(req.TriggerType) && !canInvokeFn(fn, req.CallerWallet, req.CallerIsAdmin, req.CallerHasInvoke) {
 		// Authorization uses the function we already fetched above —
 		// CanInvoke would re-`registry.Get` it, a redundant leader-routed
 		// read on every op (bugboard #708).
@@ -466,13 +469,10 @@ func (i *Invoker) BatchInvoke(ctx context.Context, req *BatchInvokeRequest) (*Ba
 //   - Public functions (`is_public: true`): anyone can invoke, no auth needed.
 //     The auth middleware lets unauthenticated requests through to public
 //     paths.
-//   - Private functions: any caller that the auth middleware has already
-//     authenticated for THIS namespace can invoke. By the time we reach
-//     this function, the request has passed authMiddleware which validates
-//     EITHER a JWT-bearing token whose `namespace` claim matches the target
-//     namespace OR an API key resolved to the target namespace. So the
-//     non-empty `callerWallet` here is sufficient evidence of a verified
-//     in-namespace caller.
+//   - Private functions: an identified caller who holds the invoke grant
+//     (API-key `invoke` scope, admin, or a SIWE wallet). A storage-only
+//     API key is denied (bugboard #259). HTTP `/invoke` is a public path,
+//     so this check is the choke point — scopeMiddleware never runs.
 //   - Internal functions (`internal: true`, bugboard #152): invokable ONLY
 //     by a system trigger or an admin caller (callerIsAdmin). A normal
 //     app-runtime key is rejected even though it has a valid identity.
@@ -530,29 +530,29 @@ func (i *Invoker) CanInvoke(ctx context.Context, namespace, functionName string,
 	if err != nil {
 		return false, err
 	}
-	return canInvokeFn(fn, callerWallet, callerIsAdmin), nil
+	return canInvokeFn(fn, callerWallet, callerIsAdmin, true), nil
 }
 
 // canInvokeFn is the pure authorization decision for an already-fetched
-// function, so the hot Invoke path doesn't re-read the registry (bugboard
-// #708). Public functions are open; a private function only requires that the
-// caller has SOME identity — the auth middleware already verified namespace
-// membership before the function ran.
-//
-// An internal function (bugboard #152) may be invoked ONLY by a system
-// trigger or an admin caller. System triggers bypass this function entirely
-// (isSystemTrigger short-circuits the gate in Invoke), so reaching here with
-// an internal function means an external caller — require admin. This closes
-// the hole where a scoped app-runtime key could invoke internal/admin/cron
-// functions (e.g. `migrate`) by name.
-func canInvokeFn(fn *Function, callerWallet string, callerIsAdmin bool) bool {
+// function. Public functions are open. Internal functions require admin.
+// Private functions require a non-empty identity AND the invoke grant
+// (bugboard #259). The HTTP handler reports SIWE wallets as hasInvoke;
+// do not treat callerWallet as an API-key detector — getWalletFromRequest
+// returns the namespace string for API keys, not an ak_ prefix.
+func canInvokeFn(fn *Function, callerWallet string, callerIsAdmin, callerHasInvoke bool) bool {
 	if fn.IsInternal && !callerIsAdmin {
 		return false
 	}
 	if fn.IsPublic {
 		return true
 	}
-	return strings.TrimSpace(callerWallet) != ""
+	if callerIsAdmin {
+		return true
+	}
+	if strings.TrimSpace(callerWallet) == "" {
+		return false
+	}
+	return callerHasInvoke
 }
 
 // GetFunctionInfo returns basic info about a function for invocation.

--- a/core/pkg/serverless/invoke_system_trigger_test.go
+++ b/core/pkg/serverless/invoke_system_trigger_test.go
@@ -89,9 +89,9 @@ func TestInvoke_systemTriggerBypassesAuth(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		trigger   TriggerType
-		wantAuth  bool // true → must hit ErrUnauthorized; false → must NOT
+		name     string
+		trigger  TriggerType
+		wantAuth bool // true → must hit ErrUnauthorized; false → must NOT
 	}{
 		// System triggers — must bypass auth. The original bug was every
 		// one of these returning ErrUnauthorized.
@@ -260,11 +260,12 @@ func TestInvoke_userTriggerWithCallerStillWorks(t *testing.T) {
 	cancel()
 
 	req := &InvokeRequest{
-		Namespace:    "anchat-test",
-		FunctionName: "user-create",
-		Input:        []byte(`{}`),
-		TriggerType:  TriggerTypeHTTP,
-		CallerWallet: "0xRealUser",
+		Namespace:       "anchat-test",
+		FunctionName:    "user-create",
+		Input:           []byte(`{}`),
+		TriggerType:     TriggerTypeHTTP,
+		CallerWallet:    "0xRealUser",
+		CallerHasInvoke: true,
 	}
 	_, err := inv.Invoke(ctx, req)
 	if errors.Is(err, ErrUnauthorized) {

--- a/core/pkg/serverless/registry_cache_test.go
+++ b/core/pkg/serverless/registry_cache_test.go
@@ -103,17 +103,32 @@ func TestRegistryCache_keyDistinctNoCollision(t *testing.T) {
 }
 
 func TestCanInvokeFn(t *testing.T) {
-	if !canInvokeFn(&Function{IsPublic: true}, "", false) {
+	if !canInvokeFn(&Function{IsPublic: true}, "", false, false) {
 		t.Error("public function must be invokable by an anonymous caller")
 	}
-	if canInvokeFn(&Function{IsPublic: false}, "", false) {
+	if canInvokeFn(&Function{IsPublic: false}, "", false, false) {
 		t.Error("private function must reject an empty (anonymous) caller")
 	}
-	if canInvokeFn(&Function{IsPublic: false}, "   ", false) {
+	if canInvokeFn(&Function{IsPublic: false}, "   ", false, false) {
 		t.Error("private function must reject a whitespace-only caller")
 	}
-	if !canInvokeFn(&Function{IsPublic: false}, "wallet-abc", false) {
-		t.Error("private function must accept an identified caller")
+	if canInvokeFn(&Function{IsPublic: false}, "wallet-abc", false, false) {
+		t.Error("private function must reject a wallet without the invoke grant")
+	}
+	if !canInvokeFn(&Function{IsPublic: false}, "wallet-abc", false, true) {
+		t.Error("private function must accept a wallet with the invoke grant")
+	}
+	if canInvokeFn(&Function{IsPublic: false}, "anchat-test", false, false) {
+		t.Error("private function must reject an API-key namespace identity without invoke")
+	}
+	if !canInvokeFn(&Function{IsPublic: false}, "anchat-test", false, true) {
+		t.Error("private function must accept an API key with invoke")
+	}
+	if canInvokeFn(&Function{IsPublic: false}, "ak_runtime:ns", false, false) {
+		t.Error("private function must reject an API key without invoke")
+	}
+	if !canInvokeFn(&Function{IsPublic: false}, "ak_runtime:ns", false, true) {
+		t.Error("private function must accept an API key with invoke")
 	}
 }
 
@@ -137,11 +152,12 @@ func TestRowToFunction_isInternal(t *testing.T) {
 // external caller — admin required). Non-internal behavior is unchanged.
 func TestCanInvokeFn_internal(t *testing.T) {
 	tests := []struct {
-		name          string
-		fn            *Function
-		callerWallet  string
-		callerIsAdmin bool
-		want          bool
+		name            string
+		fn              *Function
+		callerWallet    string
+		callerIsAdmin   bool
+		callerHasInvoke bool
+		want            bool
 	}{
 		{
 			name:          "internal private, admin caller allowed",
@@ -179,11 +195,12 @@ func TestCanInvokeFn_internal(t *testing.T) {
 			want:          true,
 		},
 		{
-			name:          "non-internal private, identified caller allowed (unchanged)",
-			fn:            &Function{IsInternal: false, IsPublic: false},
-			callerWallet:  "wallet-abc",
-			callerIsAdmin: false,
-			want:          true,
+			name:            "non-internal private, identified caller with invoke allowed",
+			fn:              &Function{IsInternal: false, IsPublic: false},
+			callerWallet:    "wallet-abc",
+			callerIsAdmin:   false,
+			callerHasInvoke: true,
+			want:            true,
 		},
 		{
 			name:          "non-internal private, anonymous caller denied (unchanged)",
@@ -195,7 +212,7 @@ func TestCanInvokeFn_internal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := canInvokeFn(tt.fn, tt.callerWallet, tt.callerIsAdmin); got != tt.want {
+			if got := canInvokeFn(tt.fn, tt.callerWallet, tt.callerIsAdmin, tt.callerHasInvoke); got != tt.want {
 				t.Errorf("canInvokeFn = %v, want %v", got, tt.want)
 			}
 		})

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -377,6 +377,7 @@ Function Invocation:
    - Long-lived credentials
    - Stored in RQLite
    - Namespace-scoped
+   - Carry a grant set (`invoke`, `storage`, `push`, `webrtc`, `proxy`, `pubsub`, `cache`, or `admin`). HTTP `/v1/invoke` is a public path; private functions still require the `invoke` grant (or a SIWE wallet). Node command/logs/leave and network connect/disconnect require `admin`.
 
 3. **JWT Tokens**
    - Short-lived (15 min default)
@@ -396,12 +397,16 @@ All inter-node communication is encrypted via a WireGuard VPN mesh:
 
 ### Service Authentication
 
-- **RQLite:** HTTP basic auth on all queries/executions — credentials generated at genesis, distributed via join response
+- **RQLite:** credentials are generated at genesis; `rqlited` is **not** started with `-auth` today. Overlay + firewall keep the HTTP API off the public internet
 - **Olric:** Memberlist gossip encrypted with a shared 32-byte key
-- **IPFS Cluster:** TrustedPeers restricted to known cluster peer IDs (not `*`)
+- **IPFS Cluster:** TrustedPeers restricted to known cluster peer IDs (not `*`). The systemd unit is not written if `CLUSTER_SECRET` is missing or empty
 - **Internal endpoints:** `/v1/internal/wg/peers` and `/v1/internal/wg/peer/remove` require cluster secret
 - **Vault:** V1 push/pull endpoints require session token authentication when guardian is configured
 - **WebSockets:** Origin header validated against the node's configured domain
+- **Tenant SQLite:** opened with `SQLITE_LIMIT_ATTACHED=0`; `ATTACH`/`DETACH` and multi-statement queries are rejected
+- **WASM egress:** `http_fetch` / `anyone_fetch` deny loopback, private, link-local, unspecified, and multicast URLs
+- **WASM memory:** wazero `WithMemoryLimitPages` from `MaxMemoryLimitMB` (default 256 MB). Modules without a memory max still cannot grow past that
+- **WASM concurrency:** process-wide semaphore plus a per-namespace cap (`maxConcurrent/2`, min 1)
 
 ### Token & Key Security
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -425,7 +425,7 @@ orama db backups my-database
 ### Database Features
 
 - ✅ **WAL Mode**: Write-Ahead Logging for better concurrency
-- ✅ **Namespace Isolation**: Complete separation between namespaces
+- ✅ **Namespace Isolation**: Complete separation between namespaces. Tenant SQL cannot `ATTACH`/`DETACH` another database file, and extra statements in one query are rejected.
 - ✅ **On-Demand Backups**: Back up to IPFS anytime with `orama db backup`
 - ✅ **ACID Transactions**: Full SQLite transactional support
 - ✅ **Concurrent Reads**: Multiple readers can query simultaneously

--- a/docs/DEV_DEPLOY.md
+++ b/docs/DEV_DEPLOY.md
@@ -385,9 +385,11 @@ orama node unlock --genesis --node-ip <wg-ip>
 OramaOS nodes have no SSH access. All management happens through the Gateway API:
 
 ```bash
-# Status, logs, commands — all via Gateway proxy
-curl "https://gateway.example.com/v1/node/status?node_id=<id>"
-curl "https://gateway.example.com/v1/node/logs?node_id=<id>&service=gateway"
+# Status, logs, commands — admin credential required
+curl "https://gateway.example.com/v1/node/status?node_id=<id>" \
+  -H "Authorization: Bearer <admin-api-key>"
+curl "https://gateway.example.com/v1/node/logs?node_id=<id>&service=gateway" \
+  -H "Authorization: Bearer <admin-api-key>"
 ```
 
 See [ORAMAOS_DEPLOYMENT.md](ORAMAOS_DEPLOYMENT.md) for the full guide.

--- a/docs/ORAMAOS_DEPLOYMENT.md
+++ b/docs/ORAMAOS_DEPLOYMENT.md
@@ -122,22 +122,26 @@ If not enough peers are available, the agent retries the share fetch with expone
 
 ## Node Management
 
-Since OramaOS has no SSH, all management happens through the Gateway API:
+Since OramaOS has no SSH, all management happens through the Gateway API. Status, command, logs, and leave require an **admin** API key (or owner JWT). `service` on logs is an allowlist (`rqlite`, `olric`, `ipfs`, `ipfs-cluster`, `gateway`, `coredns`, `agent`).
 
 ```bash
 # Check node status
-curl "https://gateway.example.com/v1/node/status?node_id=<id>"
+curl "https://gateway.example.com/v1/node/status?node_id=<id>" \
+  -H "Authorization: Bearer <admin-api-key>"
 
 # Send a command (e.g., restart a service)
 curl -X POST "https://gateway.example.com/v1/node/command?node_id=<id>" \
+  -H "Authorization: Bearer <admin-api-key>" \
   -H "Content-Type: application/json" \
   -d '{"action":"restart","service":"rqlite"}'
 
 # View logs
-curl "https://gateway.example.com/v1/node/logs?node_id=<id>&service=gateway&lines=100"
+curl "https://gateway.example.com/v1/node/logs?node_id=<id>&service=gateway&lines=100" \
+  -H "Authorization: Bearer <admin-api-key>"
 
 # Graceful node departure
 curl -X POST "https://gateway.example.com/v1/node/leave" \
+  -H "Authorization: Bearer <admin-api-key>" \
   -H "Content-Type: application/json" \
   -d '{"node_id":"<id>"}'
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -43,6 +43,17 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - V1 push/pull endpoints require a valid session token when vault-guardian is configured
 - Previously, auth was optional for backward compatibility — any WG peer could read/overwrite Shamir shares
 
+### Tenant isolation
+
+- **SQLite ATTACH:** tenant query connections register `sqlite3_tenant_noattach` with `SQLITE_LIMIT_ATTACHED=0`. `ATTACH`/`DETACH` and extra statements in one query are rejected before exec
+- **WASM `http_fetch` / `anyone_fetch`:** loopback, private, link-local, unspecified, and multicast destinations are rejected so tenant code cannot reach RQLite/agent/Olric on the host
+- **WASM memory:** wazero runtime `WithMemoryLimitPages` from `MaxMemoryLimitMB` (default 256 MB)
+- **WASM concurrency:** global semaphore plus a per-namespace slot so one tenant cannot fill the process
+- **Private function invoke:** HTTP `/v1/invoke` is unauthenticated at the middleware; `canInvokeFn` requires the `invoke` grant (or a SIWE wallet) for private functions. Storage-only API keys cannot invoke
+- **Node/network control:** `/v1/node/{status,command,logs,leave}` and `/v1/network/{connect,disconnect}` require admin. `/v1/node/enroll` authenticates via invite token in the handler
+- **IPFS Cluster:** generated unit and `ipfs-cluster-service init` refuse an empty `CLUSTER_SECRET`
+- **Agent logs:** `/v1/agent/logs?service=` is an allowlist (`rqlite`, `olric`, `ipfs`, `ipfs-cluster`, `gateway`, `coredns`, `agent`); path traversal is rejected
+
 ### Token & Key Storage
 
 **Refresh Token Hashing (Step 1.5)**

--- a/docs/SERVERLESS.md
+++ b/docs/SERVERLESS.md
@@ -39,7 +39,10 @@ my-function/
 
 ```yaml
 name: my-function       # Required. Letters, digits, hyphens, underscores.
-public: false           # Allow unauthenticated invocation (default: false)
+public: false           # Allow unauthenticated invocation (default: false).
+                        # Private functions require a SIWE wallet JWT or an
+                        # API key that holds the `invoke` grant. A storage-only
+                        # key is rejected.
 memory: 64              # Memory limit in MB (1-256, default: 64)
 timeout: 30             # Execution timeout in seconds (1-300, default: 30)
                         # Bump to 60-300 for batch DB ops, schema migrations,
@@ -299,7 +302,7 @@ if !res.Committed {
 
 | Function | Description |
 |----------|-------------|
-| `http_fetch(method, url, headersJSON, body)` → JSON | Make outbound HTTP request. Headers as JSON object. Returns `{"status": 200, "headers": {...}, "body": "..."}`. Timeout: 30s. |
+| `http_fetch(method, url, headersJSON, body)` → JSON | Make outbound HTTP request. Headers as JSON object. Returns `{"status": 200, "headers": {...}, "body": "..."}`. Timeout: 30s. Loopback, private, link-local, unspecified, and multicast destinations are rejected (same for `anyone_fetch`). |
 
 ### Storage (IPFS)
 

--- a/os/agent/internal/command/receiver.go
+++ b/os/agent/internal/command/receiver.go
@@ -21,7 +21,28 @@ import (
 const (
 	// ListenAddr is the address for the command receiver (WG-only).
 	ListenAddr = ":9998"
+	logsDir    = "/opt/orama/.orama/logs"
 )
+
+// knownLogServices is the only set of log files the agent will read
+// (bugboard #93). Query `service` is not concatenated into a path.
+var knownLogServices = []string{"rqlite", "olric", "ipfs", "ipfs-cluster", "gateway", "coredns", "agent"}
+
+func allowedLogService(service string) bool {
+	if service == "" || strings.ContainsAny(service, `/\:`) || strings.Contains(service, "..") {
+		return false
+	}
+	for _, s := range knownLogServices {
+		if s == service {
+			return true
+		}
+	}
+	return false
+}
+
+func logPathForService(service string) string {
+	return logsDir + "/" + service + ".log"
+}
 
 // Command represents an incoming command from the Gateway.
 type Command struct {
@@ -148,20 +169,18 @@ func (r *Receiver) handleLogs(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	const logsDir = "/opt/orama/.orama/logs"
 	result := make(map[string]string)
 
 	if service == "all" {
-		// Return tail of each service log
-		services := []string{"rqlite", "olric", "ipfs", "ipfs-cluster", "gateway", "coredns"}
-		for _, svc := range services {
-			logPath := logsDir + "/" + svc + ".log"
-			lines := tailFile(logPath, maxLines)
-			result[svc] = lines
+		for _, svc := range knownLogServices {
+			result[svc] = tailFile(logPathForService(svc), maxLines)
 		}
 	} else {
-		logPath := logsDir + "/" + service + ".log"
-		result[service] = tailFile(logPath, maxLines)
+		if !allowedLogService(service) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown service"})
+			return
+		}
+		result[service] = tailFile(logPathForService(service), maxLines)
 	}
 
 	writeJSON(w, http.StatusOK, result)

--- a/os/agent/internal/command/receiver_logs_test.go
+++ b/os/agent/internal/command/receiver_logs_test.go
@@ -1,0 +1,24 @@
+package command
+
+import "testing"
+
+func TestAllowedLogService(t *testing.T) {
+	if !allowedLogService("gateway") {
+		t.Error("gateway must be allowed")
+	}
+	if allowedLogService("../secrets") {
+		t.Error("path traversal must be denied")
+	}
+	if allowedLogService("rqlite/../../etc/passwd") {
+		t.Error("slash in service must be denied")
+	}
+	if allowedLogService("not-a-service") {
+		t.Error("unknown service must be denied")
+	}
+	if allowedLogService("") {
+		t.Error("empty service must be denied")
+	}
+	if p := logPathForService("gateway"); p != logsDir+"/gateway.log" {
+		t.Errorf("logPathForService(gateway) = %q", p)
+	}
+}


### PR DESCRIPTION
## Summary

CHG-202 on top of #108. Gateway authz and multi-tenant isolation. API-breaking for storage-only keys on private functions. Not a VERSION bump.

Merge order: **#101 → #102 → #103 → #104 → #105 → #106 → #107 → #108 → this**.

## What landed

| Bug | Change |
|---|---|
| **#252** | Tenant SQLite `SQLITE_LIMIT_ATTACHED=0`; reject `ATTACH`/`DETACH` and extra statements. |
| **#83** | `http_fetch` / `anyone_fetch` deny loopback, private, link-local, unspecified, multicast. |
| **#84** | wazero `WithMemoryLimitPages` from `MaxMemoryLimitMB` (default 256 MB). |
| **#85** | Per-namespace concurrency slot plus the process-wide semaphore. |
| **#54 #55** | `requiredScope` admin for `/v1/node/*` except enroll (invite token in the handler). |
| **#56** | `requiredScope` admin for `/v1/network/connect\|disconnect`; status/peers stay public. |
| **#93** | Agent logs `service` allowlist; path traversal rejected. |
| **#259** | Private functions require the `invoke` grant for API keys; SIWE wallets still invoke. HTTP `/invoke` is a public path — this is the choke point. |
| **#109** | Refuse empty `CLUSTER_SECRET` in the generated unit and cluster init. |

## Skipped (comment on Bugboard)

| Bug | Why |
|---|---|
| **#57** | OramaOS agent `:9998`; Handler has no cluster-secret to send. Skip with OramaOS. |
| **#106** | SFU room tokens = protocol. |
| **#107** | GossipSub validator needs identity→namespace map. |
| **#108 #110** | pnet / WG bind breaks the existing swarm. |
| **#200** | Per-function grants need schema; #259 is the class. |
| **#74** | pion/dtls v2→v3 still API-breaking. |

## Test plan

- [x] Focused tests + pre-push `go test ./...`
- [ ] Human review