### PR TITLE
fix: CHG-245 drop unused Olric YAML key; wg0.conf 0600

### DIFF
--- a/core/pkg/environments/production/config.go
+++ b/core/pkg/environments/production/config.go
@@ -2,7 +2,6 @@ package production
 
 import (
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -441,17 +440,9 @@ func (cg *ConfigGenerator) GenerateGatewayConfig(peerAddresses []string, enableH
 }
 
 // GenerateOlricConfig generates Olric configuration.
-// Reads the Olric encryption key from secrets if available.
+// Olric v0.7.0's YAML loader has no encryptionKey field (bugboard #246);
+// WireGuard is the confidentiality control for memberlist.
 func (cg *ConfigGenerator) GenerateOlricConfig(serverBindAddr string, httpPort int, memberlistBindAddr string, memberlistPort int, memberlistEnv string, advertiseAddr string, peers []string) (string, error) {
-	// Read encryption key from secrets if available
-	encryptionKey := ""
-	if data, err := os.ReadFile(filepath.Join(cg.oramaDir, "secrets", "olric-encryption-key")); err == nil {
-		encryptionKey = strings.TrimSpace(string(data))
-	}
-	if encryptionKey == "" {
-		return "", fmt.Errorf("olric-encryption-key missing or empty; refusing to start Olric without memberlist encryption")
-	}
-
 	data := templates.OlricConfigData{
 		ServerBindAddr:          serverBindAddr,
 		HTTPPort:                httpPort,
@@ -460,7 +451,6 @@ func (cg *ConfigGenerator) GenerateOlricConfig(serverBindAddr string, httpPort i
 		MemberlistEnvironment:   memberlistEnv,
 		MemberlistAdvertiseAddr: advertiseAddr,
 		Peers:                   peers,
-		EncryptionKey:           encryptionKey,
 	}
 	return templates.RenderOlricConfig(data)
 }
@@ -582,47 +572,6 @@ func (sg *SecretGenerator) EnsureRQLiteAuth() (string, string, error) {
 	}
 
 	return username, password, nil
-}
-
-// EnsureOlricEncryptionKey gets or generates a 32-byte encryption key for Olric memberlist gossip.
-// The key is stored as base64 on disk and returned as base64 (what Olric expects).
-func (sg *SecretGenerator) EnsureOlricEncryptionKey() (string, error) {
-	secretPath := filepath.Join(sg.oramaDir, "secrets", "olric-encryption-key")
-	secretDir := filepath.Dir(secretPath)
-
-	if err := os.MkdirAll(secretDir, 0700); err != nil {
-		return "", fmt.Errorf("failed to create secrets directory: %w", err)
-	}
-	if err := os.Chmod(secretDir, 0700); err != nil {
-		return "", fmt.Errorf("failed to set secrets directory permissions: %w", err)
-	}
-
-	// Try to read existing key
-	if data, err := os.ReadFile(secretPath); err == nil {
-		key := strings.TrimSpace(string(data))
-		if key != "" {
-			if err := ensureSecretFilePermissions(secretPath); err != nil {
-				return "", err
-			}
-			return key, nil
-		}
-	}
-
-	// Generate new 32-byte key, base64 encoded
-	keyBytes := make([]byte, 32)
-	if _, err := rand.Read(keyBytes); err != nil {
-		return "", fmt.Errorf("failed to generate Olric encryption key: %w", err)
-	}
-	key := base64.StdEncoding.EncodeToString(keyBytes)
-
-	if err := os.WriteFile(secretPath, []byte(key), 0600); err != nil {
-		return "", fmt.Errorf("failed to save Olric encryption key: %w", err)
-	}
-	if err := ensureSecretFilePermissions(secretPath); err != nil {
-		return "", err
-	}
-
-	return key, nil
 }
 
 // EnsureAPIKeyHMACSecret gets or generates the HMAC secret used to hash API keys.

--- a/core/pkg/environments/production/olric_encryption_failclosed_test.go
+++ b/core/pkg/environments/production/olric_encryption_failclosed_test.go
@@ -1,30 +1,18 @@
 package production
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestGenerateOlricConfig_emptyKeyFailsClosed(t *testing.T) {
+func TestGenerateOlricConfig_omitsIgnoredEncryptionKey(t *testing.T) {
 	dir := t.TempDir()
 	cg := NewConfigGenerator(dir)
-	_, err := cg.GenerateOlricConfig("127.0.0.1", 3320, "127.0.0.1", 3322, "local", "", nil)
-	if err == nil {
-		t.Fatal("missing olric-encryption-key must fail closed")
-	}
-	if err := os.MkdirAll(filepath.Join(dir, "secrets"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "secrets", "olric-encryption-key"), []byte("dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdA==\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	out, err := cg.GenerateOlricConfig("127.0.0.1", 3320, "127.0.0.1", 3322, "local", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "encryptionKey:") {
-		t.Fatalf("expected encryptionKey in config, got %q", out)
+	if strings.Contains(out, "encryptionKey") {
+		t.Fatalf("Olric v0.7.0 YAML loader ignores encryptionKey; must not emit it:\n%s", out)
 	}
 }

--- a/core/pkg/environments/production/orchestrator.go
+++ b/core/pkg/environments/production/orchestrator.go
@@ -504,12 +504,6 @@ func (ps *ProductionSetup) Phase3GenerateSecrets() error {
 	}
 	ps.logf("  ✓ RQLite auth credentials ensured")
 
-	// Olric gossip encryption key
-	if _, err := ps.secretGenerator.EnsureOlricEncryptionKey(); err != nil {
-		return fmt.Errorf("failed to ensure Olric encryption key: %w", err)
-	}
-	ps.logf("  ✓ Olric encryption key ensured")
-
 	// API key HMAC secret
 	if _, err := ps.secretGenerator.EnsureAPIKeyHMACSecret(); err != nil {
 		return fmt.Errorf("failed to ensure API key HMAC secret: %w", err)

--- a/core/pkg/environments/production/wireguard.go
+++ b/core/pkg/environments/production/wireguard.go
@@ -138,20 +138,33 @@ func (wp *WireGuardProvisioner) WriteConfig() error {
 	confPath := filepath.Join(wp.configDir, "wg0.conf")
 	content := wp.GenerateConfig()
 
-	// Try direct write first (works when running as root)
 	if err := os.MkdirAll(wp.configDir, 0700); err == nil {
 		if err := os.WriteFile(confPath, []byte(content), 0600); err == nil {
-			return nil
+			return forcePrivateMode(confPath)
 		}
 	}
 
-	// Fallback to tee (for non-root, e.g. orama user)
 	cmd := exec.Command("tee", confPath)
 	cmd.Stdin = strings.NewReader(content)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write wg0.conf via tee: %w\n%s", err, string(output))
 	}
+	return forcePrivateMode(confPath)
+}
 
+// forcePrivateMode chmod 0600 and verifies the result (bugboard #247).
+// os.WriteFile's mode is umask-masked; tee inherits umask (often 0644).
+func forcePrivateMode(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod 0600 %s: %w", path, err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		return fmt.Errorf("%s mode %o, want 0600", path, fi.Mode().Perm())
+	}
 	return nil
 }
 

--- a/core/pkg/environments/production/wireguard_mode_test.go
+++ b/core/pkg/environments/production/wireguard_mode_test.go
@@ -1,0 +1,28 @@
+package production
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteConfig_mode0600(t *testing.T) {
+	dir := t.TempDir()
+	wp := &WireGuardProvisioner{
+		configDir: dir,
+		config: WireGuardConfig{
+			PrivateIP:  "10.0.0.1",
+			PrivateKey: "dGVzdA==",
+		},
+	}
+	if err := wp.WriteConfig(); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "wg0.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("wg0.conf mode %o, want 0600", fi.Mode().Perm())
+	}
+}

--- a/core/pkg/environments/templates/olric.yaml
+++ b/core/pkg/environments/templates/olric.yaml
@@ -15,6 +15,3 @@ memberlist:
     - "{{.}}"
 {{- end}}
 {{- end}}
-{{- if .EncryptionKey}}
-  encryptionKey: "{{.EncryptionKey}}"
-{{- end}}

--- a/core/pkg/environments/templates/render.go
+++ b/core/pkg/environments/templates/render.go
@@ -107,7 +107,6 @@ type OlricConfigData struct {
 	MemberlistEnvironment   string   // "local", "lan", or "wan"
 	MemberlistAdvertiseAddr string   // Advertise address (WG IP) so other nodes can reach us
 	Peers                   []string // Seed peers for memberlist (host:port)
-	EncryptionKey           string   // Base64-encoded 32-byte key for memberlist gossip encryption (empty = no encryption)
 }
 
 // SystemdIPFSData holds parameters for systemd IPFS service rendering

--- a/core/pkg/gateway/handlers/join/handler.go
+++ b/core/pkg/gateway/handlers/join/handler.go
@@ -34,10 +34,12 @@ type JoinResponse struct {
 	WGPeers []WGPeerInfo `json:"wg_peers"`
 
 	// Secrets
-	ClusterSecret      string `json:"cluster_secret"`
-	SwarmKey           string `json:"swarm_key"`
-	APIKeyHMACSecret   string `json:"api_key_hmac_secret,omitempty"`
-	RQLitePassword     string `json:"rqlite_password,omitempty"`
+	ClusterSecret    string `json:"cluster_secret"`
+	SwarmKey         string `json:"swarm_key"`
+	APIKeyHMACSecret string `json:"api_key_hmac_secret,omitempty"`
+	RQLitePassword   string `json:"rqlite_password,omitempty"`
+	// Unused: Olric v0.7.0 YAML loader ignores encryptionKey (bugboard #246).
+	// Kept so older joiners still decode the field.
 	OlricEncryptionKey string `json:"olric_encryption_key,omitempty"`
 	// Serverless secrets encryption key (bugboard #837) — must be identical on
 	// every node so namespace function secrets decrypt cluster-wide.
@@ -200,12 +202,6 @@ func (h *Handler) HandleJoin(w http.ResponseWriter, r *http.Request) {
 		rqlitePassword = strings.TrimSpace(string(data))
 	}
 
-	// Read Olric encryption key (optional — may not exist on older clusters)
-	olricEncryptionKey := ""
-	if data, err := os.ReadFile(h.oramaDir + "/secrets/olric-encryption-key"); err == nil {
-		olricEncryptionKey = strings.TrimSpace(string(data))
-	}
-
 	// Read serverless secrets encryption key (optional — may not exist on
 	// older clusters; bugboard #837)
 	secretsEncryptionKey := ""
@@ -290,7 +286,6 @@ func (h *Handler) HandleJoin(w http.ResponseWriter, r *http.Request) {
 		SwarmKey:             strings.TrimSpace(string(swarmKey)),
 		APIKeyHMACSecret:     apiKeyHMACSecret,
 		RQLitePassword:       rqlitePassword,
-		OlricEncryptionKey:   olricEncryptionKey,
 		SecretsEncryptionKey: secretsEncryptionKey,
 		TURNSecret:           turnSecret,
 		RQLiteJoinAddress:    fmt.Sprintf("%s:7001", myWGIP),
@@ -427,6 +422,18 @@ func (h *Handler) addWGPeerLocally(pubKey, publicIP, wgIP string) error {
 	writeCmd.Stdin = strings.NewReader(newConf)
 	if output, err := writeCmd.CombinedOutput(); err != nil {
 		h.logger.Warn("could not persist peer to wg0.conf", zap.Error(err), zap.String("output", string(output)))
+		return nil
+	}
+	if err := os.Chmod(confPath, 0o600); err != nil {
+		h.logger.Warn("could not chmod wg0.conf 0600 after tee", zap.Error(err))
+		return nil
+	}
+	fi, err := os.Stat(confPath)
+	if err != nil {
+		return nil
+	}
+	if fi.Mode().Perm() != 0o600 {
+		h.logger.Warn("wg0.conf mode not 0600 after chmod", zap.String("mode", fi.Mode().Perm().String()))
 	}
 
 	return nil

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ All inter-node communication is encrypted via a WireGuard VPN mesh:
 ### Service Authentication
 
 - **RQLite:** credentials are generated at genesis; `rqlited` is **not** started with `-auth` today. Overlay + firewall keep the HTTP API off the public internet
-- **Olric:** Memberlist gossip encrypted with a shared 32-byte key
+- **Olric:** memberlist binds the WireGuard address. Olric v0.7.0 YAML has no `encryptionKey`; overlay is the control
 - **IPFS Cluster:** TrustedPeers restricted to known cluster peer IDs (not `*`). The systemd unit is not written if `CLUSTER_SECRET` is missing or empty
 - **Internal endpoints:** `/v1/internal/wg/peers` and `/v1/internal/wg/peer/remove` require cluster secret
 - **Vault:** V1 push/pull endpoints require session token authentication when guardian is configured
@@ -408,7 +408,8 @@ All inter-node communication is encrypted via a WireGuard VPN mesh:
 - **WASM memory:** wazero `WithMemoryLimitPages` from `MaxMemoryLimitMB` (default 256 MB). Modules without a memory max still cannot grow past that
 - **WASM concurrency:** process-wide semaphore plus a per-namespace cap (`maxConcurrent/2`, min 1)
 - **Process uid:** namespace gateway/rqlite/olric/sfu/turn/pubsub run as `User=orama` (not root). `/opt/orama/bin` is `root:orama` 0750. CoreDNS/Caddy `ReadWritePaths` do not include `secrets/`
-- **TLS:** internet-facing TLS is 1.2+ (`TCPSNIGateway`, CLI, tlsutil). Olric memberlist encryption is required at config render (missing key is a startup error, not cleartext)
+- **TLS:** internet-facing TLS is 1.2+ (`TCPSNIGateway`, CLI, tlsutil)
+- **wg0.conf:** written 0600 (chmod after WriteFile/tee; umask is not trusted)
 
 ### Token & Key Security
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,10 +29,9 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - What keeps the RQLite API off the public internet is the firewall / WireGuard overlay, not RQLite HTTP auth
 
 **Olric Gossip Encryption (Step 1.8)**
-- Olric memberlist uses a 32-byte encryption key for all gossip traffic
-- Key generated at genesis, distributed via join response
-- Prevents rogue nodes from joining the gossip ring and poisoning caches
-- Note: encryption is all-or-nothing (coordinated restart required when enabling)
+- Olric v0.7.0's YAML loader has **no** `encryptionKey` field; a generated key was shipped and silently dropped
+- That plumbing is removed. Memberlist confidentiality is the WireGuard overlay (`10.0.0.x`), not Olric AES-GCM
+- Wiring `MemberlistConfig.SecretKey` would require embedding Olric, not a YAML field
 
 **IPFS Cluster TrustedPeers (Step 1.9)**
 - IPFS Cluster `TrustedPeers` populated with actual cluster peer IDs (was `["*"]`)
@@ -84,7 +83,7 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - Production CLI and `tlsutil.NewHTTPClientForDomain` do **not** set `InsecureSkipVerify` — public Caddy certs verify against system CAs
 - `TCPSNIGateway` sets `MinVersion: TLS 1.2`
 - Certificate serials are 128-bit `crypto/rand` values
-- Olric config generation refuses an empty `olric-encryption-key` (no cleartext memberlist)
+- wg0.conf is chmod 0600 after write (WriteFile and tee); umask is not trusted
 
 **WebSocket Origin Validation (Step 1.4)**
 - All WebSocket upgraders validate the `Origin` header against the node's configured domain
@@ -186,6 +185,8 @@ Stated so the gaps above are known positions, not implied protections:
 - **ntfy** — no auth-file in v1; listen-localhost is the control
 - **A captured disk snapshot of RQLite** — plaintext application data, including `deployment_env_vars`
 - **Immediate erase of deleted rows** — a SQL `DELETE` is a Raft log entry; the original INSERT remains in `raft.db` until size-driven compaction, not a privacy TTL
+- **Olric memberlist AES-GCM** — v0.7.0 YAML has no `encryptionKey`; WireGuard is the control
+- **WireGuard key rotation** — none; `wg0.conf` is 0600. Rotation would be a rolling mesh with a health gate
 
 ## Rollout Strategy
 


### PR DESCRIPTION
## Summary

CHG-245 on top of #111. Drop a config field Olric v0.7.0 ignores; lock down wg0.conf mode. Not a VERSION bump.

Merge order: **#101 → #102 → #103 → #104 → #105 → #106 → #107 → #108 → #109 → #110 → #111 → this**.

## What landed

| Bug | Change |
|---|---|
| **#246** | Stop generating/shipping/rendering Olric `encryptionKey`. v0.7.0 YAML loader has no such field. WireGuard is the memberlist control. |
| **#247** | `chmod 0600` + verify after WriteFile and tee on `wg0.conf`. Join peer persist too. |

## Skipped (comment on Bugboard)

| Item | Why |
|---|---|
| **#247 rotation** | Rolling WG key rotation with a health gate is a mesh-wide protocol. |
| **#247 stdin key** | Would drop wg-quick PostUp INPUT ACCEPT (UFW conntrack). |
| **#246 embed Olric** | SecretKey is not in the YAML loader; embedding is architecture. |

## Test plan

- [x] Focused tests + pre-push `go test ./...`
- [ ] Human review