### PR TITLE
fix: CHG-206 TLS MinVersion, fail-closed Olric, sniproxy caps

### DIFF
--- a/core/pkg/certutil/cert_manager.go
+++ b/core/pkg/certutil/cert_manager.go
@@ -28,6 +28,18 @@ func NewCertificateManager(baseDir string) *CertificateManager {
 	}
 }
 
+// mustSerial returns a 128-bit CSPRNG serial (bugboard #118).
+func mustSerial() *big.Int {
+	n, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic("certutil: crypto/rand unavailable: " + err.Error())
+	}
+	if n.Sign() == 0 {
+		n = big.NewInt(1)
+	}
+	return n
+}
+
 // EnsureCACertificate creates or loads the CA certificate
 func (cm *CertificateManager) EnsureCACertificate() ([]byte, []byte, error) {
 	caCertPath := filepath.Join(cm.baseDir, "ca.crt")
@@ -113,7 +125,7 @@ func (cm *CertificateManager) generateCACertificate() ([]byte, []byte, error) {
 
 	// Create certificate template
 	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: mustSerial(),
 		Subject: pkix.Name{
 			CommonName:   "Orama Network Root CA",
 			Organization: []string{"Orama"},
@@ -168,7 +180,7 @@ func (cm *CertificateManager) generateNodeCertificate(hostname string, caCertPEM
 
 	// Create certificate template
 	template := x509.Certificate{
-		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		SerialNumber: mustSerial(),
 		Subject: pkix.Name{
 			CommonName: hostname,
 		},

--- a/core/pkg/certutil/serial_test.go
+++ b/core/pkg/certutil/serial_test.go
@@ -1,0 +1,16 @@
+package certutil
+
+import (
+	"testing"
+)
+
+func TestMustSerial_unique(t *testing.T) {
+	a := mustSerial()
+	b := mustSerial()
+	if a.Cmp(b) == 0 {
+		t.Fatal("CSPRNG serials must not collide")
+	}
+	if a.Sign() <= 0 || b.Sign() <= 0 {
+		t.Fatal("serial must be positive")
+	}
+}

--- a/core/pkg/cli/cmd/namespacecmd/rqlite.go
+++ b/core/pkg/cli/cmd/namespacecmd/rqlite.go
@@ -71,7 +71,7 @@ func rqliteExport(cmd *cobra.Command, args []string) error {
 	client := &http.Client{
 		Timeout: 0,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 
@@ -167,7 +167,7 @@ func rqliteImport(cmd *cobra.Command, args []string) error {
 	client := &http.Client{
 		Timeout: 0,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 

--- a/core/pkg/cli/namespace_commands.go
+++ b/core/pkg/cli/namespace_commands.go
@@ -75,10 +75,11 @@ func HandleNamespaceCommand(args []string) {
 }
 
 // handleNamespaceKeys drives scoped API-key management (bugboard #148):
-//   orama namespace keys create --scope <profile|grants> [--label ...]
-//   orama namespace keys list
-//   orama namespace keys revoke --id <n>
-//   orama namespace keys revoke-legacy
+//
+//	orama namespace keys create --scope <profile|grants> [--label ...]
+//	orama namespace keys list
+//	orama namespace keys revoke --id <n>
+//	orama namespace keys revoke-legacy
 func handleNamespaceKeys(args []string) {
 	if len(args) == 0 {
 		showNamespaceKeysHelp()
@@ -125,7 +126,7 @@ func keysDo(method, url, apiKey string, body io.Reader) (map[string]interface{},
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}}
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to connect to gateway: %v\n", err)
@@ -371,7 +372,7 @@ func handleNamespaceDelete(force bool) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)
@@ -443,7 +444,7 @@ func handleNamespaceEnable(args []string) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)
@@ -507,7 +508,7 @@ func handleNamespaceStealthToggle(args []string, enable bool) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)
@@ -573,7 +574,7 @@ func handleNamespaceDisable(args []string) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)
@@ -612,7 +613,7 @@ func handleNamespaceWebRTCStatus(ns string) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)
@@ -707,7 +708,7 @@ func handleNamespaceList() {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	resp, err := client.Do(req)

--- a/core/pkg/cli/production/invite/command.go
+++ b/core/pkg/cli/production/invite/command.go
@@ -83,7 +83,7 @@ func getTLSCertFingerprint(domain string) string {
 		&net.Dialer{Timeout: 5 * time.Second},
 		"tcp",
 		domain+":443",
-		&tls.Config{InsecureSkipVerify: true},
+		&tls.Config{MinVersion: tls.VersionTLS12},
 	)
 	if err != nil {
 		return ""

--- a/core/pkg/environments/production/config.go
+++ b/core/pkg/environments/production/config.go
@@ -448,6 +448,9 @@ func (cg *ConfigGenerator) GenerateOlricConfig(serverBindAddr string, httpPort i
 	if data, err := os.ReadFile(filepath.Join(cg.oramaDir, "secrets", "olric-encryption-key")); err == nil {
 		encryptionKey = strings.TrimSpace(string(data))
 	}
+	if encryptionKey == "" {
+		return "", fmt.Errorf("olric-encryption-key missing or empty; refusing to start Olric without memberlist encryption")
+	}
 
 	data := templates.OlricConfigData{
 		ServerBindAddr:          serverBindAddr,

--- a/core/pkg/environments/production/olric_encryption_failclosed_test.go
+++ b/core/pkg/environments/production/olric_encryption_failclosed_test.go
@@ -1,0 +1,30 @@
+package production
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateOlricConfig_emptyKeyFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	cg := NewConfigGenerator(dir)
+	_, err := cg.GenerateOlricConfig("127.0.0.1", 3320, "127.0.0.1", 3322, "local", "", nil)
+	if err == nil {
+		t.Fatal("missing olric-encryption-key must fail closed")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "secrets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secrets", "olric-encryption-key"), []byte("dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdA==\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := cg.GenerateOlricConfig("127.0.0.1", 3320, "127.0.0.1", 3322, "local", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "encryptionKey:") {
+		t.Fatalf("expected encryptionKey in config, got %q", out)
+	}
+}

--- a/core/pkg/gateway/tcp_sni_gateway.go
+++ b/core/pkg/gateway/tcp_sni_gateway.go
@@ -59,6 +59,7 @@ func NewTCPSNIGateway(logger *logging.ColoredLogger, cfg *config.SNIConfig) (*TC
 		cancel: cancel,
 		tlsConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
 		},
 	}
 

--- a/core/pkg/sniproxy/server.go
+++ b/core/pkg/sniproxy/server.go
@@ -21,16 +21,25 @@ type Config struct {
 	// MaxConcurrentConns caps total in-flight connections to prevent
 	// resource exhaustion. 0 selects 10000.
 	MaxConcurrentConns int
+	// MaxConnsPerIP caps in-flight connections from one client IP.
+	// 0 selects 32.
+	MaxConnsPerIP int
+	// IdleTimeout is the read/write idle deadline during the copy.
+	// 0 selects 60 seconds.
+	IdleTimeout time.Duration
 }
 
 // Server is a TCP-level SNI router. Create via NewServer, then call
 // Serve(listener) in a goroutine. Close cancels in-flight connections.
 type Server struct {
-	router  *Router
-	cfg     Config
-	logger  *zap.Logger
+	router *Router
+	cfg    Config
+	logger *zap.Logger
 
-	gate   chan struct{}      // bounded semaphore for concurrent connections
+	gate   chan struct{} // bounded semaphore for concurrent connections
+	perIP  map[string]chan struct{}
+	perIPN int
+	mu     sync.Mutex
 	wg     sync.WaitGroup
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -50,15 +59,34 @@ func NewServer(router *Router, cfg Config, logger *zap.Logger) *Server {
 	if cfg.MaxConcurrentConns <= 0 {
 		cfg.MaxConcurrentConns = 10000
 	}
+	if cfg.MaxConnsPerIP <= 0 {
+		cfg.MaxConnsPerIP = 32
+	}
+	if cfg.IdleTimeout <= 0 {
+		cfg.IdleTimeout = 60 * time.Second
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Server{
 		router: router,
 		cfg:    cfg,
 		logger: logger.Named("sniproxy"),
 		gate:   make(chan struct{}, cfg.MaxConcurrentConns),
+		perIP:  make(map[string]chan struct{}),
+		perIPN: cfg.MaxConnsPerIP,
 		ctx:    ctx,
 		cancel: cancel,
 	}
+}
+
+func (s *Server) ipSlot(ip string) chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch := s.perIP[ip]
+	if ch == nil {
+		ch = make(chan struct{}, s.perIPN)
+		s.perIP[ip] = ch
+	}
+	return ch
 }
 
 // Serve accepts connections from ln until ln.Accept returns a permanent
@@ -89,12 +117,29 @@ func (s *Server) Serve(ln net.Listener) error {
 			conn.Close()
 			continue
 		}
+		ip, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+		if ip == "" {
+			ip = conn.RemoteAddr().String()
+		}
+		slot := s.ipSlot(ip)
+		select {
+		case slot <- struct{}{}:
+		default:
+			<-s.gate
+			s.logger.Warn("max connections per IP reached, dropping",
+				zap.Int("limit", s.perIPN),
+				zap.String("ip", ip),
+			)
+			conn.Close()
+			continue
+		}
 		s.wg.Add(1)
-		go func(c net.Conn) {
+		go func(c net.Conn, ipSlot chan struct{}) {
 			defer s.wg.Done()
 			defer func() { <-s.gate }()
+			defer func() { <-ipSlot }()
 			s.handle(c)
-		}(conn)
+		}(conn, slot)
 	}
 }
 
@@ -154,16 +199,19 @@ func (s *Server) handle(conn net.Conn) {
 		}
 	}
 
+	src := idleConn{Conn: conn, idle: s.cfg.IdleTimeout}
+	dst := idleConn{Conn: upstream, idle: s.cfg.IdleTimeout}
+
 	// Bidirectional copy. We close both connections when either side
 	// finishes OR when the server is shutting down, so handle() can't
 	// hang forever on a half-stuck peer.
 	done := make(chan struct{}, 2)
 	go func() {
-		_, _ = io.Copy(upstream, conn)
+		_, _ = io.Copy(dst, src)
 		done <- struct{}{}
 	}()
 	go func() {
-		_, _ = io.Copy(conn, upstream)
+		_, _ = io.Copy(src, dst)
 		done <- struct{}{}
 	}()
 	select {
@@ -174,4 +222,25 @@ func (s *Server) handle(conn net.Conn) {
 	upstream.Close()
 	conn.Close()
 	<-done // drain the second goroutine
+}
+
+// idleConn resets the deadline on every Read/Write so a stalled peer
+// cannot hold a backend slot forever (bugboard #117).
+type idleConn struct {
+	net.Conn
+	idle time.Duration
+}
+
+func (c idleConn) Read(p []byte) (int, error) {
+	if c.idle > 0 {
+		_ = c.Conn.SetReadDeadline(time.Now().Add(c.idle))
+	}
+	return c.Conn.Read(p)
+}
+
+func (c idleConn) Write(p []byte) (int, error) {
+	if c.idle > 0 {
+		_ = c.Conn.SetWriteDeadline(time.Now().Add(c.idle))
+	}
+	return c.Conn.Write(p)
 }

--- a/core/pkg/sniproxy/server_test.go
+++ b/core/pkg/sniproxy/server_test.go
@@ -141,3 +141,40 @@ func TestServer_no_backend_drops_connection(t *testing.T) {
 	}
 }
 
+func TestServer_perIPCap(t *testing.T) {
+	backend, _ := startEchoBackend(t)
+	defer backend.Close()
+	router := NewRouter(Backend{Network: "tcp", Addr: backend.Addr().String()})
+	srv := NewServer(router, Config{MaxConnsPerIP: 1, MaxConcurrentConns: 100, IdleTimeout: time.Second}, zap.NewNop())
+	defer srv.Close()
+	frontLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer frontLn.Close()
+	go func() { _ = srv.Serve(frontLn) }()
+
+	hold, err := net.Dial("tcp", frontLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hold.Close()
+	// Start a TLS hello so handle() is in-flight while we try a second conn.
+	go func() {
+		c := tls.Client(hold, &tls.Config{ServerName: "x.example.com", InsecureSkipVerify: true})
+		_ = c.Handshake()
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	second, err := net.Dial("tcp", frontLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	_ = second.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, rerr := second.Read(buf)
+	if rerr == nil {
+		t.Error("second connection from same IP should be dropped at the per-IP cap")
+	}
+}

--- a/core/pkg/tlsutil/client.go
+++ b/core/pkg/tlsutil/client.go
@@ -104,11 +104,7 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 // Only skips TLS verification for explicitly trusted domains when no CA cert is available.
 func NewHTTPClientForDomain(timeout time.Duration, hostname string) *http.Client {
 	tlsConfig := GetTLSConfig()
-
-	// Only skip TLS for explicitly trusted domains when no CA pool is configured
-	if caCertPool == nil && ShouldSkipTLSVerify(hostname) {
-		tlsConfig.InsecureSkipVerify = true
-	}
+	_ = hostname // domain is for callers; verification uses system/Caddy CAs (bugboard #112)
 
 	return &http.Client{
 		Timeout: timeout,

--- a/core/pkg/tlsutil/tlsutil_test.go
+++ b/core/pkg/tlsutil/tlsutil_test.go
@@ -2,6 +2,7 @@ package tlsutil
 
 import (
 	"crypto/tls"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -176,6 +177,17 @@ func TestNewHTTPClientForDomain_Untrusted(t *testing.T) {
 	}
 	if client.Transport == nil {
 		t.Fatal("NewHTTPClientForDomain() returned client with nil Transport for untrusted domain")
+	}
+}
+
+func TestNewHTTPClientForDomain_neverSkipsVerify(t *testing.T) {
+	client := NewHTTPClientForDomain(5*time.Second, "api.orama.network")
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil {
+		t.Fatal("expected TLS client config")
+	}
+	if tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("NewHTTPClientForDomain must not set InsecureSkipVerify (bugboard #112)")
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,6 +408,7 @@ All inter-node communication is encrypted via a WireGuard VPN mesh:
 - **WASM memory:** wazero `WithMemoryLimitPages` from `MaxMemoryLimitMB` (default 256 MB). Modules without a memory max still cannot grow past that
 - **WASM concurrency:** process-wide semaphore plus a per-namespace cap (`maxConcurrent/2`, min 1)
 - **Process uid:** namespace gateway/rqlite/olric/sfu/turn/pubsub run as `User=orama` (not root). `/opt/orama/bin` is `root:orama` 0750. CoreDNS/Caddy `ReadWritePaths` do not include `secrets/`
+- **TLS:** internet-facing TLS is 1.2+ (`TCPSNIGateway`, CLI, tlsutil). Olric memberlist encryption is required at config render (missing key is a startup error, not cleartext)
 
 ### Token & Key Security
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -81,6 +81,10 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - Invite token output includes the CA certificate fingerprint (SHA-256)
 - Joining node verifies the server cert fingerprint matches before proceeding
 - After join: CA cert stored locally for future connections
+- Production CLI and `tlsutil.NewHTTPClientForDomain` do **not** set `InsecureSkipVerify` — public Caddy certs verify against system CAs
+- `TCPSNIGateway` sets `MinVersion: TLS 1.2`
+- Certificate serials are 128-bit `crypto/rand` values
+- Olric config generation refuses an empty `olric-encryption-key` (no cleartext memberlist)
 
 **WebSocket Origin Validation (Step 1.4)**
 - All WebSocket upgraders validate the `Origin` header against the node's configured domain


### PR DESCRIPTION
## Summary

CHG-206 on top of #110. TLS floor, fail-closed Olric encryption, sniproxy per-IP/idle. Minor (fail-closed). Not a VERSION bump.

Merge order: **#101 → #102 → #103 → #104 → #105 → #106 → #107 → #108 → #109 → #110 → this**.

## What landed

| Bug | Change |
|---|---|
| **#79** | `TCPSNIGateway` `MinVersion: TLS 1.2`. |
| **#118** | certutil serials are 128-bit `crypto/rand`, not `1` / UnixNano. |
| **#117** | sniproxy per-IP cap (default 32) and idle timeout (default 60s). |
| **#112** | `tlsutil.NewHTTPClientForDomain` never sets `InsecureSkipVerify`. |
| **#113** | Production namespace CLI TLS configs use MinVersion 1.2, no skip-verify. |
| **#115 / #111** | `GenerateOlricConfig` fails if `olric-encryption-key` is empty. |

## Skipped (comment on Bugboard)

| Bug | Why |
|---|---|
| **#116** | CoreDNS must listen on public `:53` for nameservers; a WG-only ACL would break resolution. |
| Join TOFU | `InsecureSkipVerify` in install stays — fingerprint-pinned after first use. |

## Test plan

- [x] Focused tests + pre-push `go test ./...`
- [ ] Human review