### PR TITLE
FEAT-221: DNS write path — ACME lock-down, cleanup, reserved names

### DIFF
--- a/core/cmd/orama/internal/production/clusterops/retire.go
+++ b/core/cmd/orama/internal/production/clusterops/retire.go
@@ -40,6 +40,17 @@ func RetirementPlan(rec NodeRecord) []RetireStep {
 				retiredLastSeen, peer),
 		},
 		{
+			// The 120s system reaper only matches status='active'. A retired
+			// node is already inactive, so apex/wildcard/NS-glue A records
+			// pointing at it would otherwise stay forever. Namespace and TURN
+			// records are found through the dns_nodes row we just marked, and
+			// the 15-minute purge handles those.
+			What: "remove this node's system DNS A records",
+			SQL: fmt.Sprintf(
+				`DELETE FROM dns_records WHERE record_type = 'A' AND namespace = 'system' AND value = (SELECT ip_address FROM dns_nodes WHERE id = '%s')`,
+				peer),
+		},
+		{
 			What: "release the mesh address",
 			SQL:  fmt.Sprintf(`DELETE FROM wireguard_peers WHERE node_id = '%s'`, peer),
 		},

--- a/core/cmd/orama/internal/production/clusterops/retire_test.go
+++ b/core/cmd/orama/internal/production/clusterops/retire_test.go
@@ -110,6 +110,24 @@ func TestRetirementPlan_is_idempotent(t *testing.T) {
 // set verifies nothing AND cannot be enrolled again; deleting it would send the
 // machine back down the never-seen path, where it could enrol a key of its own
 // choosing and speak as that node again.
+func TestRetirementPlan_deletesSystemARecordsWhileTheNodeRowStillExists(t *testing.T) {
+	sql := planSQL(t, "peerA")
+	if !strings.Contains(sql, "DELETE FROM dns_records") {
+		t.Fatal("retirement does not delete system A records, so apex/glue stay after the 120s reaper skips an already-inactive node")
+	}
+	if !strings.Contains(sql, "namespace = 'system'") {
+		t.Error("the delete must be scoped to system records, not namespace hosts")
+	}
+	if !strings.Contains(sql, "SELECT ip_address FROM dns_nodes WHERE id = 'peerA'") {
+		t.Error("the delete must find the IP through the dns_nodes row, which still exists at this step")
+	}
+	mark := strings.Index(sql, "UPDATE dns_nodes SET status = 'inactive'")
+	drop := strings.Index(sql, "DELETE FROM dns_records")
+	if mark < 0 || drop < 0 || drop < mark {
+		t.Error("system A records must be deleted after the node is marked inactive, while the row still exists")
+	}
+}
+
 func TestRetirementPlan_revokesTheNodeKeyRatherThanDeletingIt(t *testing.T) {
 	sql := planSQL(t, "peerA")
 

--- a/core/migrations/056_drop_reserved_domains.sql
+++ b/core/migrations/056_drop_reserved_domains.sql
@@ -1,0 +1,14 @@
+-- Migration 056: drop reserved_domains.
+--
+-- 005_dns_records.sql created the table and seeded api/www/admin/ns1–ns4/mail/
+-- cdn/docs/status under orama.network. Nothing has ever SELECTed it. Namespace
+-- create already refuses a code denylist; the table's only effect was to
+-- suggest those names were reserved while they were not.
+--
+-- DROP IF EXISTS is idempotent. The table is unused, so dropping it takes
+-- nothing with it.
+BEGIN;
+
+DROP TABLE IF EXISTS reserved_domains;
+
+COMMIT;

--- a/core/pkg/gateway/acme_handler.go
+++ b/core/pkg/gateway/acme_handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DeBrosOfficial/network/pkg/auth"
 	"github.com/DeBrosOfficial/network/pkg/client"
 	"go.uber.org/zap"
 )
@@ -23,6 +24,12 @@ type ACMERequest struct {
 func (g *Gateway) acmePresentHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !auth.IsNodeLocal(r) {
+		// 404 rather than 403: an endpoint the public has no business
+		// reaching should not confirm that it exists. Same as node register.
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 
@@ -81,6 +88,10 @@ func (g *Gateway) acmePresentHandler(w http.ResponseWriter, r *http.Request) {
 func (g *Gateway) acmeCleanupHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !auth.IsNodeLocal(r) {
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 

--- a/core/pkg/gateway/acme_handler_test.go
+++ b/core/pkg/gateway/acme_handler_test.go
@@ -1,0 +1,114 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/client"
+	"github.com/DeBrosOfficial/network/pkg/logging"
+)
+
+// acmeQueryDB records Query calls so the present/cleanup handlers can be
+// exercised without a real rqlite.
+type acmeQueryDB struct {
+	client.DatabaseClient
+	calls int
+}
+
+func (d *acmeQueryDB) Query(_ context.Context, _ string, _ ...interface{}) (*client.QueryResult, error) {
+	d.calls++
+	return &client.QueryResult{}, nil
+}
+
+func acmeGateway(t *testing.T, db client.DatabaseClient) *Gateway {
+	t.Helper()
+	log, err := logging.NewColoredLogger(logging.ComponentGateway, false)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	return &Gateway{
+		logger: log,
+		client: &fakeNetworkClient{db: db},
+	}
+}
+
+func acmeRequest(t *testing.T, path, remote, forwarded string, body any) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	r := httptest.NewRequest(http.MethodPost, path, &buf)
+	r.RemoteAddr = remote
+	if forwarded != "" {
+		r.Header.Set("X-Forwarded-For", forwarded)
+	}
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func TestACMEPresent_refusesARequestThatCameThroughCaddy(t *testing.T) {
+	db := &acmeQueryDB{}
+	g := acmeGateway(t, db)
+	rec := httptest.NewRecorder()
+	g.acmePresentHandler(rec, acmeRequest(t, "/v1/internal/acme/present",
+		"127.0.0.1:54321", "198.51.100.9",
+		ACMERequest{FQDN: "_acme-challenge.ns-alice.example.", Value: "token"}))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if db.calls != 0 {
+		t.Fatalf("wrote %d DNS rows from the internet", db.calls)
+	}
+}
+
+func TestACMECleanup_refusesARequestThatCameThroughCaddy(t *testing.T) {
+	db := &acmeQueryDB{}
+	g := acmeGateway(t, db)
+	rec := httptest.NewRecorder()
+	g.acmeCleanupHandler(rec, acmeRequest(t, "/v1/internal/acme/cleanup",
+		"127.0.0.1:54321", "198.51.100.9",
+		ACMERequest{FQDN: "_acme-challenge.ns-alice.example.", Value: "token"}))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if db.calls != 0 {
+		t.Fatalf("deleted %d DNS rows from the internet", db.calls)
+	}
+}
+
+func TestACMEPresent_acceptsCaddyOnThisHost(t *testing.T) {
+	db := &acmeQueryDB{}
+	g := acmeGateway(t, db)
+	rec := httptest.NewRecorder()
+	g.acmePresentHandler(rec, acmeRequest(t, "/v1/internal/acme/present",
+		"127.0.0.1:54321", "",
+		ACMERequest{FQDN: "_acme-challenge.ns-alice.example.", Value: "token-value"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if db.calls != 1 {
+		t.Fatalf("Query calls = %d, want 1", db.calls)
+	}
+}
+
+func TestACMECleanup_acceptsCaddyOnThisHost(t *testing.T) {
+	db := &acmeQueryDB{}
+	g := acmeGateway(t, db)
+	rec := httptest.NewRecorder()
+	g.acmeCleanupHandler(rec, acmeRequest(t, "/v1/internal/acme/cleanup",
+		"127.0.0.1:54321", "",
+		ACMERequest{FQDN: "_acme-challenge.ns-alice.example.", Value: "token-value"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if db.calls != 1 {
+		t.Fatalf("Query calls = %d, want 1", db.calls)
+	}
+}

--- a/core/pkg/gateway/handlers/deployments/domain_handler.go
+++ b/core/pkg/gateway/handlers/deployments/domain_handler.go
@@ -237,8 +237,15 @@ func (h *DomainHandler) HandleVerifyDomain(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Create DNS record for the domain
-	go h.createDNSRecord(ctx, domain, domainRecord.DeploymentID)
+	// Write the A record before answering. A goroutine on the request
+	// context cancelled as soon as this handler returned, so "verified"
+	// often meant no DNS row.
+	if err := h.createDNSRecord(ctx, domain, domainRecord.DeploymentID); err != nil {
+		h.logger.Error("Failed to create DNS record for verified domain",
+			zap.String("domain", domain), zap.Error(err))
+		http.Error(w, "Failed to create DNS record", http.StatusInternalServerError)
+		return
+	}
 
 	h.logger.Info("Domain verified successfully",
 		zap.String("domain", domain),
@@ -468,7 +475,7 @@ func (h *DomainHandler) verifyTXTRecord(record, expectedValue string) bool {
 	return false
 }
 
-func (h *DomainHandler) createDNSRecord(ctx context.Context, domain, deploymentID string) {
+func (h *DomainHandler) createDNSRecord(ctx context.Context, domain, deploymentID string) error {
 	// Get deployment node IP
 	type deploymentRow struct {
 		HomeNodeID string `db:"home_node_id"`
@@ -477,9 +484,11 @@ func (h *DomainHandler) createDNSRecord(ctx context.Context, domain, deploymentI
 	var rows []deploymentRow
 	query := `SELECT home_node_id FROM deployments WHERE id = ?`
 	err := h.service.db.Query(ctx, &rows, query, deploymentID)
-	if err != nil || len(rows) == 0 {
-		h.logger.Error("Failed to get deployment node", zap.Error(err))
-		return
+	if err != nil {
+		return fmt.Errorf("look up deployment %s: %w", deploymentID, err)
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("deployment %s has no home node", deploymentID)
 	}
 
 	homeNodeID := rows[0].HomeNodeID
@@ -492,9 +501,11 @@ func (h *DomainHandler) createDNSRecord(ctx context.Context, domain, deploymentI
 	var nodeRows []nodeRow
 	nodeQuery := `SELECT ip_address FROM dns_nodes WHERE id = ? AND status = 'active'`
 	err = h.service.db.Query(ctx, &nodeRows, nodeQuery, homeNodeID)
-	if err != nil || len(nodeRows) == 0 {
-		h.logger.Error("Failed to get node IP", zap.Error(err))
-		return
+	if err != nil {
+		return fmt.Errorf("look up node %s: %w", homeNodeID, err)
+	}
+	if len(nodeRows) == 0 {
+		return fmt.Errorf("node %s has no active public address", homeNodeID)
 	}
 
 	nodeIP := nodeRows[0].IPAddress
@@ -515,12 +526,12 @@ func (h *DomainHandler) createDNSRecord(ctx context.Context, domain, deploymentI
 
 	_, err = h.service.db.Exec(ctx, dnsQuery, fqdn, nodeIP, "", deploymentID, homeNodeID, now, now)
 	if err != nil {
-		h.logger.Error("Failed to create DNS record", zap.Error(err))
-		return
+		return fmt.Errorf("insert A record for %s: %w", domain, err)
 	}
 
 	h.logger.Info("DNS record created for custom domain",
 		zap.String("domain", domain),
 		zap.String("ip", nodeIP),
 	)
+	return nil
 }

--- a/core/pkg/gateway/handlers/namespace/create_handler.go
+++ b/core/pkg/gateway/handlers/namespace/create_handler.go
@@ -53,6 +53,12 @@ var namespaceName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,38}[a-z0-9]$`)
 var reservedNamespaces = map[string]bool{
 	"default": true, "index": true, "nameserver": true,
 	"system": true, "orama": true, "admin": true, "internal": true,
+	// Platform DNS labels. These used to live in a reserved_domains table
+	// that nothing ever read. A namespace of this name becomes ns-<name>
+	// and also collides with hosts the nameserver already answers.
+	"api": true, "www": true, "mail": true, "cdn": true, "docs": true,
+	"status": true, "push": true, "turn": true,
+	"ns1": true, "ns2": true, "ns3": true, "ns4": true,
 }
 
 // Provisioner starts a namespace's cluster. Satisfied by the gateway's cluster

--- a/core/pkg/gateway/route_policy.go
+++ b/core/pkg/gateway/route_policy.go
@@ -102,8 +102,10 @@ func buildRoutePolicies() *routepolicy.Table {
 		// Polled while a namespace's cluster is still provisioning, by a client
 		// that has not been given anything to poll it with yet.
 		"/v1/namespace/status",
-		// Called by Caddy on this host; neither authenticates. Both are on the
-		// list of things Phase 2 has to give a credential to.
+		// Called by Caddy on this host. Present and cleanup refuse anything
+		// that arrived through the public reverse-proxy (`IsNodeLocal`); they
+		// stay Open so Caddy does not have to mint a credential. tls/check is
+		// still on the list of things Phase 2 has to give a credential to.
 		"/v1/internal/acme/present", "/v1/internal/acme/cleanup", "/v1/internal/tls/check",
 		// Peer health probing. Returns the node id and nothing else.
 		"/v1/internal/ping",

--- a/core/pkg/namespace/cluster_manager.go
+++ b/core/pkg/namespace/cluster_manager.go
@@ -1245,9 +1245,10 @@ func (cm *ClusterManager) DeprovisionCluster(ctx context.Context, namespaceID in
 	cm.portAllocator.DeallocateAllPortBlocks(ctx, cluster.ID)
 	cm.webrtcPortAllocator.DeallocateAll(ctx, cluster.ID)
 
-	// 5. Delete namespace DNS records (gateway + TURN)
+	// 5. Delete namespace DNS records (gateway + TURN + stealth)
 	cm.dnsManager.DeleteNamespaceRecords(ctx, cluster.NamespaceName)
 	cm.dnsManager.DeleteTURNRecords(ctx, cluster.NamespaceName)
+	cm.dnsManager.DeleteStealthTURNRecords(ctx, cluster.NamespaceName)
 
 	// 6. Explicitly delete child tables (FK cascades disabled in rqlite)
 	cm.db.Exec(ctx, `DELETE FROM namespace_cluster_events WHERE namespace_cluster_id = ?`, cluster.ID)

--- a/core/pkg/namespace/cluster_manager_webrtc.go
+++ b/core/pkg/namespace/cluster_manager_webrtc.go
@@ -1281,15 +1281,19 @@ const webrtcReconcileInterval = 60 * time.Second
 // record, but only while its namespace gateway is actually answering (bugboard
 // #286).
 //
-// Advertising is gated on real evidence rather than on the node merely believing
-// it holds the role: a record pointing at a gateway that is down is the #161
-// symptom in a different place — clients round-robin onto a dead endpoint.
+// Advertising is gated on the same HTTP /v1/health probe the withdraw loop
+// uses. A record pointing at a gateway that is down — or that accepts TCP
+// but cannot serve — is the #161 symptom in a different place: clients
+// round-robin onto a dead endpoint.
 func (cm *ClusterManager) ensureNamespaceHostRecordIfServing(ctx context.Context, state *ClusterLocalState) {
 	port := state.LocalPorts.GatewayHTTPPort
 	if port <= 0 {
 		return
 	}
-	if err := probeTCP(fmt.Sprintf("127.0.0.1:%d", port)); err != nil {
+	// HTTP /v1/health, not TCP-open. The withdraw loop in namespace_health.go
+	// keys on the same probe: a gateway that accepts TCP but is still starting
+	// (or 404s) must not be re-advertised here, or the two fight.
+	if err := gatewayReady(ctx, fmt.Sprintf("127.0.0.1:%d", port)); err != nil {
 		// Not serving yet — say nothing and retry on the next tick. This is the
 		// normal state for the first minute after a restart.
 		return

--- a/core/pkg/namespace/dns_manager.go
+++ b/core/pkg/namespace/dns_manager.go
@@ -32,8 +32,6 @@ func NewDNSRecordManager(db rqlite.Client, baseDomain string, logger *zap.Logger
 // Each namespace gets records for ns-{namespace}.{baseDomain} pointing to its gateway nodes.
 // Multiple A records enable round-robin DNS load balancing.
 func (drm *DNSRecordManager) CreateNamespaceRecords(ctx context.Context, namespaceName string, nodeIPs []string) error {
-	internalCtx := client.WithInternalAuth(ctx)
-
 	if len(nodeIPs) == 0 {
 		return &ClusterError{Message: "no node IPs provided for DNS records"}
 	}
@@ -47,61 +45,12 @@ func (drm *DNSRecordManager) CreateNamespaceRecords(ctx context.Context, namespa
 		zap.Strings("node_ips", nodeIPs),
 	)
 
-	// First, delete any existing records for this namespace
-	deleteQuery := `DELETE FROM dns_records WHERE fqdn = ? AND namespace = ?`
-	_, err := drm.db.Exec(internalCtx, deleteQuery, fqdn, "namespace:"+namespaceName)
-	if err != nil {
-		drm.logger.Warn("Failed to delete existing DNS records", zap.Error(err))
-		// Continue anyway - the insert will just add more records
-	}
-
-	// Create A records for each node IP
+	// Additive. A DELETE of the whole FQDN here raced the 30s per-node
+	// ensure: one node wiped the round-robin while another re-inserted its
+	// own row. Repair already uses AddNamespaceRecord; provision does too.
 	for _, ip := range nodeIPs {
-		insertQuery := `
-			INSERT INTO dns_records (
-				fqdn, record_type, value, ttl, namespace, created_by, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-		`
-		now := time.Now()
-		_, err := drm.db.Exec(internalCtx, insertQuery,
-			fqdn, "A", ip, 60,
-			"namespace:"+namespaceName, "cluster-manager",
-			now, now,
-		)
-		if err != nil {
-			return &ClusterError{
-				Message: fmt.Sprintf("failed to create DNS record for %s -> %s", fqdn, ip),
-				Cause:   err,
-			}
-		}
-	}
-
-	// Also create wildcard records for deployments under this namespace
-	// *.ns-{namespace}.{baseDomain} -> same IPs
-	wildcardFqdn := fmt.Sprintf("*.ns-%s.%s.", namespaceName, drm.baseDomain)
-
-	// Delete existing wildcard records
-	_, _ = drm.db.Exec(internalCtx, deleteQuery, wildcardFqdn, "namespace:"+namespaceName)
-
-	for _, ip := range nodeIPs {
-		insertQuery := `
-			INSERT INTO dns_records (
-				fqdn, record_type, value, ttl, namespace, created_by, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-		`
-		now := time.Now()
-		_, err := drm.db.Exec(internalCtx, insertQuery,
-			wildcardFqdn, "A", ip, 60,
-			"namespace:"+namespaceName, "cluster-manager",
-			now, now,
-		)
-		if err != nil {
-			drm.logger.Warn("Failed to create wildcard DNS record",
-				zap.String("fqdn", wildcardFqdn),
-				zap.String("ip", ip),
-				zap.Error(err),
-			)
-			// Continue - wildcard is nice to have but not critical
+		if err := drm.AddNamespaceRecord(ctx, namespaceName, ip); err != nil {
+			return err
 		}
 	}
 

--- a/core/pkg/namespace/dns_manager_test.go
+++ b/core/pkg/namespace/dns_manager_test.go
@@ -299,6 +299,38 @@ func TestDisableNamespaceRecord_surfacesAWriteFailure(t *testing.T) {
 	}
 }
 
+func TestCreateNamespaceRecords_isAdditive(t *testing.T) {
+	// Provision used to DELETE every row for the FQDN then INSERT. The 30s
+	// per-node ensure races that: one node wiped the round-robin while
+	// another re-inserted only itself.
+	mockDB := newMockRQLiteClient()
+	manager := NewDNSRecordManager(mockDB, "orama-devnet.network", zap.NewNop())
+
+	if err := manager.CreateNamespaceRecords(context.Background(), "alice", []string{"203.0.113.1", "203.0.113.2"}); err != nil {
+		t.Fatalf("CreateNamespaceRecords: %v", err)
+	}
+
+	for _, call := range mockDB.execCalls {
+		if strings.Contains(strings.ToUpper(call.Query), "DELETE FROM DNS_RECORDS") {
+			t.Fatalf("provision deleted the round-robin set:\n%s", call.Query)
+		}
+	}
+	inserts := 0
+	for _, call := range mockDB.execCalls {
+		if !strings.Contains(call.Query, "INSERT INTO dns_records") {
+			continue
+		}
+		inserts++
+		if !strings.Contains(call.Query, "ON CONFLICT(fqdn, record_type, value)") {
+			t.Fatalf("the insert is not an upsert:\n%s", call.Query)
+		}
+	}
+	// Two IPs × (primary + wildcard).
+	if inserts != 4 {
+		t.Fatalf("expected 4 upserts, got %d", inserts)
+	}
+}
+
 func TestAddNamespaceRecord_revivesASoftDisabledRow(t *testing.T) {
 	// dns_records has UNIQUE(fqdn, record_type, value) and
 	// DisableNamespaceRecord leaves the row in place with is_active = 0. A bare

--- a/core/pkg/namespace/webrtc_host_dns_reconcile_test.go
+++ b/core/pkg/namespace/webrtc_host_dns_reconcile_test.go
@@ -2,7 +2,11 @@ package namespace
 
 import (
 	"context"
+	"encoding/json"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -50,14 +54,30 @@ func dnsUpserts(db *recoveryMockDB) int {
 	return n
 }
 
+func servingGatewayPort(t *testing.T, status int, body string) int {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	_, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split %s: %v", srv.URL, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port %q: %v", portStr, err)
+	}
+	return port
+}
+
 // The reproduction's fix: gateway serving, so the record is asserted.
 func TestEnsureNamespaceHostRecordIfServing_advertisesWhenGatewayAnswers(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer ln.Close()
-	port := ln.Addr().(*net.TCPAddr).Port
+	body, _ := json.Marshal(map[string]any{"status": "ok", "services": map[string]string{}})
+	port := servingGatewayPort(t, http.StatusOK, string(body))
 
 	cm, db := dnsProbeCM(t, "203.0.113.10")
 	state := &ClusterLocalState{
@@ -95,6 +115,25 @@ func TestEnsureNamespaceHostRecordIfServing_skipsWhenGatewayIsDown(t *testing.T)
 	}
 }
 
+// TCP-open is not "serving". A gateway that accepts connections but returns
+// 404 / starting would be withdrawn by the HTTP health loop and put back by
+// a TCP probe — the two must not fight.
+func TestEnsureNamespaceHostRecordIfServing_skipsWhenGatewayAcceptsTCPButIsNotReady(t *testing.T) {
+	port := servingGatewayPort(t, http.StatusNotFound, "not this namespace")
+
+	cm, db := dnsProbeCM(t, "203.0.113.10")
+	state := &ClusterLocalState{
+		NamespaceName: "anchat-v2",
+		LocalPorts:    ClusterLocalStatePorts{GatewayHTTPPort: port},
+	}
+
+	cm.ensureNamespaceHostRecordIfServing(context.Background(), state)
+
+	if dnsUpserts(db) != 0 {
+		t.Error("advertised a node whose gateway accepts TCP but is not ready")
+	}
+}
+
 // A state file with no gateway port recorded must be a no-op rather than a panic
 // or a bogus probe against port 0.
 func TestEnsureNamespaceHostRecordIfServing_noPortIsNoop(t *testing.T) {
@@ -110,12 +149,8 @@ func TestEnsureNamespaceHostRecordIfServing_noPortIsNoop(t *testing.T) {
 
 // No public IP recorded: skip rather than write a record with an empty value.
 func TestEnsureNamespaceHostRecordIfServing_skipsWithoutPublicIP(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer ln.Close()
-	port := ln.Addr().(*net.TCPAddr).Port
+	body, _ := json.Marshal(map[string]any{"status": "ok", "services": map[string]string{}})
+	port := servingGatewayPort(t, http.StatusOK, string(body))
 
 	cm, db := dnsProbeCM(t, "") // lookup yields nothing
 	state := &ClusterLocalState{

--- a/core/pkg/node/membership/reconciler.go
+++ b/core/pkg/node/membership/reconciler.go
@@ -140,6 +140,15 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			  WHERE node_id = ? AND revoked_at IS NULL`, peerID); err != nil {
 			return fmt.Errorf("revoke the key of departed node %s: %w", peerID, err)
 		}
+		// System A records (apex, wildcard, NS glue) are keyed on the public
+		// IP in dns_nodes. Delete them while the row still exists; dropping
+		// the row first strands them, which is what retire.go was written to
+		// avoid.
+		if _, err := rqlite.SafeExecContext(r.db, ctx,
+			`DELETE FROM dns_records WHERE record_type = 'A' AND namespace = 'system'
+			   AND value = (SELECT ip_address FROM dns_nodes WHERE id = ?)`, peerID); err != nil {
+			return fmt.Errorf("drop system DNS records of departed node %s: %w", peerID, err)
+		}
 		if _, err := rqlite.SafeExecContext(r.db, ctx,
 			`DELETE FROM dns_nodes WHERE id = ?`, peerID); err != nil {
 			return fmt.Errorf("drop dns node %s: %w", peerID, err)

--- a/core/pkg/node/membership/reconciler_test.go
+++ b/core/pkg/node/membership/reconciler_test.go
@@ -47,6 +47,13 @@ func membershipDB(t *testing.T) *sql.DB {
 			public_key TEXT NOT NULL,
 			enrolled_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			revoked_at TIMESTAMP
+		);
+		CREATE TABLE dns_records (
+			fqdn TEXT NOT NULL,
+			record_type TEXT NOT NULL DEFAULT 'A',
+			value TEXT NOT NULL,
+			namespace TEXT NOT NULL DEFAULT 'system',
+			UNIQUE(fqdn, record_type, value)
 		);`); err != nil {
 		t.Fatalf("schema: %v", err)
 	}
@@ -359,5 +366,38 @@ func TestReconcile_revokesTheKeyOfADepartedNode(t *testing.T) {
 	}
 	if !revoked.Valid || revoked.String == "" {
 		t.Error("a departed node kept a live credential, so its disk still speaks for it")
+	}
+}
+
+// Dropping the dns_nodes row first stranded system A records: the purge
+// finds the IP through that row. Delete them while the row still exists.
+func TestReconcile_dropsSystemDNSRecordsBeforeTheNodeRow(t *testing.T) {
+	db := membershipDB(t)
+	seedNode(t, db, "peerGone", "10.0.0.9", 86400)
+	seedTombstone(t, db, "10.0.0.9:10101", "peerGone", int(TombstoneGrace.Seconds())+3600)
+	if _, err := db.Exec(
+		`INSERT INTO dns_records (fqdn, record_type, value, namespace) VALUES
+		 ('example.', 'A', '203.0.113.1', 'system'),
+		 ('ns-alice.example.', 'A', '203.0.113.1', 'namespace:alice')`); err != nil {
+		t.Fatalf("seed dns_records: %v", err)
+	}
+
+	r := NewReconciler(db, fakeDiscovery{}, func() bool { return true }, nil)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var systemLeft, nsLeft int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM dns_records WHERE namespace = 'system'`).Scan(&systemLeft); err != nil {
+		t.Fatalf("count system: %v", err)
+	}
+	if systemLeft != 0 {
+		t.Errorf("system A records left after the node row was dropped: %d", systemLeft)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM dns_records WHERE namespace = 'namespace:alice'`).Scan(&nsLeft); err != nil {
+		t.Fatalf("count namespace: %v", err)
+	}
+	if nsLeft != 1 {
+		t.Errorf("namespace A records = %d, want 1 (the last-record purge is a different loop)", nsLeft)
 	}
 }

--- a/core/pkg/rqlite/schema_placement.go
+++ b/core/pkg/rqlite/schema_placement.go
@@ -122,7 +122,6 @@ var tablePlacement = map[string]tableNote{
 	"dns_records":                  {PlacementNamespace, "cluster DNS; unverified, see ARCH-2"},
 	"dns_nodes":                    {PlacementNamespace, "cluster DNS; unverified, see ARCH-2"},
 	"dns_nameservers":              {PlacementNamespace, "cluster DNS; unverified, see ARCH-2"},
-	"reserved_domains":             {PlacementNamespace, "cluster DNS; unverified, see ARCH-2"},
 	"raft_evicted_nodes":           {PlacementNamespace, "cluster membership; unverified, see ARCH-2"},
 	"node_health_events":           {PlacementNamespace, "cluster health; unverified, see ARCH-2"},
 	"rqlite_backups":               {PlacementNamespace, "cluster backups; unverified, see ARCH-2"},

--- a/core/pkg/serverless/hostfunctions/sqlguard.go
+++ b/core/pkg/serverless/hostfunctions/sqlguard.go
@@ -75,7 +75,6 @@ var protectedTables = map[string]string{
 	"dns_records":                  "DNS",
 	"dns_nodes":                    "DNS",
 	"dns_nameservers":              "DNS",
-	"reserved_domains":             "domain reservation",
 	"raft_evicted_nodes":           "cluster membership",
 	"cluster_locks":                "cluster coordination",
 	"orama_schema_migrations":      "the platform's own schema bookkeeping",

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -226,8 +226,8 @@ unit test read, so a shape change on either side fails without a cluster.
 
 | Route | Owner | Notes |
 |-------|-------|-------|
-| `/v1/internal/acme/cleanup` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
-| `/v1/internal/acme/present` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
+| `/v1/internal/acme/cleanup` | internal | Caddy on this host, over loopback, with no forwarding header. Refused from the internet (Caddy reverse-proxies every path). |
+| `/v1/internal/acme/present` | internal | Caddy on this host, over loopback, with no forwarding header. Refused from the internet (Caddy reverse-proxies every path). |
 | `/v1/internal/deployments/replica/rollback` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
 | `/v1/internal/deployments/replica/setup` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
 | `/v1/internal/deployments/replica/teardown` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |

--- a/docs/NODE_REPLACEMENT.md
+++ b/docs/NODE_REPLACEMENT.md
@@ -613,6 +613,11 @@ DELETE FROM webrtc_port_allocations  WHERE node_id = '<OLD_LIBP2P_ID>';
 -- node's A records, its NS glue and the namespace records pointing at it.
 UPDATE dns_nodes SET status = 'inactive', last_seen = '1970-01-01 00:00:00',
   updated_at = datetime('now') WHERE id = '<OLD_LIBP2P_ID>';
+
+-- The 120s system reaper only matches status='active'. A retired node is
+-- already inactive, so apex/wildcard/NS-glue A records would otherwise stay.
+DELETE FROM dns_records WHERE record_type = 'A' AND namespace = 'system'
+  AND value = (SELECT ip_address FROM dns_nodes WHERE id = '<OLD_LIBP2P_ID>');
 ```
 
 Finally erase the box with `orama node wipe --env <env> --node <OLD_PUBLIC_IP>`,

--- a/docs/whitepaper/whitepaper.html
+++ b/docs/whitepaper/whitepaper.html
@@ -923,7 +923,6 @@
         <tr><td class="mono">dns_records</td><td>A, AAAA, CNAME and TXT for deployments, namespaces and certificate challenges</td></tr>
         <tr><td class="mono">dns_nodes</td><td>Every node's peer ID, public address, overlay address, active flag, heartbeat</td></tr>
         <tr><td class="mono">dns_nameservers</td><td>Which nodes answer on port 53 — the NS set</td></tr>
-        <tr><td class="mono">reserved_domains</td><td>Names tenants may not claim</td></tr>
         <tr><td class="mono">global_deployment_subdomains</td><td>Cluster-unique subdomain reservations</td></tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary

feat-221 is the DNS write-path audit. The six questions are answered in the parent ticket; this PR is the follow-up code.

- **bug-415** — `/v1/internal/acme/present` and `/cleanup` refuse anything that arrived through Caddy (`IsNodeLocal`). Loopback with no forwarding header still works for Caddy on this host.
- **bug-416** — Namespace-host advertise uses HTTP `/v1/health`, the same probe as withdraw. TCP-open no longer re-enables a gateway that is not ready.
- **bug-417** — Custom-domain verify writes the A record before answering `verified`.
- **bug-418** — `orama node remove` and membership drop system/apex/glue A records while the `dns_nodes` row still exists, so they cannot be stranded.
- **bug-419** — Drop unused `reserved_domains`. Namespace create denylist covers the platform labels. Deprovision deletes stealth TURNS records.
- **bug-420** — `CreateNamespaceRecords` is additive (`AddNamespaceRecord`), not DELETE-all-then-INSERT.

Stacked on #123 (feat-216).

## Already tracked, not in this PR

- bug-116 CoreDNS public `:53` (nameservers must listen publicly; remaining work is RRL)
- bug-158 / bug-286 / bug-295 namespace DNS reclaim and withdraw (already shipped)
- bug-268 / feat-269 RQLite HTTP auth
- ARCH-2 placement of DNS tables
- ARCH-4 node-stamp for `dns_nodes` self-register (already shipped)

## Test plan

- [x] `go test ./...` in `core/` (pre-push hook)
- [x] ACME: loopback no `X-Forwarded-For` → 200; loopback + header → 404
- [x] Advertise: HTTP 200 writes DNS; TCP-open 404 does not
- [x] CreateNamespaceRecords issues no DELETE of the round-robin set
- [x] Retirement plan deletes `namespace='system'` A records after marking inactive
- [x] Membership drops system A records before `DELETE FROM dns_nodes`
- [ ] Not tested: live ACME issuance, live `orama node remove` on a disposable cluster (no deploy)

## Distributed system impact

- [x] Raft quorum / RQLite — migration 056 drops an unused table (`DROP IF EXISTS`, idempotent)
- [ ] WireGuard mesh / networking
- [ ] Olric gossip / caching
- [ ] Service startup ordering
- [x] Rolling upgrade compatibility — ACME present from Caddy on localhost is unchanged; internet callers start getting 404

## Checklist

- [x] Tests added for new functionality or bug fix
- [x] No debug code left behind
- [x] Docs updated (`docs/API_SURFACE.md`, `docs/NODE_REPLACEMENT.md`, whitepaper table)
- [x] Errors wrapped with context

## Out of scope

- CoreDNS ACL / rate-limit (bug-116 — overlay ACL would break public nameservers)
- RQLite `-auth` (feat-269)
- Moving DNS tables off the tenant DB (ARCH-2)