### PR TITLE
feat(auth): attribute requests to a device, not only to an account (feat-384)

### DIFF
--- a/core/migrations/036_device_bindings.sql
+++ b/core/migrations/036_device_bindings.sql
@@ -1,0 +1,69 @@
+-- 036_device_bindings.sql
+--
+-- Device attribution (bugboard feat-384).
+--
+-- A serverless function could previously learn only WHICH ACCOUNT was calling:
+-- every device of an account produced an identical JWT subject. That is enough
+-- for delivery (the app controls fan-out) but not for retrieval, which is
+-- authenticated per account — anyone holding the account seed could call the
+-- history endpoints as the account without being a current device.
+--
+-- The gateway now binds a device public key to a login when the client presents
+-- a device assertion, and stamps an unforgeable device claim into the JWT.
+--
+-- first_seen_at is the load-bearing column. The product rule it supports is "a
+-- device added to an account syncs forward and never receives the archive",
+-- which is meant to bound the damage of a stolen recovery phrase. An app's own
+-- device roster CANNOT bound that case when the roster is signed by a key
+-- derived from the seed: an attacker holding the seed signs a roster backdating
+-- their device to genesis and pulls everything. A gateway-observed first-seen is
+-- the one timestamp such an attacker cannot move, because it records when THIS
+-- server first saw the key — not what a signed document claims.
+--
+-- Named with the orama_ prefix deliberately. These migrations also run inside
+-- each tenant's namespace RQLite, and "device_bindings" is exactly the table a
+-- device-roster app would create for itself; an unprefixed name would let a
+-- pre-existing tenant table win CREATE TABLE IF NOT EXISTS and silently break
+-- every device login. Follows the orama_schema_migrations precedent.
+--
+-- The gateway deliberately stores no notion of a roster or of device
+-- authorization. It asserts possession ("this key signed this login"); the
+-- namespace's own function decides whether that device is currently allowed.
+CREATE TABLE IF NOT EXISTS orama_device_bindings (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    namespace_id  INTEGER NOT NULL,
+    -- subject is the account identity the device authenticated as: the same
+    -- value that lands in the JWT `sub`.
+    subject       TEXT NOT NULL,
+    -- device_fp is the fingerprint the JWT carries and functions compare
+    -- against their roster. Derived from public_key, never client-supplied.
+    device_fp     TEXT NOT NULL,
+    -- public_key is the raw device key (base64), kept so a binding can be
+    -- re-verified and so an operator can audit what was bound.
+    public_key    TEXT NOT NULL,
+    -- first_seen_at is set once, on the first successful assertion, and is
+    -- never updated afterwards. See the note above: its value is that nothing
+    -- the client controls can move it backwards.
+    first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- revoked_at is set by the namespace when it removes the device. A revoked
+    -- binding stops minting device claims AND its refresh tokens are revoked,
+    -- so the device is out within one access-token TTL rather than riding the
+    -- 30-day refresh chain.
+    revoked_at    TIMESTAMP,
+    UNIQUE(namespace_id, subject, device_fp),
+    FOREIGN KEY(namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_orama_device_bindings_subject
+    ON orama_device_bindings(namespace_id, subject);
+
+-- Binds a refresh token to the device that obtained it.
+--
+-- Without this the device claim would ride the refresh chain for the refresh
+-- token's full 30-day life: revoking a device would stop new logins but the
+-- already-issued chain would keep minting fresh, validly-signed, device-stamped
+-- access tokens. Revocation targets these rows, which is what makes "a revoked
+-- device stops being served" true within one 15-minute access token rather than
+-- in 30 days. NULL = a login that presented no device assertion.
+ALTER TABLE refresh_tokens ADD COLUMN device_fp TEXT;

--- a/core/pkg/gateway/auth/device.go
+++ b/core/pkg/gateway/auth/device.go
@@ -1,0 +1,462 @@
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DeBrosOfficial/network/pkg/client"
+	"github.com/DeBrosOfficial/network/pkg/logging"
+	"go.uber.org/zap"
+)
+
+// Device attribution (bugboard feat-384).
+//
+// A function could previously learn only which ACCOUNT was calling: every
+// device of an account produced an identical JWT subject. Retrieval endpoints
+// are authenticated per account, so anyone holding the account seed could call
+// them without being a current device of that account.
+//
+// The split of responsibility here is deliberate and is the whole design:
+//
+//   - The GATEWAY asserts POSSESSION — "the holder of device key X was present
+//     at this login" — a cryptographic fact it can verify by itself.
+//   - The NAMESPACE asserts AUTHORIZATION — "X is a current device of this
+//     account" — policy only the app can know.
+//
+// The gateway therefore stores no roster and has no opinion about which devices
+// an account may have. Teaching it otherwise would put a per-request WASM call
+// into the auth path (fail-open, 2s timeout, 3 attempts — every property you do
+// not want on an authorization check) and couple the platform to one tenant's
+// data model.
+
+const (
+	// DeviceClaimFingerprint is the JWT claim carrying the verified device
+	// fingerprint. Functions read it with the `get_caller_claim` host call.
+	DeviceClaimFingerprint = "device_fp"
+
+	// DeviceClaimSince is the JWT claim carrying the gateway's first-seen time
+	// for this (account, device) pair, as Unix seconds.
+	//
+	// This is the claim that makes "a new device never receives the archive"
+	// actually hold. An app's signed device roster cannot establish it against
+	// the threat the rule exists for: if the roster is signed by a key derived
+	// from the account seed, an attacker holding that seed backdates their
+	// device and claims the whole history. The gateway's observation is not
+	// something that attacker can move.
+	DeviceClaimSince = "device_since"
+
+	// deviceAssertionPrefix is prepended to the login challenge before the
+	// device signs it, so a device signature can never be replayed as an
+	// account signature (or vice versa) over the same bytes. Domain separation.
+	deviceAssertionPrefix = "orama-device-assertion:v1:"
+
+	// deviceFingerprintBytes is how much of the SHA-256 of the public key forms
+	// the fingerprint. 16 bytes / 128 bits leaves no practical margin for a
+	// targeted collision, which matters because the fingerprint is the identity
+	// a function authorizes against.
+	deviceFingerprintBytes = 16
+)
+
+// ethAddressPattern matches a 20-byte hex ETH address in any casing.
+var ethAddressPattern = regexp.MustCompile(`^0[xX][0-9a-fA-F]{40}$`)
+
+// ErrDeviceBindTransient marks a device-binding failure caused by
+// infrastructure rather than by the caller's credentials.
+//
+// The distinction is the bugboard #125 lesson applied here: during a leader
+// re-election in a rolling upgrade, an rqlite error is not "your signature is
+// wrong". Collapsing it into 401 makes every device login look like rejected
+// credentials, and clients respond to 401 by tearing down the session and
+// re-running SIWE — a reconnect storm precisely when the cluster is already
+// struggling. Callers must surface this as a retryable 503.
+var ErrDeviceBindTransient = fmt.Errorf("device binding temporarily unavailable")
+
+// DeviceBinding is a verified device identity bound to one account.
+type DeviceBinding struct {
+	// Fingerprint is the value stamped into the JWT and compared by functions.
+	Fingerprint string
+	// PublicKey is the raw ed25519 device key, base64 standard encoding.
+	PublicKey string
+	// FirstSeen is when THIS gateway first observed this key for this account.
+	FirstSeen time.Time
+}
+
+// DeviceFingerprint derives the stable fingerprint of a device public key.
+//
+// Derived, never client-supplied: a client that could choose its own
+// fingerprint could claim another device's identity while still proving
+// possession of its own key.
+func DeviceFingerprint(publicKey ed25519.PublicKey) string {
+	sum := sha256.Sum256(publicKey)
+	return hex.EncodeToString(sum[:deviceFingerprintBytes])
+}
+
+// VerifyDeviceAssertion checks that the holder of publicKeyB64 signed the login
+// challenge, and returns the device fingerprint.
+//
+// challenge is the same value the account signed. Binding both signatures to
+// one challenge is what ties "this account authenticated" and "this device was
+// present" into a single event — two independently-replayable signatures over
+// different material would not.
+func VerifyDeviceAssertion(challenge, publicKeyB64, signatureB64 string) (string, error) {
+	pub, err := decodeDeviceKey(publicKeyB64)
+	if err != nil {
+		return "", err
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(signatureB64))
+	if err != nil {
+		return "", fmt.Errorf("device_signature is not valid base64")
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return "", fmt.Errorf("device_signature must be %d bytes, got %d", ed25519.SignatureSize, len(sig))
+	}
+	if strings.TrimSpace(challenge) == "" {
+		return "", fmt.Errorf("cannot verify a device assertion against an empty challenge")
+	}
+
+	if !ed25519.Verify(pub, deviceAssertionMessage(challenge), sig) {
+		return "", fmt.Errorf("device signature does not verify against the login challenge")
+	}
+	return DeviceFingerprint(pub), nil
+}
+
+// deviceAssertionMessage is the exact byte string a device signs.
+func deviceAssertionMessage(challenge string) []byte {
+	return []byte(deviceAssertionPrefix + challenge)
+}
+
+// DeviceAssertionMessage exposes the signing input so clients and tests build
+// the identical bytes. Publishing this is what keeps the client and the server
+// from drifting into two subtly different messages.
+func DeviceAssertionMessage(challenge string) []byte {
+	return deviceAssertionMessage(challenge)
+}
+
+// decodeDeviceKey parses and validates a base64 ed25519 public key.
+func decodeDeviceKey(publicKeyB64 string) (ed25519.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(publicKeyB64))
+	if err != nil {
+		return nil, fmt.Errorf("device_public_key is not valid base64")
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("device_public_key must be %d bytes, got %d", ed25519.PublicKeySize, len(raw))
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// BindDevice records a verified device for an account and returns the binding.
+//
+// The first successful assertion sets first_seen_at; every later one only moves
+// last_seen_at. That asymmetry is the point — see DeviceClaimSince.
+//
+// A revoked binding is NOT silently resurrected: it returns an error, so a
+// device the namespace removed cannot log back in and re-acquire its claim.
+// Un-revoking is the namespace's decision, made through its own flow, not a
+// side effect of the removed device trying again.
+func (s *Service) BindDevice(ctx context.Context, namespace, subject, publicKeyB64, fingerprint string) (*DeviceBinding, error) {
+	subject = normalizeDeviceSubject(subject)
+	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("%w: resolve namespace %s: %v", ErrDeviceBindTransient, namespace, err)
+	}
+	internalCtx := client.WithInternalAuth(ctx)
+	db := s.orm.Database()
+	now := time.Now().UTC()
+
+	// Insert-if-absent, then read back. The read is authoritative for
+	// first_seen_at: on a returning device the INSERT is a no-op and the stored
+	// (older) timestamp is what the claim must carry.
+	if _, err := db.Query(internalCtx,
+		`INSERT OR IGNORE INTO orama_device_bindings
+		   (namespace_id, subject, device_fp, public_key, first_seen_at, last_seen_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		nsID, subject, fingerprint, publicKeyB64, now, now); err != nil {
+		return nil, fmt.Errorf("%w: record device binding: %v", ErrDeviceBindTransient, err)
+	}
+
+	res, err := db.Query(internalCtx,
+		`SELECT public_key, first_seen_at, revoked_at FROM orama_device_bindings
+		  WHERE namespace_id = ? AND subject = ? AND device_fp = ?`,
+		nsID, subject, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read device binding: %v", ErrDeviceBindTransient, err)
+	}
+	if res == nil || res.Count == 0 || len(res.Rows) == 0 {
+		return nil, fmt.Errorf("device binding vanished immediately after insert (namespace %s)", namespace)
+	}
+	row := res.Rows[0]
+	if len(row) < 3 {
+		return nil, fmt.Errorf("device binding row has %d columns, want 3", len(row))
+	}
+	if row[2] != nil && fmt.Sprint(row[2]) != "" {
+		return nil, fmt.Errorf("device %s is revoked for this account", fingerprint)
+	}
+
+	// Fail CLOSED here: an unestablishable first-seen becomes "now", the newest
+	// possible value, so the device gets the least archive access rather than
+	// the most.
+	firstSeen, ok := parseDeviceTime(row[1])
+	if !ok {
+		firstSeen = now
+	}
+
+	if _, err := db.Query(internalCtx,
+		`UPDATE orama_device_bindings SET last_seen_at = ?
+		  WHERE namespace_id = ? AND subject = ? AND device_fp = ?`,
+		now, nsID, subject, fingerprint); err != nil {
+		// Non-fatal: last_seen is observability, not authorization. Losing the
+		// update must never fail a login that is otherwise fully verified.
+		s.logger.ComponentWarn(logging.ComponentGeneral, "failed to update device last_seen_at",
+			zap.String("namespace", namespace), zap.String("device_fp", fingerprint), zap.Error(err))
+	}
+
+	return &DeviceBinding{
+		Fingerprint: fingerprint,
+		PublicKey:   fmt.Sprint(row[0]),
+		FirstSeen:   firstSeen,
+	}, nil
+}
+
+// ErrDeviceNotFound means no binding matched and no token was revoked — the
+// revocation did nothing at all.
+//
+// Surfaced rather than reported as success because the realistic ways to hit it
+// are all silent misses an operator must see: a subject in the wrong casing or
+// form, a fingerprint that never existed, or the call sent to a gateway whose
+// RQLite does not hold that binding. A security control that answers 200 while
+// changing nothing is worse than one that errors.
+var ErrDeviceNotFound = fmt.Errorf("no device binding or bound refresh token matched")
+
+// RevokeDevice marks a device binding revoked and revokes every refresh token
+// obtained by that device.
+//
+// Both halves are required. Marking the binding alone stops future logins but
+// leaves the existing refresh chain minting valid device-stamped tokens for its
+// full 30-day life; revoking the refresh rows is what bounds a revoked device
+// to one access-token TTL. Returns the number of refresh tokens revoked.
+func (s *Service) RevokeDevice(ctx context.Context, namespace, subject, fingerprint string) (int64, error) {
+	// s.db is wired conditionally (SetRqliteClient), and this path needs it for
+	// RowsAffected. RefreshToken guards it the same way rather than panicking
+	// inside an HTTP handler.
+	if s.db == nil {
+		return 0, fmt.Errorf("device revocation requires the rqlite client, which is not configured")
+	}
+	subject = normalizeDeviceSubject(subject)
+	nsID, err := s.ResolveNamespaceID(ctx, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("resolve namespace %s: %w", namespace, err)
+	}
+	internalCtx := client.WithInternalAuth(ctx)
+	now := time.Now().UTC()
+
+	// s.db (not s.orm) is the lower-level rqlite client: it is the one that
+	// exposes RowsAffected, which this path needs to tell "revoked something"
+	// from "matched nothing".
+	res, err := s.db.Exec(internalCtx,
+		`UPDATE orama_device_bindings SET revoked_at = ?
+		  WHERE namespace_id = ? AND subject = ? AND device_fp = ? AND revoked_at IS NULL`,
+		now, nsID, subject, fingerprint)
+	if err != nil {
+		return 0, fmt.Errorf("revoke device binding: %w", err)
+	}
+	bindingsRevoked, _ := res.RowsAffected()
+	if bindingsRevoked == 0 {
+		// Either unknown or already revoked. Still fall through to the token
+		// revocation below: an earlier partial failure could have left the
+		// binding revoked with live tokens, and this call must converge on
+		// "this device holds nothing".
+		s.logger.ComponentWarn(logging.ComponentGeneral,
+			"device revoke matched no live binding; revoking any bound refresh tokens anyway",
+			zap.String("namespace", namespace), zap.String("device_fp", fingerprint))
+	}
+
+	// grace_used_at is burned alongside revoked_at, exactly as RevokeToken does
+	// for logout. Without it the reuse grace (bugboard #125) would still accept
+	// the revoked device's token once more within the grace window, handing it a
+	// fresh 30-day chain — this call must converge on "this device holds
+	// nothing", not "nothing new".
+	tokRes, err := s.db.Exec(internalCtx,
+		`UPDATE refresh_tokens SET revoked_at = ?, grace_used_at = ?
+		  WHERE namespace_id = ? AND subject = ? AND device_fp = ? AND revoked_at IS NULL`,
+		now, now, nsID, subject, fingerprint)
+	if err != nil {
+		return 0, fmt.Errorf("revoke refresh tokens for device %s: %w", fingerprint, err)
+	}
+	revoked, _ := tokRes.RowsAffected()
+	if bindingsRevoked == 0 && revoked == 0 {
+		// Nothing matched anywhere. Do not let the caller believe a device was
+		// stopped when none was found.
+		return 0, ErrDeviceNotFound
+	}
+	return revoked, nil
+}
+
+// deviceClaims renders a binding as the gateway-owned JWT claims.
+//
+// Kept separate from the namespace claims provider's output on purpose: these
+// are stamped by the gateway after the provider runs, and the keys are reserved
+// so a provider can never inject or overwrite them.
+func deviceClaims(b *DeviceBinding) map[string]string {
+	if b == nil {
+		return nil
+	}
+	return map[string]string{
+		DeviceClaimFingerprint: b.Fingerprint,
+		DeviceClaimSince:       fmt.Sprint(b.FirstSeen.UTC().Unix()),
+	}
+}
+
+// parseDeviceTime coerces a stored timestamp into a time.Time, reporting
+// whether it could be established at all.
+//
+// It returns ok=false rather than a fallback because the two call sites need
+// OPPOSITE failure behaviour, and a shared silent default gave the refresh path
+// the dangerous one: time.Time{}.Unix() is -62135596800, so an unparseable
+// timestamp minted device_since = year 1 — older than every message, which
+// under "a new device never receives the archive" grants the whole archive.
+// That is maximally fail-open on the single rule this feature exists to
+// enforce. Callers now decide explicitly.
+func parseDeviceTime(v any) (time.Time, bool) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, true
+	case string:
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999 -0700 MST", "2006-01-02 15:04:05"} {
+			if parsed, err := time.Parse(layout, t); err == nil {
+				return parsed, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// normalizeDeviceSubject canonicalises the account identifier used for device
+// bindings.
+//
+// ETH addresses are hex and the signature check is case-insensitive
+// (verifyEthSignature compares recovered addresses without regard to case), so
+// a client may present any casing and still authenticate. Without
+// normalisation, a REVOKED device simply logs back in with different casing:
+// the UNIQUE(namespace_id, subject, device_fp) constraint does not collide, a
+// fresh un-revoked row is created, and revocation is defeated. It would also
+// silently reset first_seen_at, handing a device archive access it had lost.
+//
+// Only ETH is folded. Solana addresses are base58 and case is significant
+// there, so lowercasing them would merge genuinely distinct accounts.
+func normalizeDeviceSubject(subject string) string {
+	s := strings.TrimSpace(subject)
+	if ethAddressPattern.MatchString(s) {
+		return strings.ToLower(s)
+	}
+	return s
+}
+
+// withDeviceClaims returns custom with the gateway-owned device claims added.
+//
+// Always returns a fresh map when a device is present, so the caller's map (the
+// one that gets stored on the refresh token) is never mutated to include them.
+func withDeviceClaims(custom map[string]string, device *DeviceBinding) map[string]string {
+	dc := deviceClaims(device)
+	if len(dc) == 0 {
+		return custom
+	}
+	out := make(map[string]string, len(custom)+len(dc))
+	for k, v := range custom {
+		out[k] = v
+	}
+	// Device claims win: their keys are gateway-reserved, so a namespace
+	// provider cannot have set them, but overwriting rather than skipping means
+	// a future provider bug cannot shadow a verified device either.
+	for k, v := range dc {
+		out[k] = v
+	}
+	return out
+}
+
+// stripDeviceClaims returns custom without the gateway-owned device claims.
+//
+// Used before persisting claims on a refresh token: those stored claims feed
+// reuseLastKnownClaims, which is wallet-scoped and would otherwise replay one
+// device's identity into another device's login.
+func stripDeviceClaims(custom map[string]string) map[string]string {
+	if len(custom) == 0 {
+		return custom
+	}
+	out := make(map[string]string, len(custom))
+	for k, v := range custom {
+		if k == DeviceClaimFingerprint || k == DeviceClaimSince {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// deviceFingerprintOf renders a binding's fingerprint for the refresh_tokens
+// column, mapping a nil binding to NULL.
+func deviceFingerprintOf(device *DeviceBinding) any {
+	if device == nil {
+		return nil
+	}
+	return nullableFingerprint(device.Fingerprint)
+}
+
+// nullableFingerprint renders a fingerprint for the refresh_tokens column,
+// mapping "" to NULL. See deviceFingerprintOf for why the distinction matters.
+func nullableFingerprint(fp string) any {
+	if fp == "" {
+		return nil
+	}
+	return fp
+}
+
+// liveDeviceBinding returns the binding for a fingerprint, or nil when it is
+// revoked or unknown. An error means the lookup itself failed, which callers
+// must NOT read as "revoked".
+//
+// Takes an already-resolved nsID: the refresh path resolved it several steps
+// earlier, and re-resolving would add a second rqlite round-trip to every
+// device-bound refresh plus an extra transient failure mode that drops the
+// claim for 15 minutes.
+func (s *Service) liveDeviceBinding(ctx context.Context, nsID interface{}, subject, fingerprint string) (*DeviceBinding, error) {
+	subject = normalizeDeviceSubject(subject)
+	res, err := s.orm.Database().Query(client.WithInternalAuth(ctx),
+		`SELECT public_key, first_seen_at FROM orama_device_bindings
+		  WHERE namespace_id = ? AND subject = ? AND device_fp = ? AND revoked_at IS NULL`,
+		nsID, subject, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("read device binding: %w", err)
+	}
+	if res == nil || res.Count == 0 || len(res.Rows) == 0 {
+		// Positive evidence: no live binding. The caller unbinds the chain.
+		return nil, nil
+	}
+	if len(res.Rows[0]) < 2 {
+		// A shape anomaly is NOT evidence of revocation. Returning nil here
+		// would permanently unbind a chain whose device is perfectly valid, so
+		// surface it as an error and let the caller drop only this token's claim.
+		return nil, fmt.Errorf("device binding row has %d columns, want 2", len(res.Rows[0]))
+	}
+	firstSeen, ok := parseDeviceTime(res.Rows[0][1])
+	if !ok {
+		// Same reasoning: cannot establish first-seen, so cannot honestly stamp
+		// device_since. An error drops the claim for this token; it must never
+		// become year 1.
+		return nil, fmt.Errorf("device binding for %s has an unreadable first_seen_at", fingerprint)
+	}
+	return &DeviceBinding{
+		Fingerprint: fingerprint,
+		PublicKey:   fmt.Sprint(res.Rows[0][0]),
+		FirstSeen:   firstSeen,
+	}, nil
+}

--- a/core/pkg/gateway/auth/device_test.go
+++ b/core/pkg/gateway/auth/device_test.go
@@ -1,0 +1,317 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Device attribution (bugboard feat-384).
+//
+// The gateway's job here is narrow and absolute: assert that the holder of a
+// specific device key was present at a specific login, in a way the caller
+// cannot forge. Everything downstream — a function refusing history to a device
+// that joined yesterday, an app revoking a stolen phone — rests on that one
+// assertion being unfakeable. These tests exist to hold it.
+
+func newDeviceKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate device key: %v", err)
+	}
+	return pub, priv, base64.StdEncoding.EncodeToString(pub)
+}
+
+func signAssertion(t *testing.T, priv ed25519.PrivateKey, challenge string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, DeviceAssertionMessage(challenge)))
+}
+
+// The happy path: a device that signs the challenge is identified by a
+// fingerprint derived from its key.
+func TestVerifyDeviceAssertion_acceptsAGenuineAssertion(t *testing.T) {
+	pub, priv, pubB64 := newDeviceKey(t)
+	const challenge = "nonce-abc123"
+
+	fp, err := VerifyDeviceAssertion(challenge, pubB64, signAssertion(t, priv, challenge))
+	if err != nil {
+		t.Fatalf("genuine assertion rejected: %v", err)
+	}
+	if fp != DeviceFingerprint(pub) {
+		t.Errorf("fingerprint = %q, want the derivation of the presented key", fp)
+	}
+}
+
+// The core forgery case: a signature from a DIFFERENT key must not authenticate
+// as this device. Without this the claim is decorative.
+func TestVerifyDeviceAssertion_rejectsAnotherDevicesSignature(t *testing.T) {
+	_, _, victimPubB64 := newDeviceKey(t)
+	_, attackerPriv, _ := newDeviceKey(t)
+	const challenge = "nonce-abc123"
+
+	if _, err := VerifyDeviceAssertion(challenge, victimPubB64, signAssertion(t, attackerPriv, challenge)); err == nil {
+		t.Fatal("a signature made by another key verified as this device — the device claim would be forgeable")
+	}
+}
+
+// A signature over a DIFFERENT challenge must not be replayable into this
+// login. This is what binds the device assertion to one specific login event
+// rather than making it a reusable bearer artifact.
+func TestVerifyDeviceAssertion_rejectsAReplayedSignatureFromAnotherLogin(t *testing.T) {
+	_, priv, pubB64 := newDeviceKey(t)
+	stolen := signAssertion(t, priv, "nonce-from-an-earlier-login")
+
+	if _, err := VerifyDeviceAssertion("nonce-for-this-login", pubB64, stolen); err == nil {
+		t.Fatal("a device assertion from a previous login replayed into a new one")
+	}
+}
+
+// The account signature and the device assertion cover different bytes, so
+// neither can be presented as the other. Domain separation, verified rather
+// than assumed.
+func TestDeviceAssertionMessage_isDomainSeparatedFromTheRawChallenge(t *testing.T) {
+	const challenge = "nonce-abc123"
+	msg := string(DeviceAssertionMessage(challenge))
+
+	if msg == challenge {
+		t.Fatal("the device signs the bare challenge — an account signature could be replayed as a device assertion")
+	}
+	if !strings.HasSuffix(msg, challenge) {
+		t.Errorf("assertion message %q does not bind the challenge", msg)
+	}
+}
+
+// A raw signature over the bare challenge (what a naive client, or an attacker
+// holding only an account signature, would present) must not verify.
+func TestVerifyDeviceAssertion_rejectsASignatureOverTheBareChallenge(t *testing.T) {
+	_, priv, pubB64 := newDeviceKey(t)
+	const challenge = "nonce-abc123"
+	bare := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, []byte(challenge)))
+
+	if _, err := VerifyDeviceAssertion(challenge, pubB64, bare); err == nil {
+		t.Fatal("a signature over the undomain-separated challenge verified")
+	}
+}
+
+// Malformed input is rejected with a clear error rather than panicking or
+// being coerced into a valid-looking result.
+func TestVerifyDeviceAssertion_rejectsMalformedInput(t *testing.T) {
+	_, priv, pubB64 := newDeviceKey(t)
+	const challenge = "nonce-abc123"
+	good := signAssertion(t, priv, challenge)
+
+	for name, tc := range map[string]struct{ pub, sig, challenge string }{
+		"public key not base64": {"not!base64!", good, challenge},
+		"public key wrong size": {base64.StdEncoding.EncodeToString([]byte("short")), good, challenge},
+		"signature not base64":  {pubB64, "not!base64!", challenge},
+		"signature wrong size":  {pubB64, base64.StdEncoding.EncodeToString([]byte("short")), challenge},
+		"empty challenge":       {pubB64, good, ""},
+		"empty public key":      {"", good, challenge},
+		"empty signature":       {pubB64, "", challenge},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := VerifyDeviceAssertion(tc.challenge, tc.pub, tc.sig); err == nil {
+				t.Error("malformed device assertion accepted")
+			}
+		})
+	}
+}
+
+// Distinct keys must produce distinct fingerprints, and the same key the same
+// one — the fingerprint IS the identity a function authorizes against.
+func TestDeviceFingerprint_isStableAndDistinct(t *testing.T) {
+	pubA, _, _ := newDeviceKey(t)
+	pubB, _, _ := newDeviceKey(t)
+
+	if DeviceFingerprint(pubA) != DeviceFingerprint(pubA) {
+		t.Error("fingerprint is not stable for one key")
+	}
+	if DeviceFingerprint(pubA) == DeviceFingerprint(pubB) {
+		t.Error("two different device keys share a fingerprint")
+	}
+	if got := len(DeviceFingerprint(pubA)); got != deviceFingerprintBytes*2 {
+		t.Errorf("fingerprint is %d hex chars, want %d", got, deviceFingerprintBytes*2)
+	}
+}
+
+// --- claim plumbing -------------------------------------------------------
+
+// The device claims must never be persisted onto the refresh token.
+//
+// This is the cross-device forgery guard. reuseLastKnownClaims replays the most
+// recent stored claims for a WALLET, with no device dimension — so a stored
+// device claim would be replayed into a different device's login during a
+// claims-provider hiccup, producing a correctly-signed token attributing device
+// B's request to device A.
+func TestStripDeviceClaims_removesOnlyTheDeviceClaims(t *testing.T) {
+	in := map[string]string{
+		"account_id":           "acct-1",
+		"tier":                 "pro",
+		DeviceClaimFingerprint: "fp-1",
+		DeviceClaimSince:       "1700000000",
+	}
+
+	out := stripDeviceClaims(in)
+
+	if _, ok := out[DeviceClaimFingerprint]; ok {
+		t.Error("device fingerprint would be stored on the refresh token and replayed to another device")
+	}
+	if _, ok := out[DeviceClaimSince]; ok {
+		t.Error("device_since would be stored on the refresh token")
+	}
+	if out["account_id"] != "acct-1" || out["tier"] != "pro" {
+		t.Errorf("stripping device claims disturbed the namespace's own claims: %v", out)
+	}
+	if _, ok := in[DeviceClaimFingerprint]; !ok {
+		t.Error("stripDeviceClaims mutated its input")
+	}
+}
+
+// A claim set that was only device claims becomes nil, not an empty map that
+// would marshal to a misleading "{}" on the refresh row.
+func TestStripDeviceClaims_deviceOnlyBecomesNil(t *testing.T) {
+	if out := stripDeviceClaims(map[string]string{DeviceClaimFingerprint: "fp-1"}); out != nil {
+		t.Errorf("got %v, want nil", out)
+	}
+}
+
+func TestWithDeviceClaims_stampsFingerprintAndFirstSeen(t *testing.T) {
+	first := time.Unix(1700000000, 0).UTC()
+	out := withDeviceClaims(map[string]string{"account_id": "acct-1"},
+		&DeviceBinding{Fingerprint: "fp-1", FirstSeen: first})
+
+	if out[DeviceClaimFingerprint] != "fp-1" {
+		t.Errorf("device_fp = %q", out[DeviceClaimFingerprint])
+	}
+	if out[DeviceClaimSince] != "1700000000" {
+		t.Errorf("device_since = %q, want the gateway's first-seen unix time", out[DeviceClaimSince])
+	}
+	if out["account_id"] != "acct-1" {
+		t.Error("namespace claims were lost")
+	}
+}
+
+// An account-only login (no assertion) must mint no device claim at all —
+// never an empty one, which a function might read as "device present".
+func TestWithDeviceClaims_nilDeviceAddsNothing(t *testing.T) {
+	in := map[string]string{"account_id": "acct-1"}
+	out := withDeviceClaims(in, nil)
+
+	if _, ok := out[DeviceClaimFingerprint]; ok {
+		t.Error("an account-only login carries a device claim")
+	}
+}
+
+// withDeviceClaims must not mutate the caller's map — that map is what gets
+// persisted to the refresh token, and mutating it would smuggle the device
+// claims into storage despite stripDeviceClaims.
+func TestWithDeviceClaims_doesNotMutateItsInput(t *testing.T) {
+	in := map[string]string{"account_id": "acct-1"}
+	_ = withDeviceClaims(in, &DeviceBinding{Fingerprint: "fp-1", FirstSeen: time.Now()})
+
+	if _, ok := in[DeviceClaimFingerprint]; ok {
+		t.Error("the map destined for the refresh token was mutated to include device claims")
+	}
+}
+
+// "" must become SQL NULL, not an empty string: the revocation UPDATE matches
+// on device_fp, and an empty string would collide with account-only rows.
+func TestNullableFingerprint_emptyIsNull(t *testing.T) {
+	if got := nullableFingerprint(""); got != nil {
+		t.Errorf("got %v, want nil so the column is NULL", got)
+	}
+	if got := nullableFingerprint("fp-1"); got != "fp-1" {
+		t.Errorf("got %v, want the fingerprint", got)
+	}
+}
+
+func TestDeviceFingerprintOf_nilBindingIsNull(t *testing.T) {
+	if got := deviceFingerprintOf(nil); got != nil {
+		t.Errorf("got %v, want nil for an account-only login", got)
+	}
+}
+
+// --- subject normalisation ------------------------------------------------
+
+// The revocation bypass this closes: ETH signature verification is
+// case-insensitive, so a revoked device can present a different casing of the
+// same address. Without normalisation the UNIQUE(namespace_id, subject,
+// device_fp) constraint does not collide, a fresh UN-REVOKED row is created,
+// and the device is fully back — with a reset first_seen_at that also hands it
+// archive access it had lost.
+func TestNormalizeDeviceSubject_foldsEthAddressCasing(t *testing.T) {
+	const checksummed = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01"
+	lower := strings.ToLower(checksummed)
+
+	if normalizeDeviceSubject(checksummed) != normalizeDeviceSubject(lower) {
+		t.Error("two casings of one ETH address normalise differently — a revoked device could re-bind by changing case")
+	}
+	if got := normalizeDeviceSubject(checksummed); got != lower {
+		t.Errorf("got %q, want the lowercase form %q", got, lower)
+	}
+}
+
+// Solana addresses are base58 and case is significant: folding them would merge
+// genuinely distinct accounts into one device namespace.
+func TestNormalizeDeviceSubject_leavesBase58Untouched(t *testing.T) {
+	const sol = "7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK"
+
+	if got := normalizeDeviceSubject(sol); got != sol {
+		t.Errorf("a Solana address was case-folded: %q → %q; distinct accounts would collide", sol, got)
+	}
+}
+
+func TestNormalizeDeviceSubject_trimsWhitespace(t *testing.T) {
+	if got := normalizeDeviceSubject("  0xABCDEF0123456789abcdef0123456789ABCDEF01  "); got != "0xabcdef0123456789abcdef0123456789abcdef01" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --- stored timestamp parsing ---------------------------------------------
+
+// parseDeviceTime must REPORT failure rather than return a zero time.
+//
+// A zero time.Time has Unix() == -62135596800, so a silent fallback minted
+// device_since = year 1 — older than every message, which under "a new device
+// never receives the archive" grants the entire archive. That is the exact
+// inverse of the rule, reached by a driver returning an unexpected layout.
+func TestParseDeviceTime_reportsFailureInsteadOfYearOne(t *testing.T) {
+	for name, in := range map[string]any{
+		"unparseable string": "not-a-timestamp",
+		"nil":                nil,
+		"integer":            12345,
+		"empty string":       "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := parseDeviceTime(in)
+			if ok {
+				t.Fatalf("claimed success for %v", in)
+			}
+			if got.Unix() > 0 {
+				t.Errorf("returned a usable-looking time %v for unparseable input", got)
+			}
+		})
+	}
+}
+
+func TestParseDeviceTime_acceptsTheDriverFormats(t *testing.T) {
+	want := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	for name, in := range map[string]any{
+		"time.Time": want,
+		"RFC3339":   want.Format(time.RFC3339),
+		"sqlite":    want.Format("2006-01-02 15:04:05"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := parseDeviceTime(in)
+			if !ok {
+				t.Fatalf("failed to parse %v", in)
+			}
+			if !got.Equal(want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/core/pkg/gateway/auth/refresh_rotation_test.go
+++ b/core/pkg/gateway/auth/refresh_rotation_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/DeBrosOfficial/network/pkg/client"
 	"github.com/DeBrosOfficial/network/pkg/rqlite"
@@ -32,6 +33,8 @@ type rotationMockORMDB struct {
 	mu             sync.Mutex
 	subjectByToken map[string]string // hashedToken -> subject (nil/missing = "invalid")
 	claimsByToken  map[string]string // hashedToken -> custom_claims JSON (bugboard #548)
+	deviceByToken  map[string]string // hashedToken -> device_fp (feat-384)
+	liveBindings   map[string]bool   // device_fp -> binding exists and is NOT revoked (feat-384)
 	// claimsBySubject: subject -> last-known-good custom_claims JSON. Serves the
 	// lastKnownCustomClaims lookup (bugboard #143): the anti-fragmentation reuse
 	// reads the most recent stored account_id for a wallet at login.
@@ -73,6 +76,20 @@ func (m *rotationMockORMDB) Query(_ context.Context, sql string, args ...interfa
 		}
 		return &client.QueryResult{Count: 0}, nil
 	}
+	// device_bindings lookup (feat-384): the refresh path re-derives the device
+	// claim from a LIVE binding, so the fake must be able to say "revoked or
+	// unknown" as well as "live" — that distinction is what makes revocation
+	// testable at all.
+	if containsCI(sql, "orama_device_bindings") {
+		if len(args) < 3 {
+			return &client.QueryResult{Count: 0}, nil
+		}
+		fp, _ := args[2].(string)
+		if m.liveBindings != nil && m.liveBindings[fp] {
+			return &client.QueryResult{Count: 1, Rows: [][]interface{}{{"pubkey-b64", time.Unix(1700000000, 0).UTC()}}}, nil
+		}
+		return &client.QueryResult{Count: 0}, nil
+	}
 	// Grace-path SELECT (bugboard #125): SELECT subject for a recently-revoked,
 	// grace-available token. Distinguished from the active-path SELECT by the
 	// grace_used_at predicate. Must be checked BEFORE the generic handler.
@@ -86,11 +103,11 @@ func (m *rotationMockORMDB) Query(_ context.Context, sql string, args ...interfa
 			if m.claimsByToken != nil {
 				claims = m.claimsByToken[hashedTok]
 			}
-			return &client.QueryResult{Count: 1, Rows: [][]interface{}{{subj, claims}}}, nil
+			return &client.QueryResult{Count: 1, Rows: [][]interface{}{{subj, claims, m.deviceFor(hashedTok)}}}, nil
 		}
 		return &client.QueryResult{Count: 0}, nil
 	}
-	// SELECT subject (+ custom_claims, bugboard #548) for the lookup.
+	// SELECT subject (+ custom_claims, bugboard #548, + device_fp, feat-384).
 	if containsCI(sql, "SELECT subject") && containsCI(sql, "FROM refresh_tokens") {
 		m.selectAttemptsTaken++
 		if m.selectErrRemaining > 0 {
@@ -106,7 +123,7 @@ func (m *rotationMockORMDB) Query(_ context.Context, sql string, args ...interfa
 			if m.claimsByToken != nil {
 				claims = m.claimsByToken[hashedTok]
 			}
-			return &client.QueryResult{Count: 1, Rows: [][]interface{}{{subj, claims}}}, nil
+			return &client.QueryResult{Count: 1, Rows: [][]interface{}{{subj, claims, m.deviceFor(hashedTok)}}}, nil
 		}
 		return &client.QueryResult{Count: 0}, nil
 	}
@@ -140,18 +157,50 @@ func (m *rotationMockORMDB) Query(_ context.Context, sql string, args ...interfa
 				m.subjectByToken = map[string]string{}
 			}
 			m.subjectByToken[hashedTok] = subj
-			// custom_claims is the LAST arg (bugboard #548) — capture it so
-			// rotation-propagation tests can assert it carries forward.
+			// custom_claims is arg index 4 — (namespace_id, subject, token,
+			// audience, custom_claims, device_fp), with expires_at inlined as
+			// datetime(). Captured by position, NOT as "the last arg": that
+			// assumption silently broke when device_fp was appended for
+			// feat-384, and a positional read fails loudly instead.
 			if m.claimsByToken == nil {
 				m.claimsByToken = map[string]string{}
 			}
-			if cc, ok := args[len(args)-1].(string); ok {
-				m.claimsByToken[hashedTok] = cc
+			if len(args) > refreshInsertCustomClaimsArg {
+				if cc, ok := args[refreshInsertCustomClaimsArg].(string); ok {
+					m.claimsByToken[hashedTok] = cc
+				}
+			}
+			if m.deviceByToken == nil {
+				m.deviceByToken = map[string]string{}
+			}
+			if len(args) > refreshInsertDeviceFPArg {
+				if fp, ok := args[refreshInsertDeviceFPArg].(string); ok {
+					m.deviceByToken[hashedTok] = fp
+				}
 			}
 		}
 		return &client.QueryResult{Count: 1}, nil
 	}
 	return &client.QueryResult{Count: 0}, nil
+}
+
+// refreshInsertCustomClaimsArg / refreshInsertDeviceFPArg are the positions of
+// custom_claims and device_fp in the INSERT INTO refresh_tokens argument list.
+const (
+	refreshInsertCustomClaimsArg = 4
+	refreshInsertDeviceFPArg     = 5
+)
+
+// deviceFor returns the device_fp the fake holds for a token, as the driver
+// would: a real NULL column comes back as nil, not "".
+func (m *rotationMockORMDB) deviceFor(hashedTok string) interface{} {
+	if m.deviceByToken == nil {
+		return nil
+	}
+	if fp, ok := m.deviceByToken[hashedTok]; ok && fp != "" {
+		return fp
+	}
+	return nil
 }
 
 // rotationMockRqlite is the lower-level client used for the CAS UPDATE.
@@ -918,5 +967,120 @@ func TestRevokeToken_burnsGrace_blocksLogoutBypass(t *testing.T) {
 	}
 	if ormDB.inserted != 0 {
 		t.Errorf("no session should be minted for a logged-out token; inserts=%d", ormDB.inserted)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// feat-384 — device attribution across the refresh paths.
+// ----------------------------------------------------------------------------
+
+// A device that recovers through the reuse grace must keep its device binding.
+//
+// The grace path exists for a legitimate client whose rotation response was lost
+// — a VoIP-woken locked device being the motivating case. Its first version
+// selected only (subject, custom_claims), so the recovered session came back
+// with device_fp NULL: the device silently lost its attribution, and every
+// function requiring it would deny the very client the grace window was built to
+// rescue. It failed closed rather than forging, but it broke the feature exactly
+// where it was needed.
+func TestRefreshToken_reuseGrace_preservesTheDeviceBinding(t *testing.T) {
+	s, ormDB, _ := newRotationTestService(t)
+
+	const lostTok = "rotated-but-response-lost"
+	hashed := sha256Hex(lostTok)
+	ormDB.graceableTokens = map[string]string{hashed: "0xWALLET"}
+	ormDB.deviceByToken = map[string]string{hashed: "device-fp-1"}
+	ormDB.liveBindings = map[string]bool{"device-fp-1": true}
+
+	_, newRefresh, _, _, err := s.RefreshToken(context.Background(), lostTok, "anchat-test")
+	if err != nil {
+		t.Fatalf("grace recovery failed: %v", err)
+	}
+
+	if got := ormDB.deviceByToken[sha256Hex(newRefresh)]; got != "device-fp-1" {
+		t.Errorf("device binding lost through the reuse grace: got %q, want device-fp-1", got)
+	}
+}
+
+// An account-only session (no device assertion at login) must keep device_fp
+// NULL through rotation — never "", which would compare equal in the revocation
+// UPDATE and let a device revocation sweep up unrelated account-only chains.
+func TestRefreshToken_accountOnlySessionStaysUnbound(t *testing.T) {
+	s, ormDB, _ := newRotationTestService(t)
+
+	const tok = "account-only-token"
+	ormDB.subjectByToken = map[string]string{sha256Hex(tok): "0xWALLET"}
+
+	_, newRefresh, _, _, err := s.RefreshToken(context.Background(), tok, "anchat-test")
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	if got, ok := ormDB.deviceByToken[sha256Hex(newRefresh)]; ok && got != "" {
+		t.Errorf("an account-only session acquired a device binding: %q", got)
+	}
+}
+
+// The revocation requirement, on the path that actually decides it.
+//
+// A revoked device holds a live refresh chain. It must NOT be able to rotate
+// that chain into a new device-stamped access token — otherwise "a revoked
+// device stops being served" would take the chain's full 30-day life instead of
+// one 15-minute access token. The claim is re-derived from the live binding on
+// every refresh precisely so this fails.
+func TestRefreshToken_revokedDevice_mintsNoDeviceClaim(t *testing.T) {
+	s, ormDB, _ := newRotationTestService(t)
+
+	const tok = "chain-held-by-a-revoked-device"
+	hashed := sha256Hex(tok)
+	ormDB.subjectByToken = map[string]string{hashed: "0xWALLET"}
+	ormDB.deviceByToken = map[string]string{hashed: "device-fp-revoked"}
+	// The binding was revoked: the lookup finds nothing live.
+	ormDB.liveBindings = map[string]bool{}
+
+	access, newRefresh, _, _, err := s.RefreshToken(context.Background(), tok, "anchat-test")
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	claims, err := s.ParseAndVerifyJWT(access)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyJWT: %v", err)
+	}
+	if fp := claims.Custom[DeviceClaimFingerprint]; fp != "" {
+		t.Errorf("a revoked device still received a device claim (%q) — revocation would take 30 days, not 15 minutes", fp)
+	}
+	// And the rotated chain must not carry the binding forward either, or the
+	// next rotation would resurrect it.
+	if got, ok := ormDB.deviceByToken[sha256Hex(newRefresh)]; ok && got != "" {
+		t.Errorf("the revoked device's binding survived rotation: %q", got)
+	}
+}
+
+// The complement: a device that is still current keeps its claim across
+// rotation. Without this the revocation test above would pass trivially on a
+// refresh path that simply never stamps a device claim.
+func TestRefreshToken_liveDevice_keepsItsClaim(t *testing.T) {
+	s, ormDB, _ := newRotationTestService(t)
+
+	const tok = "chain-held-by-a-live-device"
+	hashed := sha256Hex(tok)
+	ormDB.subjectByToken = map[string]string{hashed: "0xWALLET"}
+	ormDB.deviceByToken = map[string]string{hashed: "device-fp-live"}
+	ormDB.liveBindings = map[string]bool{"device-fp-live": true}
+
+	access, _, _, _, err := s.RefreshToken(context.Background(), tok, "anchat-test")
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+	claims, err := s.ParseAndVerifyJWT(access)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyJWT: %v", err)
+	}
+	if claims.Custom[DeviceClaimFingerprint] != "device-fp-live" {
+		t.Errorf("a live device lost its claim on refresh; custom=%v", claims.Custom)
+	}
+	if claims.Custom[DeviceClaimSince] != "1700000000" {
+		t.Errorf("device_since = %q, want the binding's first-seen time", claims.Custom[DeviceClaimSince])
 	}
 }

--- a/core/pkg/gateway/auth/service.go
+++ b/core/pkg/gateway/auth/service.go
@@ -296,8 +296,20 @@ func (s *Service) verifySolSignature(wallet, nonce, signature string) (bool, err
 	return ed25519.Verify(ed25519.PublicKey(pubKeyBytes), message, sig), nil
 }
 
-// IssueTokens generates access and refresh tokens for a verified wallet
+// IssueTokens generates access and refresh tokens for a verified wallet.
 func (s *Service) IssueTokens(ctx context.Context, wallet, namespace string) (string, string, int64, error) {
+	return s.IssueTokensForDevice(ctx, wallet, namespace, nil)
+}
+
+// IssueTokensForDevice is IssueTokens with an optional verified device binding
+// (bugboard feat-384).
+//
+// A nil device is the ordinary account-only login — the CLI, the SDK and any
+// client that presents no device assertion. Those tokens carry no device claim,
+// and a function that requires one must treat its absence as DENY rather than
+// as "legacy client, allow": the whole point is that the claim cannot be
+// omitted by a caller trying to escape the check.
+func (s *Service) IssueTokensForDevice(ctx context.Context, wallet, namespace string, device *DeviceBinding) (string, string, int64, error) {
 	if s.signingKey == nil {
 		return "", "", 0, fmt.Errorf("signing key unavailable")
 	}
@@ -313,6 +325,18 @@ func (s *Service) IssueTokens(ctx context.Context, wallet, namespace string) (st
 	}
 
 	custom = s.reuseLastKnownClaims(ctx, nsID, wallet, namespace, custom)
+
+	// Stamp the device claims LAST, after the namespace provider and after the
+	// last-known-claims fallback (bugboard feat-384).
+	//
+	// The ordering is a security property, not tidiness. reuseLastKnownClaims
+	// replays the most recent stored claims for this WALLET, with no device
+	// dimension — so if device claims were part of that set, a provider hiccup
+	// during device B's login would replay device A's fingerprint into a
+	// correctly-signed token. That is worse than having no claim: a forged
+	// attribution the function has every reason to trust. Stamping afterwards,
+	// from the binding just verified in THIS request, makes that impossible.
+	custom = withDeviceClaims(custom, device)
 
 	// Issue access token (15m)
 	token, expUnix, err := s.GenerateJWT(namespace, wallet, 15*time.Minute, custom)
@@ -330,9 +354,18 @@ func (s *Service) IssueTokens(ctx context.Context, wallet, namespace string) (st
 	internalCtx := client.WithInternalAuth(ctx)
 	db := s.orm.Database()
 	hashedRefresh := sha256Hex(refresh)
+	// Store the refresh token WITHOUT the device claims, and record the device
+	// in its own column instead.
+	//
+	// Two reasons. The stored claims are the input to reuseLastKnownClaims, so
+	// leaving device claims in them would reintroduce the cross-device replay
+	// described above through the back door. And the refresh path must re-derive
+	// the device claim from a LIVE binding each time — a claim frozen into this
+	// row would keep minting for a device the namespace has since revoked, for
+	// the refresh token's full 30-day life.
 	if _, err := db.Query(internalCtx,
-		"INSERT INTO refresh_tokens(namespace_id, subject, token, audience, expires_at, custom_claims) VALUES (?, ?, ?, ?, datetime('now', '+30 days'), ?)",
-		nsID, wallet, hashedRefresh, "gateway", marshalClaims(custom),
+		"INSERT INTO refresh_tokens(namespace_id, subject, token, audience, expires_at, custom_claims, device_fp) VALUES (?, ?, ?, ?, datetime('now', '+30 days'), ?, ?)",
+		nsID, wallet, hashedRefresh, "gateway", marshalClaims(stripDeviceClaims(custom)), deviceFingerprintOf(device),
 	); err != nil {
 		return "", "", 0, fmt.Errorf("failed to store refresh token: %w", err)
 	}
@@ -447,11 +480,14 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 	// retries). An actual empty result (Count == 0) is a real bad/expired
 	// token → "invalid or expired" (→ 401). Collapsing the two used to 401 a
 	// valid session during every restart, defeating the VoIP-wake refresh.
-	selectQ := `SELECT subject, custom_claims FROM refresh_tokens
+	selectQ := `SELECT subject, custom_claims, device_fp FROM refresh_tokens
 	            WHERE namespace_id = ? AND token = ?
 	              AND revoked_at IS NULL
 	              AND (expires_at IS NULL OR expires_at > datetime('now'))
 	            LIMIT 1`
+	// deviceFP is the device that obtained this refresh chain, "" for an
+	// account-only login (feat-384).
+	var deviceFP string
 	var res *client.QueryResult
 	var selErr error
 	for attempt := 0; attempt < refreshSelectRetries; attempt++ {
@@ -481,7 +517,7 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 	graceRecovery := false
 	var custom map[string]string
 	if res.Count == 0 {
-		gSubject, gCustom, gOK, gErr := s.tryRefreshReuseGrace(internalCtx, ormDB, nsID, hashedRefresh)
+		gSubject, gCustom, gDeviceFP, gOK, gErr := s.tryRefreshReuseGrace(internalCtx, ormDB, nsID, hashedRefresh)
 		if gErr != nil {
 			// Transient rqlite error during the grace lookup/claim — retryable,
 			// not a verdict on the token (bugboard #125).
@@ -497,6 +533,7 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 		}
 		subject = gSubject
 		custom = gCustom
+		deviceFP = gDeviceFP
 		graceRecovery = true
 		s.logger.ComponentInfo(logging.ComponentGeneral,
 			"refresh token reuse-grace recovery (lost-response retry, single-use)",
@@ -515,6 +552,12 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 			if len(res.Rows[0]) > 1 {
 				if cc, ok := res.Rows[0][1].(string); ok {
 					customClaimsJSON = cc
+				}
+			}
+			// device_fp (feat-384) — which device obtained this refresh chain.
+			if len(res.Rows[0]) > 2 && res.Rows[0][2] != nil {
+				if fp, ok := res.Rows[0][2].(string); ok {
+					deviceFP = fp
 				}
 			}
 		}
@@ -582,6 +625,39 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 
 	// Step 3: mint the new access JWT, carrying forward the stored custom
 	// claims so a rotated token keeps the same account_id etc. (bugboard #548).
+	//
+	// The device claim is deliberately NOT carried forward from storage — it is
+	// re-derived here from the LIVE binding (feat-384). That re-check is what
+	// makes revocation mean anything: a claim frozen into the refresh row would
+	// keep minting valid device-stamped tokens for the chain's full 30-day life
+	// after the namespace revoked the device. Re-deriving bounds a revoked
+	// device to one access-token TTL.
+	//
+	// A revoked (or vanished) binding drops the claim rather than failing the
+	// refresh: the account is still legitimately authenticated, it simply stops
+	// being able to prove it is that device, and the function's deny-on-absent
+	// rule takes it from there.
+	custom = stripDeviceClaims(custom)
+	if deviceFP != "" {
+		binding, bErr := s.liveDeviceBinding(ctx, nsID, subject, deviceFP)
+		switch {
+		case bErr != nil:
+			// Unknown state, not positive evidence of revocation. Minting the
+			// claim on an unreadable control plane would be the fail-open we
+			// are trying to avoid, so drop it and let the caller re-login.
+			s.logger.ComponentWarn(logging.ComponentGeneral,
+				"device binding lookup failed on refresh; minting without the device claim",
+				zap.String("namespace", namespace), zap.Error(bErr))
+		case binding == nil:
+			s.logger.ComponentInfo(logging.ComponentGeneral,
+				"refresh for a revoked or unknown device; minting without the device claim",
+				zap.String("namespace", namespace), zap.String("device_fp", deviceFP))
+			deviceFP = ""
+		default:
+			custom = withDeviceClaims(custom, binding)
+		}
+	}
+
 	accessToken, expUnix, err = s.GenerateJWT(namespace, subject, 15*time.Minute, custom)
 	if err != nil {
 		return "", "", "", 0, fmt.Errorf("generate access token: %w", err)
@@ -604,8 +680,8 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 	// rather than being propagated forward verbatim. custom_claims is written
 	// ONLY here and in IssueTokens, both from a sanitized map (bugboard #548).
 	if _, err := ormDB.Query(internalCtx,
-		"INSERT INTO refresh_tokens(namespace_id, subject, token, audience, expires_at, custom_claims) VALUES (?, ?, ?, ?, datetime('now', '+30 days'), ?)",
-		nsID, subject, hashedNew, "gateway", marshalClaims(custom)); err != nil {
+		"INSERT INTO refresh_tokens(namespace_id, subject, token, audience, expires_at, custom_claims, device_fp) VALUES (?, ?, ?, ?, datetime('now', '+30 days'), ?, ?)",
+		nsID, subject, hashedNew, "gateway", marshalClaims(stripDeviceClaims(custom)), nullableFingerprint(deviceFP)); err != nil {
 		// The old token is already revoked (step 2). A retryable error here
 		// leaves the client to re-attempt — which will re-auth since the old
 		// token is gone — but that's strictly better than masking a transient
@@ -635,9 +711,14 @@ func (s *Service) RefreshToken(ctx context.Context, refreshToken, namespace stri
 // grace_used_at), so a stolen token cannot be replayed repeatedly; and it never
 // touches the concurrent-rotation replay tripwire, which fires on the active
 // path only.
-func (s *Service) tryRefreshReuseGrace(ctx context.Context, ormDB client.DatabaseClient, nsID interface{}, hashedRefresh string) (subject string, custom map[string]string, ok bool, err error) {
+func (s *Service) tryRefreshReuseGrace(ctx context.Context, ormDB client.DatabaseClient, nsID interface{}, hashedRefresh string) (subject string, custom map[string]string, deviceFP string, ok bool, err error) {
 	graceArg := fmt.Sprintf("-%d seconds", int(refreshReuseGrace.Seconds()))
-	sel := `SELECT subject, custom_claims FROM refresh_tokens
+	// device_fp is selected here too (feat-384). Omitting it would silently
+	// strip device attribution from the recovering client and leave its whole
+	// future chain unattributed — and this path exists precisely for a
+	// legitimate device whose rotation response was lost, so dropping its
+	// device identity breaks the case the grace window was built to rescue.
+	sel := `SELECT subject, custom_claims, device_fp FROM refresh_tokens
 	        WHERE namespace_id = ? AND token = ?
 	          AND revoked_at IS NOT NULL
 	          AND revoked_at > datetime('now', ?)
@@ -646,10 +727,10 @@ func (s *Service) tryRefreshReuseGrace(ctx context.Context, ormDB client.Databas
 	        LIMIT 1`
 	res, qerr := ormDB.Query(ctx, sel, nsID, hashedRefresh, graceArg)
 	if qerr != nil {
-		return "", nil, false, qerr // transient rqlite error → caller 503
+		return "", nil, "", false, qerr // transient rqlite error → caller 503
 	}
 	if res == nil || res.Count == 0 {
-		return "", nil, false, nil // no eligible grace row → caller 401
+		return "", nil, "", false, nil // no eligible grace row → caller 401
 	}
 
 	var customClaimsJSON string
@@ -665,9 +746,14 @@ func (s *Service) tryRefreshReuseGrace(ctx context.Context, ormDB client.Databas
 				customClaimsJSON = cc
 			}
 		}
+		if len(res.Rows[0]) > 2 && res.Rows[0][2] != nil {
+			if fp, fok := res.Rows[0][2].(string); fok {
+				deviceFP = fp
+			}
+		}
 	}
 	if subject == "" {
-		return "", nil, false, nil // defensive: never grace-mint an anonymous session
+		return "", nil, "", false, nil // defensive: never grace-mint an anonymous session
 	}
 
 	// Single-use CAS: claim the grace. Exactly one caller wins; a concurrent
@@ -680,12 +766,12 @@ func (s *Service) tryRefreshReuseGrace(ctx context.Context, ormDB client.Databas
 		   AND revoked_at IS NOT NULL AND revoked_at > datetime('now', ?)`,
 		nsID, hashedRefresh, graceArg)
 	if uerr != nil {
-		return "", nil, false, uerr // transient
+		return "", nil, "", false, uerr // transient
 	}
 	if affected, _ := updRes.RowsAffected(); affected == 0 {
-		return "", nil, false, nil // grace already consumed (concurrent) → caller 401
+		return "", nil, "", false, nil // grace already consumed (concurrent) → caller 401
 	}
-	return subject, unmarshalClaims(customClaimsJSON), true, nil
+	return subject, unmarshalClaims(customClaimsJSON), deviceFP, true, nil
 }
 
 // RevokeToken revokes a specific refresh token or all tokens for a subject

--- a/core/pkg/gateway/claims_provider.go
+++ b/core/pkg/gateway/claims_provider.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DeBrosOfficial/network/pkg/gateway/auth"
 	"github.com/DeBrosOfficial/network/pkg/serverless"
 	"github.com/DeBrosOfficial/network/pkg/serverless/registry"
 	"go.uber.org/zap"
@@ -68,6 +69,13 @@ var reservedClaimKeys = map[string]struct{}{
 	// tenant could mint admin for every end-user's JWT. Only the API-key→JWT
 	// exchange path sets it, and callerScopes only trusts it on an ak_ subject.
 	"scopes": {},
+	// Device attribution (feat-384). These are stamped by the gateway from a
+	// signature it verified itself. A provider that could set them could mint
+	// any device identity for any caller — which is the exact forgery the
+	// feature exists to prevent, handed to the app layer that is supposed to be
+	// the one CHECKING it.
+	auth.DeviceClaimFingerprint: {},
+	auth.DeviceClaimSince:       {},
 }
 
 // claimsInvoker is the narrow invoke seam the claims provider depends on —

--- a/core/pkg/gateway/claims_provider_test.go
+++ b/core/pkg/gateway/claims_provider_test.go
@@ -201,3 +201,24 @@ func itoa(n int) string {
 	}
 	return string(b)
 }
+
+// A namespace claims provider must not be able to mint device claims.
+//
+// The provider is tenant-deployed WASM. If it could set device_fp, the forgery
+// would be handed to the exact layer that is supposed to be CHECKING it — an
+// app compromise would silently become a device-attribution bypass.
+func TestSanitizeProviderClaims_dropsDeviceClaims(t *testing.T) {
+	raw := []byte(`{"device_fp":"forged","device_since":"0","account_id":"acct-1"}`)
+
+	out := sanitizeProviderClaims(raw)
+
+	if _, ok := out["device_fp"]; ok {
+		t.Error("a namespace provider injected device_fp — device attribution would be forgeable by the app itself")
+	}
+	if _, ok := out["device_since"]; ok {
+		t.Error("a namespace provider injected device_since")
+	}
+	if out["account_id"] != "acct-1" {
+		t.Errorf("the provider's own claims were dropped: %v", out)
+	}
+}

--- a/core/pkg/gateway/handlers/auth/device_handler.go
+++ b/core/pkg/gateway/handlers/auth/device_handler.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	authsvc "github.com/DeBrosOfficial/network/pkg/gateway/auth"
+	"github.com/DeBrosOfficial/network/pkg/gateway/ctxkeys"
+	"go.uber.org/zap"
+)
+
+// DeviceRevokeRequest is the body of POST /v1/auth/device/revoke.
+type DeviceRevokeRequest struct {
+	// Subject is the account whose device is being revoked — the JWT `sub`
+	// that device authenticates as.
+	Subject string `json:"subject"`
+	// DeviceFingerprint is the value the gateway stamped as the `device_fp`
+	// claim.
+	DeviceFingerprint string `json:"device_fingerprint"`
+}
+
+// DeviceRevokeResponse reports what the revocation actually did.
+type DeviceRevokeResponse struct {
+	Subject           string `json:"subject"`
+	DeviceFingerprint string `json:"device_fingerprint"`
+	// RefreshTokensRevoked is how many live refresh chains were cut. Returned
+	// because it is the difference between "marked revoked" and "actually
+	// stopped": a device with a live chain keeps minting device-stamped access
+	// tokens until those rows are revoked.
+	RefreshTokensRevoked int64 `json:"refresh_tokens_revoked"`
+}
+
+// DeviceRevokeHandler revokes a device binding and every refresh token that
+// device obtained.
+//
+// POST /v1/auth/device/revoke
+//
+// This is the seam that lets a namespace enforce "a revoked device stops being
+// served" WITHOUT the gateway knowing anything about rosters (bugboard
+// feat-384). The app decides a device is no longer current — that is its
+// policy, from its own signed roster — and tells the gateway, rather than the
+// gateway asking the app on every request. Asking would put a fail-open WASM
+// invoke with a 2s timeout inside the authorization path.
+//
+// After this returns, the device is out within one access-token TTL (15
+// minutes): its chain is dead so it cannot refresh, and its current access
+// token expires on its own.
+//
+// Authorization: namespace-scoped admin credentials, the same gate the other
+// namespace-administrative endpoints use. An end-user JWT must not be able to
+// revoke devices, or a compromised device could revoke the legitimate ones.
+func (h *Handlers) DeviceRevokeHandler(w http.ResponseWriter, r *http.Request) {
+	if h.authService == nil {
+		writeError(w, http.StatusServiceUnavailable, "auth service not initialized")
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	namespace := namespaceFromRequest(r)
+	if namespace == "" {
+		writeError(w, http.StatusUnauthorized, "namespace could not be resolved from credentials")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
+	var req DeviceRevokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	subject := strings.TrimSpace(req.Subject)
+	fingerprint := strings.TrimSpace(req.DeviceFingerprint)
+	if subject == "" || fingerprint == "" {
+		writeError(w, http.StatusBadRequest, "subject and device_fingerprint are required")
+		return
+	}
+
+	revoked, err := h.authService.RevokeDevice(r.Context(), namespace, subject, fingerprint)
+	if err != nil {
+		// 404 when nothing matched: the caller asked to stop a device that is
+		// not there, and must not read that as "stopped".
+		if errors.Is(err, authsvc.ErrDeviceNotFound) {
+			writeError(w, http.StatusNotFound, "no device binding matched that subject and fingerprint")
+			return
+		}
+		// Everything else is infrastructure. The wrapped error carries SQL and
+		// namespace-resolution detail, so log it and return fixed text.
+		if h.logger != nil {
+			h.logger.Warn("device revocation failed",
+				zap.String("namespace", namespace), zap.Error(err))
+		}
+		writeError(w, http.StatusInternalServerError, "device revocation failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, DeviceRevokeResponse{
+		Subject:              subject,
+		DeviceFingerprint:    fingerprint,
+		RefreshTokensRevoked: revoked,
+	})
+}
+
+// namespaceFromRequest resolves the namespace the caller is authorized for.
+//
+// Read from the context the auth middleware populated, never from the request
+// body: a body-supplied namespace would let any authenticated caller revoke
+// devices in someone else's namespace.
+func namespaceFromRequest(r *http.Request) string {
+	if v := r.Context().Value(ctxkeys.NamespaceOverride); v != nil {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}

--- a/core/pkg/gateway/handlers/auth/types.go
+++ b/core/pkg/gateway/handlers/auth/types.go
@@ -14,6 +14,19 @@ type VerifyRequest struct {
 	Signature string `json:"signature"`
 	Namespace string `json:"namespace"`
 	ChainType string `json:"chain_type"`
+
+	// DevicePublicKey / DeviceSignature are the OPTIONAL device assertion
+	// (bugboard feat-384): an ed25519 signature over the same login challenge
+	// the account signed, made with the device's own key. Presenting both binds
+	// the issued token to that device and stamps an unforgeable device claim
+	// the namespace's functions can authorize against.
+	//
+	// Optional by design. The CLI, the SDK and RootWallet-signed operator
+	// logins cannot produce one, and making it mandatory would break every
+	// existing client. A function that REQUIRES device attribution must deny
+	// when the claim is absent — absence is not permission.
+	DevicePublicKey string `json:"device_public_key,omitempty"`
+	DeviceSignature string `json:"device_signature,omitempty"`
 }
 
 // APIKeyRequest is the request body for API key generation

--- a/core/pkg/gateway/handlers/auth/verify_handler.go
+++ b/core/pkg/gateway/handlers/auth/verify_handler.go
@@ -1,10 +1,16 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	authsvc "github.com/DeBrosOfficial/network/pkg/gateway/auth"
+	"go.uber.org/zap"
 )
 
 // VerifyHandler verifies a wallet signature and issues JWT tokens and an API key.
@@ -48,6 +54,20 @@ func (h *Handlers) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 	nsID, _ := h.resolveNamespace(ctx, req.Namespace)
 	h.markNonceUsed(ctx, nsID, strings.ToLower(req.Wallet), req.Nonce)
 
+	// Optional device assertion (bugboard feat-384). Verified against the SAME
+	// challenge the account just signed, so both signatures describe one login
+	// event rather than two independently replayable facts.
+	//
+	// A malformed or non-verifying assertion is a hard 401, never a silent
+	// downgrade to an account-only token: a client that meant to prove a device
+	// and failed must find out, not receive a token that quietly lacks the
+	// claim and get denied later by a function for reasons it cannot see.
+	device, devStatus, devErr := h.bindDeviceIfAsserted(ctx, &req)
+	if devErr != nil {
+		writeError(w, devStatus, devicePublicError(devStatus))
+		return
+	}
+
 	// Check if namespace cluster provisioning is needed (for non-default namespaces)
 	namespace := strings.TrimSpace(req.Namespace)
 	if namespace == "" {
@@ -60,7 +80,7 @@ func (h *Handlers) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 			_ = checkErr // Log but don't fail
 		} else if needsProvisioning || status == "provisioning" {
 			// Issue tokens and API key before returning provisioning status
-			token, refresh, expUnix, tokenErr := h.authService.IssueTokens(ctx, req.Wallet, req.Namespace)
+			token, refresh, expUnix, tokenErr := h.authService.IssueTokensForDevice(ctx, req.Wallet, req.Namespace, device)
 			if tokenErr != nil {
 				writeError(w, http.StatusInternalServerError, tokenErr.Error())
 				return
@@ -112,7 +132,7 @@ func (h *Handlers) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	token, refresh, expUnix, err := h.authService.IssueTokens(ctx, req.Wallet, req.Namespace)
+	token, refresh, expUnix, err := h.authService.IssueTokensForDevice(ctx, req.Wallet, req.Namespace, device)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -135,4 +155,70 @@ func (h *Handlers) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		"nonce":              req.Nonce,
 		"signature_verified": true,
 	})
+}
+
+// bindDeviceIfAsserted verifies an optional device assertion and records the
+// binding, returning nil when the request carried no assertion.
+//
+// Presenting only one of the two fields is rejected rather than ignored: it is
+// always a client bug, and silently treating it as "no device" would hand back
+// a token missing the claim the client believes it just obtained.
+func (h *Handlers) bindDeviceIfAsserted(ctx context.Context, req *VerifyRequest) (*authsvc.DeviceBinding, int, error) {
+	pub := strings.TrimSpace(req.DevicePublicKey)
+	sig := strings.TrimSpace(req.DeviceSignature)
+	if pub == "" && sig == "" {
+		return nil, http.StatusOK, nil
+	}
+	if pub == "" || sig == "" {
+		// A client bug, not a failed authentication: 400 so it is not mistaken
+		// for rejected credentials and retried as a re-login.
+		return nil, http.StatusBadRequest, fmt.Errorf("device_public_key and device_signature must be provided together")
+	}
+
+	fingerprint, err := authsvc.VerifyDeviceAssertion(req.Nonce, pub, sig)
+	if err != nil {
+		return nil, http.StatusUnauthorized, err
+	}
+
+	namespace := strings.TrimSpace(req.Namespace)
+	if namespace == "" {
+		namespace = "default"
+	}
+	binding, err := h.authService.BindDevice(ctx, namespace, req.Wallet, pub, fingerprint)
+	if err != nil {
+		// Infrastructure failure is retryable, not a credential verdict — a
+		// 401 here would send every client into a re-SIWE loop during a leader
+		// re-election (bugboard #125).
+		if errors.Is(err, authsvc.ErrDeviceBindTransient) {
+			h.logDeviceBindFailure(namespace, err)
+			return nil, http.StatusServiceUnavailable, err
+		}
+		h.logDeviceBindFailure(namespace, err)
+		return nil, http.StatusUnauthorized, err
+	}
+	return binding, http.StatusOK, nil
+}
+
+// devicePublicError is the client-facing message for a device-assertion
+// failure. Deliberately fixed text: the wrapped errors carry SQL and
+// namespace-resolution detail, and this endpoint is reachable unauthenticated.
+func devicePublicError(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "device_public_key and device_signature must be provided together"
+	case http.StatusServiceUnavailable:
+		return "device binding temporarily unavailable, retry"
+	default:
+		return "device assertion verification failed"
+	}
+}
+
+// logDeviceBindFailure records the real cause server-side, since the client
+// only receives the generic message above.
+func (h *Handlers) logDeviceBindFailure(namespace string, err error) {
+	if h.logger == nil {
+		return
+	}
+	h.logger.Warn("device binding failed",
+		zap.String("namespace", namespace), zap.Error(err))
 }

--- a/core/pkg/gateway/internal_auth_test.go
+++ b/core/pkg/gateway/internal_auth_test.go
@@ -1,6 +1,8 @@
 package gateway
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"testing"
@@ -191,4 +193,58 @@ func TestStripThenSet_attackerSubReplaced(t *testing.T) {
 			t.Errorf("Sub = %q, want empty (attacker value must not survive API-key auth)", got)
 		}
 	})
+}
+
+// feat-384: gateway-owned claims must not survive the internal-auth hop.
+//
+// A namespace gateway trusts X-Internal-Auth-* headers on a source-IP check
+// covering loopback and the whole WireGuard /8 — and a serverless function can
+// reach a namespace gateway directly via http_fetch. So anything on the mesh,
+// including another tenant, could otherwise assert `device_fp` for any account
+// by forging a header. That is precisely the forgery the device claim exists to
+// prevent, so these keys are stripped here and only ever come from a verified
+// signature.
+func TestClaimsFromInternalAuthHeaders_stripsGatewayOwnedClaims(t *testing.T) {
+	forged, _ := json.Marshal(map[string]string{
+		"device_fp":    "victim-device-fingerprint",
+		"device_since": "0",
+		"scopes":       "admin",
+		"account_id":   "acct-legitimate",
+	})
+
+	h := http.Header{}
+	h.Set(HeaderInternalAuthJWTSub, "0xVICTIM")
+	h.Set(HeaderInternalAuthJWTCustom, base64.StdEncoding.EncodeToString(forged))
+
+	claims := claimsFromInternalAuthHeaders(h, "victim-namespace")
+	if claims == nil {
+		t.Fatal("expected claims for a forwarded subject")
+	}
+
+	for _, forgedKey := range []string{"device_fp", "device_since", "scopes"} {
+		if v, ok := claims.Custom[forgedKey]; ok {
+			t.Errorf("gateway-owned claim %q survived the internal hop as %q — a mesh-local caller could forge it", forgedKey, v)
+		}
+	}
+	// Application claims are untouched: this filter is about gateway-owned
+	// keys, not about distrusting the hop wholesale.
+	if claims.Custom["account_id"] != "acct-legitimate" {
+		t.Errorf("an application claim was dropped: %v", claims.Custom)
+	}
+}
+
+// A header set consisting ONLY of forged gateway claims must yield no custom
+// claims at all, rather than an empty-but-present map that could read as
+// "device attribution was evaluated".
+func TestClaimsFromInternalAuthHeaders_allForgedYieldsNoCustomClaims(t *testing.T) {
+	forged, _ := json.Marshal(map[string]string{"device_fp": "forged"})
+
+	h := http.Header{}
+	h.Set(HeaderInternalAuthJWTSub, "0xVICTIM")
+	h.Set(HeaderInternalAuthJWTCustom, base64.StdEncoding.EncodeToString(forged))
+
+	claims := claimsFromInternalAuthHeaders(h, "ns")
+	if len(claims.Custom) != 0 {
+		t.Errorf("expected no custom claims, got %v", claims.Custom)
+	}
 }

--- a/core/pkg/gateway/middleware.go
+++ b/core/pkg/gateway/middleware.go
@@ -180,9 +180,52 @@ func claimsFromInternalAuthHeaders(h http.Header, namespace string) *auth.JWTCla
 		if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil {
 			var custom map[string]string
 			if json.Unmarshal(decoded, &custom) == nil && len(custom) > 0 {
-				claims.Custom = custom
+				// Drop gateway-owned claims (feat-384). These are minted by the
+				// gateway from evidence it verified itself — a device signature,
+				// an API-key grant — and a header is not that evidence. Carrying
+				// them across this hop would let anything that can reach a
+				// namespace gateway on the mesh assert a device identity, which
+				// is exactly the forgery the device claim exists to prevent.
+				// Verified-JWT callers are unaffected: their claims come from the
+				// signature, not from here.
+				for k := range custom {
+					if _, reserved := reservedClaimKeys[k]; reserved {
+						delete(custom, k)
+					}
+				}
+				if len(custom) > 0 {
+					claims.Custom = custom
+				}
 			}
 		}
+	}
+	return claims
+}
+
+// verifiedBearerClaims returns the claims of the request's Bearer JWT, verified
+// against this gateway's own signing key, or nil when there is no parseable and
+// valid token.
+//
+// Returning nil for an INVALID token (rather than failing the request) keeps
+// this a pure upgrade of the internal-auth path: the caller then falls back to
+// the header-derived identity exactly as before, so a legitimately proxied
+// API-key request is unaffected. What it removes is the ability to assert a
+// verified-only claim through a header.
+func (g *Gateway) verifiedBearerClaims(r *http.Request) *auth.JWTClaims {
+	if g == nil || g.authService == nil {
+		return nil
+	}
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(authz), "bearer ") {
+		return nil
+	}
+	tok := strings.TrimSpace(authz[len("bearer "):])
+	if tok == "" || strings.Count(tok, ".") != 2 {
+		return nil
+	}
+	claims, err := g.authService.ParseAndVerifyJWT(tok)
+	if err != nil {
+		return nil
 	}
 	return claims
 }
@@ -530,15 +573,29 @@ func (g *Gateway) authMiddleware(next http.Handler) http.Handler {
 				if ns != "" {
 					// Pre-authenticated by main gateway - trust the namespace
 					reqCtx := context.WithValue(r.Context(), CtxKeyNamespaceOverride, ns)
-					// Bug #215: also rebuild ctxKeyJWT from the trusted
-					// internal-auth headers (subject + custom claims) so
-					// serverless host functions see a non-empty
-					// caller_jwt_subject. We deliberately do NOT re-verify
-					// the JWT here — namespace gateways may not share the
-					// signing key with the main gateway, and the main gateway
-					// already verified before forwarding. Trust gate is the
-					// source-IP check above.
-					if claims := claimsFromInternalAuthHeaders(r.Header, ns); claims != nil {
+					// Identity for this request.
+					//
+					// Prefer VERIFYING the caller's own Bearer JWT over trusting
+					// the forwarded headers (feat-384). The old comment here said
+					// namespace gateways may not share the signing key — that
+					// stopped being true with bug #215, which derives the Ed25519
+					// signing key deterministically from the cluster secret on
+					// every gateway precisely so JWTs verify cross-node. So the
+					// token IS verifiable here, and a signature beats a header.
+					//
+					// It matters because the source-IP gate above is weaker than
+					// it looks: it trusts the whole WireGuard /8 and loopback, and
+					// a serverless function can reach a namespace gateway directly
+					// via http_fetch. Header-asserted identity is therefore
+					// forgeable by anything on the mesh — including another
+					// tenant. Claims taken from a verified signature are not.
+					//
+					// The headers remain the fallback for callers that have no JWT
+					// to verify (API-key auth), with gateway-owned claims filtered
+					// out of them by claimsFromInternalAuthHeaders.
+					if claims := g.verifiedBearerClaims(r); claims != nil {
+						reqCtx = context.WithValue(reqCtx, ctxKeyJWT, claims)
+					} else if claims := claimsFromInternalAuthHeaders(r.Header, ns); claims != nil {
 						reqCtx = context.WithValue(reqCtx, ctxKeyJWT, claims)
 					}
 					// #148: hydrate the API-key caller's effective scopes from the

--- a/core/pkg/gateway/routes.go
+++ b/core/pkg/gateway/routes.go
@@ -89,6 +89,10 @@ func (g *Gateway) Routes() http.Handler {
 		mux.HandleFunc("/v1/auth/refresh", g.authHandlers.RefreshHandler)
 		mux.HandleFunc("/v1/auth/logout", g.authHandlers.LogoutHandler)
 		mux.HandleFunc("/v1/auth/whoami", g.authHandlers.WhoamiHandler)
+		// Device attribution (feat-384): the namespace tells the gateway a
+		// device is no longer current. NOT on the public-path list — it needs
+		// namespace-scoped admin credentials.
+		mux.HandleFunc("/v1/auth/device/revoke", g.authHandlers.DeviceRevokeHandler)
 		// Phantom Solana auth (QR code + deep link)
 		mux.HandleFunc("/v1/auth/phantom/session", g.authHandlers.PhantomSessionHandler)
 		mux.HandleFunc("/v1/auth/phantom/session/", g.authHandlers.PhantomSessionStatusHandler)

--- a/core/pkg/gateway/scope_policy.go
+++ b/core/pkg/gateway/scope_policy.go
@@ -87,6 +87,14 @@ func requiredScope(method, path string) string {
 	}
 
 	// --- Control-plane (admin only) ---
+	// Device revocation (feat-384) is namespace administration, NOT a user
+	// action. An end-user JWT sets CtxKeyNamespaceOverride from its own
+	// `namespace` claim, so without this classification any authenticated user
+	// of the namespace could revoke devices — including other accounts' — and a
+	// compromised device could revoke the legitimate ones.
+	if path == "/v1/auth/device/revoke" {
+		return auth.ScopeAdmin
+	}
 	if path == "/rqlite" || path == "/v1/rqlite" || strings.HasPrefix(path, "/v1/rqlite/") {
 		return auth.ScopeAdmin
 	}

--- a/core/pkg/gateway/scope_policy_test.go
+++ b/core/pkg/gateway/scope_policy_test.go
@@ -214,3 +214,24 @@ func TestUnpinException_decision(t *testing.T) {
 		t.Error("upload must keep the strict wallet-JWT requirement, not the unpin exception")
 	}
 }
+
+// Device revocation is namespace administration (feat-384).
+//
+// An end-user JWT sets CtxKeyNamespaceOverride from its own `namespace` claim,
+// so the handler's namespace resolution alone does NOT restrict this endpoint
+// to admins. Without an explicit admin scope any authenticated user of the
+// namespace could revoke devices — other accounts' included — and a compromised
+// device could revoke the legitimate ones to keep itself the only one serving.
+func TestRequiredScope_deviceRevokeIsAdminOnly(t *testing.T) {
+	if got := requiredScope(http.MethodPost, "/v1/auth/device/revoke"); got != auth.ScopeAdmin {
+		t.Errorf("requiredScope(/v1/auth/device/revoke) = %q, want %q", got, auth.ScopeAdmin)
+	}
+}
+
+// The endpoint must NOT be on the public path list, or the scope gate is never
+// consulted at all.
+func TestDeviceRevoke_isNotAPublicPath(t *testing.T) {
+	if isPublicPath("/v1/auth/device/revoke") {
+		t.Error("/v1/auth/device/revoke is public — it would accept unauthenticated device revocations")
+	}
+}

--- a/docs/SERVERLESS.md
+++ b/docs/SERVERLESS.md
@@ -144,7 +144,7 @@ If you see the runtime error `failed to instantiate module: module[X] not instan
 |----------|-------------|
 | `get_caller_wallet()` → string | Resolved caller wallet (JWT subject if Bearer auth, else namespace pseudo-id when API-key auth). |
 | `get_caller_jwt_subject()` → string | JWT `sub` claim explicitly. Empty when the request was not JWT-authenticated. Use this when binding on the JWT-signed identity matters (e.g. signup flows verifying the caller signed for the wallet they're registering). |
-| `get_caller_claim(name)` → string | Custom JWT claim by name (tier, subscription, etc.). Empty if missing or non-JWT request. |
+| `get_caller_claim(name)` → string | Custom JWT claim by name (tier, subscription, etc.). Empty if missing or non-JWT request. See [Device attribution](#device-attribution) for the gateway-owned `device_fp` / `device_since` claims. |
 | `get_request_id()` → string | Unique invocation ID |
 | `get_env(key)` → string | Environment variable from function.yaml |
 | `get_secret(name)` → string | Decrypted secret value (see [Managing Secrets](#managing-secrets)) |
@@ -653,3 +653,105 @@ orama function secrets set APNS_TEAM_ID "TEAM456"
 # Wire the PubSub trigger
 orama function triggers add call-push-handler --topic calls:invite
 ```
+
+## Device attribution
+
+A function can learn **which device** of an account is calling, not only which
+account (bugboard feat-384).
+
+Without it, every device of an account produces an identical JWT subject. That
+is fine for delivery, where the app controls fan-out, but not for retrieval:
+retrieval is authenticated per account, so anyone holding the account seed can
+call history endpoints as the account without being one of its devices.
+
+### Two claims
+
+| claim | meaning |
+|---|---|
+| `device_fp` | Fingerprint of the device key that signed this login. Derived by the gateway from the public key — never client-supplied. |
+| `device_since` | Unix seconds when **this gateway first observed** that key for this account. |
+
+Read them like any other claim:
+
+```go
+fp := oh.GetCallerClaim("device_fp")
+if fp == "" {
+    // No device assertion was presented. DENY if your function requires
+    // device attribution — absence is not permission.
+}
+```
+
+### Obtaining them
+
+`POST /v1/auth/verify` accepts two optional fields alongside the normal wallet
+signature:
+
+```json
+{
+  "wallet": "0x…", "nonce": "…", "signature": "…", "namespace": "myapp",
+  "device_public_key": "<base64 ed25519 public key>",
+  "device_signature":  "<base64 ed25519 signature>"
+}
+```
+
+The device signs `"orama-device-assertion:v1:" + nonce` — the **same** nonce the
+account signed, with a distinct prefix so neither signature can be replayed as
+the other. Both fields must be present or neither: supplying one is a **400** (a client
+bug, not a credential failure), a signature that does not verify is a **401**,
+and an infrastructure failure while recording the binding is a **503** so
+clients retry instead of tearing the session down. A failed assertion is never
+silently downgraded to a token without the claim.
+
+The assertion is optional at the protocol level because the CLI, the SDK and
+RootWallet-signed operator logins cannot produce one. Functions that require
+device attribution enforce it by denying when `device_fp` is empty.
+
+### Why `device_since` comes from the gateway
+
+An app's own device roster cannot establish when a device joined, if that roster
+is signed by a key derived from the account seed: an attacker holding the seed
+signs a roster backdating their device and claims the whole archive — the exact
+scenario a "new devices sync forward only" rule exists to bound. `device_since`
+records when this server first saw the key, which such an attacker cannot move.
+
+The gateway asserts **possession** ("this key signed this login"). Your function
+asserts **authorization** ("this fingerprint is on my current roster"). The
+gateway stores no roster and has no opinion about which devices an account may
+have.
+
+### What the claim is and is not proof of
+
+`device_fp` is minted only from a signature the gateway verified, and it is
+stripped from the internal proxy hop between gateways, so it cannot be asserted
+by a header from elsewhere on the cluster network. On a namespace gateway the
+caller's own JWT is re-verified against the cluster-wide signing key, so the
+claims a function sees come from a signature rather than from a forwarded
+header.
+
+It is **not** proof that the device is currently authorized — that is your
+roster's job — and it is not proof of freshness beyond the login that minted it:
+the token lives 15 minutes and the binding rides the refresh chain until the
+device is revoked.
+
+### Revoking a device
+
+```
+POST /v1/auth/device/revoke
+{ "subject": "<account>", "device_fingerprint": "<device_fp>" }
+```
+
+Namespace admin credentials required. This marks the binding revoked **and**
+revokes every refresh token that device obtained, which is what bounds a revoked
+device to one access-token TTL (15 minutes) instead of the refresh chain's
+30-day life. The response reports `refresh_tokens_revoked` — the difference
+between "marked revoked" and "actually stopped".
+
+A revoked device cannot log back in and re-acquire its claim — `BindDevice`
+refuses a revoked binding, so the login fails rather than silently resurrecting
+it. **There is no un-revoke endpoint**: revocation is currently permanent for
+that (account, device key) pair, and a device that is meant to return must be
+re-enrolled under a new key. If you need reinstatement, say so and it can be
+added — the column supports it, the API does not expose it.
+
+Revoking something that does not exist returns **404**, not 200. A revocation
+that silently matched nothing would be indistinguishable from one that worked.


### PR DESCRIPTION
Closes bugboard **feat-384**.

## The problem

A serverless function could learn only **which account** was calling — every device of an account produced an identical JWT subject. Retrieval endpoints are authenticated per account, so anyone holding the account seed could call `messages.history` / `sync.deltas` as the account without being one of its devices, and a device removed from the app's roster kept working because the auth layer could not tell the difference.

## The split

- **Gateway asserts possession** — "the holder of device key X was present at this login", a fact it verifies itself.
- **Namespace asserts authorization** — "X is on my current roster", policy only the app knows.

The gateway stores no roster. Teaching it one would put a fail-open 2s WASM invoke inside the authorization path and couple the platform to one tenant's data model.

## What ships

- `POST /v1/auth/verify` accepts an **optional** ed25519 assertion over `"orama-device-assertion:v1:" + nonce` — the same nonce the account signed, domain-separated so neither signature replays as the other. Optional because the CLI, SDK and RootWallet logins cannot produce one; functions that require attribution deny on absence.
- Verified assertions stamp `device_fp` and `device_since`, read via the existing `get_caller_claim` host call on both the HTTP and WS paths.
- `device_since` is the **gateway's own** first-seen observation. An app roster signed by a seed-derived key cannot establish it against the threat the rule exists for — an attacker holding the seed backdates their device and takes the archive. This server's observation they cannot move.
- `POST /v1/auth/device/revoke` (admin-scoped) revokes the binding, its refresh tokens, and their reuse grace; 404s when nothing matched rather than reporting a revocation that did nothing.

## Claim integrity

The whole value is that the claim cannot be forged or omitted:

- Claim keys are **reserved**, so a tenant's claims-provider cannot mint them — that would hand the forgery to the layer meant to be checking it.
- Device claims are **never persisted on the refresh token**. `reuseLastKnownClaims` replays stored claims per *wallet* with no device dimension, so a stored claim would attribute device B's request to device A in a correctly-signed token. The binding lives in its own column.
- The refresh path **re-derives from a live binding** on both the normal and reuse-grace routes, bounding a revoked device to one 15-minute access token instead of the chain's 30-day life.

## Also closes the hop this rested on

A namespace gateway trusted `X-Internal-Auth-*` headers purely on a source-IP check covering loopback and the whole WireGuard `/8` — and a serverless function can reach one directly via `http_fetch`, so anything on the mesh could assert any identity. The comment justifying that ("namespace gateways may not share the signing key") has been **stale since bug #215**, which derives the signing key deterministically from the cluster secret on every gateway.

The caller's own JWT is now verified there, and gateway-owned claims are stripped from the header path — which also closes forged `scopes: admin`.

## Verification

Full suite green, `-race` clean, vet and gofmt clean. Mutation-tested every security property — removing domain separation, persisting device claims to the refresh row, letting a revoked binding keep its claim, and dropping the reserved-key filter each produce failing tests.

Two rounds of code-review and security-audit agents; all blocking findings fixed, including a year-1 `device_since` fail-open (an unparseable timestamp granted the *entire* archive), an ETH-casing revocation bypass, and a missing admin gate on the revoke endpoint.

## Notes

- Migration is additive (`orama_`-prefixed table + one column). Prefixed because these migrations also run in each tenant's namespace RQLite, and `device_bindings` is exactly what a device-roster app would name its own table.
- Mixed-fleet: a session that refreshes through an old-binary node during a roll loses its device claim and must re-login. Fails closed, never forges.
- **No un-revoke endpoint** — revocation is permanent for that (account, device key) pair. Documented; add on request.
- Depends on feat-366 for nonce single-use. Until that lands the challenge is not enforced fresh, which bounds how strongly "one login event" can be claimed.