### PR TITLE
FEAT-211 docs: record the client surface — CLI only, no dashboard, no Orama MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ make vault-build
 | Document | Description |
 |----------|-------------|
 | [Architecture](docs/ARCHITECTURE.md) | System architecture and design patterns |
+| [Client surface](docs/CLIENT_SURFACE.md) | Humans use the CLI; programs use the SDK / HTTP. No dashboard, no Orama MCP |
 | [Deployment Guide](docs/DEPLOYMENT_GUIDE.md) | Deploy apps, databases, and domains |
 | [Dev & Deploy](docs/DEV_DEPLOY.md) | Building, deploying to VPS, rolling upgrades |
 | [Authentication](docs/AUTH.md) | Who someone is, what they may do, and how the gateway decides |

--- a/core/cmd/cli/reference_test.go
+++ b/core/cmd/cli/reference_test.go
@@ -87,9 +87,10 @@ Every command the ` + "`orama`" + ` binary defines, with its flags. Generated fr
 command tree, so it cannot drift from the code: a test fails when this file and
 the tree disagree.
 
-Task-shaped documentation lives elsewhere — [deploying apps](DEPLOYMENT_GUIDE.md),
-[building and rolling out](DEV_DEPLOY.md), [functions](SERVERLESS.md). This page
-is the index.
+Who uses this binary, and what does not exist (no dashboard, no Orama MCP), is
+[CLIENT_SURFACE.md](CLIENT_SURFACE.md). Task-shaped documentation lives
+elsewhere — [deploying apps](DEPLOYMENT_GUIDE.md), [building and rolling
+out](DEV_DEPLOY.md), [functions](SERVERLESS.md). This page is the index.
 
 `)
 

--- a/core/cmd/cli/root.go
+++ b/core/cmd/cli/root.go
@@ -45,9 +45,14 @@ var (
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "orama",
-		Short: "Orama CLI - Distributed P2P Network Management Tool",
-		Long: `Orama CLI is a tool for managing nodes, deploying applications,
-and interacting with the Orama distributed network.`,
+		Short: "Orama CLI — operate nodes and manage a namespace",
+		Long: `The human interface to the Orama network. One binary, two audiences:
+
+  Operators  orama node, inspect, rollout, invite, monitor, …
+  Tenants    orama deploy, app, function, db, namespace, …
+
+Programs use the SDK and the gateway HTTP API. There is no Orama dashboard
+and no Orama MCP.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/core/pkg/serverless/registry/types.go
+++ b/core/pkg/serverless/registry/types.go
@@ -86,7 +86,7 @@ type LogEntry struct {
 // nested under WASMLogs (which may be empty).
 //
 // This is the right answer to "what happened on this invocation" — the
-// CLI's `function logs` and dashboard log views consume this. The
+// CLI's `function logs` consumes this. The
 // older GetLogs(LogEntry) returns ONLY WASM-emitted entries, which is
 // usually empty and confused users (bug #211).
 type Invocation struct {

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -1,7 +1,10 @@
 # Gateway API surface
 
-Every route the gateway registers, and which client owns it. The point is that
-the TypeScript SDK's coverage is a decision rather than an accident: it reaches
+Every route the gateway registers, and which client owns it. Who those clients
+are is [CLIENT_SURFACE.md](CLIENT_SURFACE.md): humans use the CLI, programs use
+the SDK and this HTTP API, and there is no Orama dashboard.
+
+The TypeScript SDK's coverage is a decision rather than an accident: it reaches
 35 of 136 routes, and the other 101 are here with a reason.
 
 `core/pkg/gateway/api_surface_test.go` keeps this document honest in both

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 Orama Network is a high-performance API Gateway and Reverse Proxy designed for a decentralized ecosystem. It serves as a unified entry point that orchestrates traffic between clients and various backend services.
 
+How you talk to it: humans use the `orama` CLI; programs use the SDK and the gateway HTTP API. There is no Orama dashboard and no Orama MCP. See [CLIENT_SURFACE.md](CLIENT_SURFACE.md).
+
 ## Architecture Pattern
 
 **Modular Gateway / Edge Proxy Architecture**
@@ -13,7 +15,7 @@ The system follows a clean, layered architecture with clear separation of concer
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                        Clients                               │
-│              (Web, Mobile, CLI, SDKs)                        │
+│              (CLI, SDKs, tenant apps)                        │
 └────────────────────────┬────────────────────────────────────┘
                          │
                          │ HTTPS/WSS
@@ -1198,6 +1200,7 @@ Sandbox clusters remain on Ubuntu for development convenience.
 
 ## Resources
 
+- [How you talk to the network](CLIENT_SURFACE.md)
 - [RQLite Documentation](https://rqlite.io/docs/)
 - [IPFS Documentation](https://docs.ipfs.tech/)
 - [LibP2P Documentation](https://docs.libp2p.io/)

--- a/docs/CLIENT_SURFACE.md
+++ b/docs/CLIENT_SURFACE.md
@@ -1,0 +1,57 @@
+# How you talk to the network
+
+Humans use one CLI. Programs use the SDK and the gateway HTTP API. There is no
+Orama dashboard and no Orama MCP.
+
+The architecture of the node is in [ARCHITECTURE.md](ARCHITECTURE.md). This
+page is only the client surface.
+
+---
+
+## Humans — the `orama` CLI
+
+One binary, two audiences. Both stay in `orama`. We will not split an operator
+CLI and we will not remove operator paths.
+
+**Operators** run the node and the fleet: `orama node` (install, enroll, setup,
+status, logs, doctor, rollout, wipe, …), plus `inspect`, `invite`, `monitor`,
+`rollout`, `push`, `nodes`, `status`, `ssh`, and `sandbox`.
+
+**Tenants** run a namespace: `deploy`, `app`, `function`, `db`, `domain`,
+`namespace`, `members`, `auth`, `audit`, `env`.
+
+Every command and flag is in [CLI_REFERENCE.md](CLI_REFERENCE.md). Task-shaped
+guides: [deploying apps](DEPLOYMENT_GUIDE.md), [building and rolling
+out](DEV_DEPLOY.md), [functions](SERVERLESS.md).
+
+---
+
+## Programs — SDK and gateway HTTP
+
+A deployed application talks to its namespace gateway. It does not shell out to
+the CLI.
+
+| Surface | For |
+|---------|-----|
+| [TypeScript SDK](TS_SDK.md) (`@debros/orama`) | Application code in JS/TS |
+| [Go client](GO_CLIENT_SDK.md) | Application code in Go |
+| [Gateway HTTP](API_SURFACE.md) | The routes those clients call, and the ones they do not |
+
+Deploying an app, minting a key, and managing nodes are the CLI's job. The SDK
+reaches a deliberate subset of the gateway; [API_SURFACE.md](API_SURFACE.md)
+records who owns each route.
+
+---
+
+## Not this product
+
+These are not Orama clients and are not being built as one:
+
+- **No Orama dashboard.** The website is a landing page and docs. Tenant web
+  and mobile apps are applications you deploy; they call the SDK, they are not
+  an Orama control plane.
+- **No Orama MCP** for tenants or operators. Agents read the docs (`llms.txt`
+  and the markdown it lists). That is documentation, not a product MCP.
+- Hosting-provider consoles and the Apple Developer dashboard are other
+  people's products. Mentions of those in the operator docs are not an Orama
+  dashboard.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -9,9 +9,10 @@ Every command the `orama` binary defines, with its flags. Generated from the
 command tree, so it cannot drift from the code: a test fails when this file and
 the tree disagree.
 
-Task-shaped documentation lives elsewhere — [deploying apps](DEPLOYMENT_GUIDE.md),
-[building and rolling out](DEV_DEPLOY.md), [functions](SERVERLESS.md). This page
-is the index.
+Who uses this binary, and what does not exist (no dashboard, no Orama MCP), is
+[CLIENT_SURFACE.md](CLIENT_SURFACE.md). Task-shaped documentation lives
+elsewhere — [deploying apps](DEPLOYMENT_GUIDE.md), [building and rolling
+out](DEV_DEPLOY.md), [functions](SERVERLESS.md). This page is the index.
 
 ## Commands
 

--- a/docs/GO_CLIENT_SDK.md
+++ b/docs/GO_CLIENT_SDK.md
@@ -5,7 +5,8 @@
 The Orama Network Go Client SDK provides a clean, type-safe Go interface for interacting with the Orama Network. It abstracts away the complexity of peer connections, authentication, and error handling.
 
 For TypeScript, see [TS_SDK.md](TS_SDK.md). Both talk to the same gateway; use
-whichever matches the code you are writing.
+whichever matches the code you are writing. Humans use the CLI, not a
+dashboard — [CLIENT_SURFACE.md](CLIENT_SURFACE.md).
 
 ## Installation
 

--- a/docs/TS_SDK.md
+++ b/docs/TS_SDK.md
@@ -9,8 +9,9 @@ There is also a Go client, documented in [GO_CLIENT_SDK.md](GO_CLIENT_SDK.md).
 It talks to the same gateway. Use whichever matches the code you are writing.
 
 The SDK reaches a deliberate subset of the gateway: deploying an application,
-minting a key and managing nodes are the CLI's job. Every route and its owner is
-listed in [API_SURFACE.md](API_SURFACE.md).
+minting a key and managing nodes are the CLI's job. There is no Orama dashboard.
+Who talks to the network, and how, is [CLIENT_SURFACE.md](CLIENT_SURFACE.md).
+Every route and its owner is listed in [API_SURFACE.md](API_SURFACE.md).
 
 The vault is **not** in this package. See [Secrets](#secrets) below.
 

--- a/website/scripts/build-llms.mjs
+++ b/website/scripts/build-llms.mjs
@@ -30,6 +30,7 @@ const MANIFEST = {
     ["DEV_DEPLOY.md", "release-and-rollout", "Release & Rollout", "Build binaries, deploy to VPS nodes, enroll OramaOS, and run rolling cluster upgrades."],
   ],
   Reference: [
+    ["CLIENT_SURFACE.md", "client-surface", "Client Surface", "Humans use the orama CLI; programs use the SDK and gateway HTTP. No dashboard, no Orama MCP."],
     ["ARCHITECTURE.md", "architecture", "Architecture", "System architecture: gateway, namespaces, RQLite, Olric cache, IPFS storage, WASM runtime."],
     ["CLI_REFERENCE.md", "cli-reference", "CLI Reference", "Every orama command and flag, generated from the command tree."],
     ["API_SURFACE.md", "api-surface", "API Surface", "Every gateway route and which client owns it: SDK, CLI, direct, or internal."],


### PR DESCRIPTION
feat-211. The dashboard and Orama MCP are already gone (feat-223); this records the client surface in `docs/` so the next change does not rebuild them, or strip `orama node` out of the CLI.

## Decision (0.200.0)

1. No Orama dashboard — not as a product, not as a second client.
2. No Orama MCP for tenants or operators.
3. One CLI, two audiences. Operator commands stay (`orama node`, inspect, rollout, …). Tenant commands stay (`deploy`, `function`, `db`, `namespace`, …).

Programs use the SDK and the gateway HTTP API.

## What this PR does

- Adds [`docs/CLIENT_SURFACE.md`](docs/CLIENT_SURFACE.md) with those three facts.
- Links it from `ARCHITECTURE.md`, the README docs table, `API_SURFACE.md`, both SDKs, the generated CLI reference, `orama --help`, and `llms.txt`.
- Drops a leftover "dashboard log views" comment in the function-logs type.

VPS / Apple Developer "dashboard" mentions stay — those are other people's consoles.

Website `/dashboard` was already removed on feat-223. This ticket is the docs record, not a second website rewrite.

## Tested

- `go test -count=1 ./cmd/cli -run TestCLIReference` (the generated `docs/CLI_REFERENCE.md` matches the command tree)
- `git grep` over `docs/` finds no Orama product dashboard or Orama MCP, only the denial of those and third-party consoles