### PR TITLE
CHG-203: finish the enrollment seal — no header leak, no GET for the code

### DIFF
--- a/core/cmd/orama/internal/cmd/node/enroll.go
+++ b/core/cmd/orama/internal/cmd/node/enroll.go
@@ -12,12 +12,14 @@ var enrollCmd = &cobra.Command{
 	Short: "Enroll an OramaOS node into the cluster",
 	Long: `Enroll a freshly booted OramaOS node into the cluster.
 
-The OramaOS node displays a registration code on port 9999. Provide this code
-along with an invite token to complete enrollment. The Gateway pushes cluster
-configuration (WireGuard, secrets, peer list) to the node.
+The OramaOS node prints a registration code on its console. Provide that code
+along with an invite token. The Gateway pushes cluster configuration
+(WireGuard, secrets, peer list) to the node, sealed under the code.
+
+The code is not served over the network. A GET on port 9999 used to return it.
 
 Usage:
-  orama node enroll --node-ip <ip> --code <code> --token <invite-token> --env <environment>
+  orama node enroll --node-ip <ip> --code <code> --token <invite-token> --gateway <url>
 
 The node must be reachable over the public internet on port 9999 (enrollment only).
 After enrollment, port 9999 is permanently closed and all communication goes over WireGuard.`,
@@ -29,8 +31,12 @@ After enrollment, port 9999 is permanently closed and all communication goes ove
 func init() {
 	f := enrollCmd.Flags()
 	f.StringVar(&enrollFlags.NodeIP, "node-ip", "", "Public IP of the OramaOS node (required)")
-	f.StringVar(&enrollFlags.Code, "code", "", "Registration code from the node (auto-fetched if not provided)")
+	f.StringVar(&enrollFlags.Code, "code", "", "Registration code from the node's console (required)")
 	f.StringVar(&enrollFlags.Token, "token", "", "Invite token for cluster joining (required)")
 	f.StringVar(&enrollFlags.GatewayURL, "gateway", "", "Gateway URL (required, e.g. https://gateway.example.com)")
 	f.StringVar(&enrollFlags.Env, "env", "production", "Environment name")
+	_ = enrollCmd.MarkFlagRequired("code")
+	_ = enrollCmd.MarkFlagRequired("node-ip")
+	_ = enrollCmd.MarkFlagRequired("token")
+	_ = enrollCmd.MarkFlagRequired("gateway")
 }

--- a/core/cmd/orama/internal/production/enroll/command.go
+++ b/core/cmd/orama/internal/production/enroll/command.go
@@ -1,7 +1,7 @@
 // Package enroll implements the OramaOS node enrollment command.
 //
 // Flow:
-//  1. Operator fetches registration code from the OramaOS node (port 9999)
+//  1. Operator reads the registration code from the OramaOS node's console
 //  2. Operator provides code + invite token to Gateway
 //  3. Gateway validates, generates cluster config, pushes to node
 //  4. Node configures WireGuard, encrypts data partition, starts services
@@ -11,40 +11,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/DeBrosOfficial/network/cmd/orama/internal/clierr"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/DeBrosOfficial/network/cmd/orama/internal/clierr"
 )
 
-// Handle processes the enroll command.
+// Run processes the enroll command.
 func Run(flags *Flags) error {
 	if err := flags.validate(); err != nil {
 		return err
 	}
 
-	// Step 1: Fetch registration code from the OramaOS node
-	fmt.Printf("Fetching registration code from %s:9999...\n", flags.NodeIP)
-
-	var code string
-	if flags.Code != "" {
-		// Code provided directly — skip fetch
-		code = flags.Code
-	} else {
-		fetchedCode, err := fetchRegistrationCode(flags.NodeIP)
-		if err != nil {
-			return clierr.Unavailable("could not reach the OramaOS node: %w\n"+
-				"  Make sure the node is booted and port 9999 is reachable", err)
-		}
-		code = fetchedCode
-	}
-
-	fmt.Printf("Registration code: %s\n", code)
-
-	// Step 2: Send enrollment request to the Gateway
 	fmt.Printf("Sending enrollment to Gateway at %s...\n", flags.GatewayURL)
 
-	if err := enrollWithGateway(flags.GatewayURL, flags.Token, code, flags.NodeIP); err != nil {
+	if err := enrollWithGateway(flags.GatewayURL, flags.Token, flags.Code, flags.NodeIP); err != nil {
 		return clierr.Failure("enrollment failed: %w", err)
 	}
 
@@ -52,33 +34,6 @@ func Run(flags *Flags) error {
 	fmt.Printf("The node is now configuring WireGuard and encrypting its data partition.\n")
 	fmt.Printf("This may take a few minutes. Check status with: orama node status --env %s\n", flags.Env)
 	return nil
-}
-
-// fetchRegistrationCode retrieves the one-time registration code from the OramaOS node.
-func fetchRegistrationCode(nodeIP string) (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://%s:9999/", nodeIP))
-	if err != nil {
-		return "", fmt.Errorf("GET failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusGone {
-		return "", fmt.Errorf("registration code already served (node may be partially enrolled)")
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
-	}
-
-	var result struct {
-		Code    string `json:"code"`
-		Expires string `json:"expires"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("invalid response: %w", err)
-	}
-
-	return result.Code, nil
 }
 
 // enrollWithGateway sends the enrollment request to the Gateway, which validates

--- a/core/cmd/orama/internal/production/enroll/flags.go
+++ b/core/cmd/orama/internal/production/enroll/flags.go
@@ -7,7 +7,7 @@ import (
 // Flags holds the parsed command-line flags for the enroll command.
 type Flags struct {
 	NodeIP     string // Public IP of the OramaOS node
-	Code       string // Registration code (optional — fetched automatically if not provided)
+	Code       string // Registration code from the node's console
 	Token      string // Invite token for cluster joining
 	GatewayURL string // Gateway HTTPS URL
 	Env        string // Environment name (for display only)
@@ -17,6 +17,9 @@ type Flags struct {
 func (f *Flags) validate() error {
 	if f.NodeIP == "" {
 		return fmt.Errorf("--node-ip is required")
+	}
+	if f.Code == "" {
+		return fmt.Errorf("--code is required: read it from the node's console")
 	}
 	if f.Token == "" {
 		return fmt.Errorf("--token is required")

--- a/core/cmd/orama/internal/production/enroll/flags_test.go
+++ b/core/cmd/orama/internal/production/enroll/flags_test.go
@@ -1,0 +1,19 @@
+package enroll
+
+import "testing"
+
+func TestValidate_requiresTheConsoleCode(t *testing.T) {
+	f := Flags{NodeIP: "203.0.113.10", Token: "tok", GatewayURL: "https://gw.example"}
+	err := f.validate()
+	if err == nil {
+		t.Fatal("missing --code was accepted — the agent no longer serves the code")
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("empty error")
+	}
+
+	f.Code = "a1b2c3d4e5f60718293a"
+	if err := f.validate(); err != nil {
+		t.Fatalf("valid flags refused: %v", err)
+	}
+}

--- a/core/pkg/gateway/handlers/enroll/handler.go
+++ b/core/pkg/gateway/handlers/enroll/handler.go
@@ -97,6 +97,15 @@ func (h *Handler) HandleEnroll(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "node_ip must be a valid IPv4 address", http.StatusBadRequest)
 		return
 	}
+	// This address is stored as wireguard_peers.public_ip (the Endpoint of
+	// every other node) AND is the target of an outbound HTTP push from this
+	// gateway. A loopback, RFC1918, link-local or metadata address is both a
+	// useless mesh endpoint and an SSRF. Refuse it before the invite token is
+	// consumed.
+	if reservedNodeIP(nodeIP) {
+		http.Error(w, "node_ip must be a public IPv4 address", http.StatusBadRequest)
+		return
+	}
 	req.NodeIP = nodeIP.String()
 
 	ctx := r.Context()
@@ -254,10 +263,11 @@ func (h *Handler) consumeToken(ctx context.Context, token, usedByIP string) erro
 // under the registration code the operator carried from its console, and
 // returns the credential the node mints for this gateway.
 //
-// The payload carries the cluster secret, the swarm key and the node's
-// WireGuard configuration. It used to be plaintext JSON over HTTP on the node's
-// public IP, to an endpoint that accepted any POST at all — so it could be read
-// by anyone on the path and written by anyone who got there first.
+// The payload carries the cluster secret and the node's WireGuard
+// configuration. It used to be plaintext JSON over HTTP on the node's public
+// IP, to an endpoint that accepted any POST at all — so it could be read by
+// anyone on the path and written by anyone who got there first. The code is
+// not sent as a header: decrypting the body is the proof the caller holds it.
 func (h *Handler) pushConfigToNode(nodeIP, code string, config *EnrollResponse) (string, error) {
 	return h.pushConfigTo(fmt.Sprintf("http://%s:9999/v1/agent/enroll/complete", nodeIP), code, config)
 }
@@ -279,17 +289,21 @@ func (h *Handler) pushConfigTo(endpoint, code string, config *EnrollResponse) (s
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set(HeaderEnrollmentCode, code)
 	req.Header.Set("Content-Type", "text/plain")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to push config: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusBadRequest {
 		return "", fmt.Errorf("the node rejected the registration code: check the code " +
 			"shown on its console")
 	}

--- a/core/pkg/gateway/handlers/enroll/nodeip.go
+++ b/core/pkg/gateway/handlers/enroll/nodeip.go
@@ -1,0 +1,26 @@
+package enroll
+
+import "net"
+
+// reservedNodeIP reports whether ip is not a usable public endpoint for an
+// OramaOS node. The value is stored as wireguard_peers.public_ip (the
+// Endpoint of every other node) and is the target of this gateway's outbound
+// enroll push, so loopback, RFC1918, link-local, CGNAT and unspecified
+// addresses are both a broken mesh endpoint and an SSRF.
+func reservedNodeIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		// 100.64.0.0/10 — carrier-grade NAT (not covered by IsPrivate).
+		if ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
+			return true
+		}
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}

--- a/core/pkg/gateway/handlers/enroll/nodeip_test.go
+++ b/core/pkg/gateway/handlers/enroll/nodeip_test.go
@@ -1,0 +1,59 @@
+package enroll
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestReservedNodeIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"203.0.113.10", false},
+		{"8.8.8.8", false},
+		{"127.0.0.1", true},
+		{"10.0.0.4", true},
+		{"192.168.1.1", true},
+		{"172.16.0.1", true},
+		{"169.254.169.254", true},
+		{"100.64.0.1", true},
+		{"0.0.0.0", true},
+		{"224.0.0.1", true},
+	}
+	for _, tc := range tests {
+		got := reservedNodeIP(net.ParseIP(tc.ip))
+		if got != tc.want {
+			t.Errorf("reservedNodeIP(%s) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+	if !reservedNodeIP(nil) {
+		t.Error("reservedNodeIP(nil) = false, want true")
+	}
+}
+
+// A reserved address must be refused before the invite token is consumed, so
+// pointing enroll at loopback or a cloud metadata address cannot spend a token
+// and cannot make this gateway issue an outbound request.
+func TestHandleEnroll_refusesAReservedNodeIP(t *testing.T) {
+	h := NewHandler(zap.NewNop(), nil, "")
+	for _, ip := range []string{"127.0.0.1", "10.0.0.1", "169.254.169.254", "100.64.1.1"} {
+		body, err := json.Marshal(EnrollRequest{Code: "abcd", Token: "tok", NodeIP: ip})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/node/enroll", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.HandleEnroll(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status %d, want 400 — this address is an SSRF and a useless WG endpoint",
+				ip, rec.Code)
+		}
+	}
+}

--- a/core/pkg/gateway/handlers/enroll/push_test.go
+++ b/core/pkg/gateway/handlers/enroll/push_test.go
@@ -11,14 +11,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// fakeAgent is an OramaOS node's enrollment listener: it requires the
-// registration code, opens the payload under it, and seals its answer.
+// fakeAgent is an OramaOS node's enrollment listener: it opens the payload
+// under the registration code and seals its answer. The code is not a header.
 func fakeAgent(t *testing.T, code, agentToken string, received *EnrollResponse) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(HeaderEnrollmentCode) != code {
-			http.Error(w, "registration code mismatch", http.StatusUnauthorized)
-			return
+		if r.Header.Get("X-Orama-Enrollment-Code") != "" {
+			t.Error("the gateway sent the registration code as a header")
 		}
 		raw, _ := io.ReadAll(r.Body)
 		plaintext, err := Open(code, string(raw))

--- a/core/pkg/gateway/handlers/enroll/sealed.go
+++ b/core/pkg/gateway/handlers/enroll/sealed.go
@@ -13,26 +13,22 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// Enrollment hands a booting OramaOS node the cluster secret, the swarm key and
-// its WireGuard configuration. That exchange used to happen over plaintext HTTP
-// on the node's public IP with no authentication in either direction: the node
-// served its registration code to whoever asked first, its config endpoint
-// accepted any POST, and the cluster secret crossed the network in the clear.
+// Enrollment hands a booting OramaOS node the cluster secret and its WireGuard
+// configuration. That exchange used to happen over plaintext HTTP on the node's
+// public IP with no authentication in either direction: the node served its
+// registration code to whoever asked first, its config endpoint accepted any
+// POST, and the cluster secret crossed the network in the clear.
 //
 // The registration code is the only secret both ends share before the node is a
 // member of anything, and the operator carries it from the node's console to
 // this gateway. So it authenticates the exchange and encrypts the payload, and
-// it is never fetched from the node — this gateway proves it holds the code
-// instead of asking for it.
+// it is never fetched from the node — this gateway proves it holds the code by
+// producing a payload that decrypts under it. The code is not sent as a header.
 //
 // This is the mirror of os/agent/internal/enroll/sealed.go. The two are
 // separate Go modules and cannot share the code, so a shared vector in
 // contracts/ pins the format: change one side and the other side's test fails.
 const (
-	// HeaderEnrollmentCode carries the registration code the operator read off
-	// the node's console.
-	HeaderEnrollmentCode = "X-Orama-Enrollment-Code"
-
 	// sealPurpose is the HKDF domain separator.
 	sealPurpose = "orama-enrollment-seal-v1"
 )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1178,7 +1178,7 @@ These OramaOS properties do **not** apply to the production Ubuntu fleet (sandbo
 - Command reception from Gateway over WireGuard (port 9998)
 - OS updates (download, verify, A/B swap, reboot with rollback)
 
-**Node enrollment:** OramaOS nodes join via `orama node enroll` instead of `orama node install`. The enrollment flow uses a registration code + invite token + wallet verification.
+**Node enrollment:** OramaOS nodes join via `orama node enroll` instead of `orama node install`. The operator reads an 80-bit registration code off the node's console and gives it to the CLI with an invite token; the gateway pushes cluster config sealed under that code. There is no WebSocket enrollment path.
 
 See [ORAMAOS_DEPLOYMENT.md](ORAMAOS_DEPLOYMENT.md) for the full deployment guide.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1601,19 +1601,21 @@ orama node enroll [flags]
 
 Enroll a freshly booted OramaOS node into the cluster.
 
-The OramaOS node displays a registration code on port 9999. Provide this code
-along with an invite token to complete enrollment. The Gateway pushes cluster
-configuration (WireGuard, secrets, peer list) to the node.
+The OramaOS node prints a registration code on its console. Provide that code
+along with an invite token. The Gateway pushes cluster configuration
+(WireGuard, secrets, peer list) to the node, sealed under the code.
+
+The code is not served over the network. A GET on port 9999 used to return it.
 
 Usage:
-  orama node enroll --node-ip <ip> --code <code> --token <invite-token> --env <environment>
+  orama node enroll --node-ip <ip> --code <code> --token <invite-token> --gateway <url>
 
 The node must be reachable over the public internet on port 9999 (enrollment only).
 After enrollment, port 9999 is permanently closed and all communication goes over WireGuard.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--code` | — | Registration code from the node (auto-fetched if not provided) |
+| `--code` | — | Registration code from the node's console (required) |
 | `--env` | `production` | Environment name |
 | `--gateway` | — | Gateway URL (required, e.g. https://gateway.example.com) |
 | `--node-ip` | — | Public IP of the OramaOS node (required) |

--- a/docs/COMMON_PROBLEMS.md
+++ b/docs/COMMON_PROBLEMS.md
@@ -266,9 +266,9 @@ orama node unlock --genesis --node-ip <wg-ip>
 
 **Symptom:** `orama node enroll` hangs or times out.
 
-**Cause:** The OramaOS node's port 9999 isn't reachable, or the Gateway can't reach the node's WebSocket.
+**Cause:** The OramaOS node's port 9999 isn't reachable from the gateway, `--code` is missing or wrong, or `--node-ip` is not the node's public IPv4.
 
-**Fix:** Check that port 9999 is open in your VPS provider's external firewall (Hetzner firewall, AWS security groups, etc.). OramaOS opens it internally, but provider-level firewalls must be configured separately.
+**Fix:** Read the registration code from the node's console (it is not served on port 9999). Check that port 9999 is open in your VPS provider's external firewall (Hetzner firewall, AWS security groups, etc.). OramaOS opens it internally, but provider-level firewalls must be configured separately. There is no WebSocket enrollment path.
 
 ---
 

--- a/docs/DEV_DEPLOY.md
+++ b/docs/DEV_DEPLOY.md
@@ -770,8 +770,8 @@ For OramaOS nodes (mainnet, devnet, testnet), use the enrollment flow instead of
 # 2. Generate invite token on existing cluster node
 orama node invite --expiry 24h
 
-# 3. Enroll the OramaOS node
-orama node enroll --node-ip <vps-public-ip> --token <invite-token> --gateway <gateway-url>
+# 3. Enroll the OramaOS node — --code is printed on the node's console
+orama node enroll --node-ip <vps-public-ip> --code <registration-code> --token <invite-token> --gateway <gateway-url>
 
 # 4. For genesis node reboots (before 5+ peers exist)
 orama node unlock --genesis --node-ip <wg-ip>

--- a/docs/ORAMAOS_DEPLOYMENT.md
+++ b/docs/ORAMAOS_DEPLOYMENT.md
@@ -53,11 +53,11 @@ wget https://releases.orama.network/oramaos-v1.0.0-amd64.qcow2
 ### Step 2: First Boot — Enrollment Mode
 
 On first boot, the agent:
-1. Generates a random 8-character registration code
-2. Starts a temporary HTTP server on port 9999 that serves the code (one-shot)
-3. Waits for the Gateway to push cluster config via HTTP `POST` to `/v1/agent/enroll/complete` on port 9999
+1. Generates an 80-bit registration code (20 hex characters)
+2. Prints it on the console TTY (not the journal)
+3. Starts a temporary HTTP server on port 9999 and waits for the Gateway to `POST` a payload sealed under that code to `/v1/agent/enroll/complete`
 
-The registration code is displayed on the VPS console (if available) and served at `http://<vps-ip>:9999/`.
+The code is **not** served over the network. A `GET` on port 9999 used to return it.
 
 ### Step 3: Run Enrollment from CLI
 
@@ -67,18 +67,17 @@ On your local machine (where you have the `orama` CLI and rootwallet):
 # Generate an invite token on any existing cluster node
 orama node invite --expiry 24h
 
-# Enroll the OramaOS node
-orama node enroll --node-ip <vps-public-ip> --token <invite-token> --gateway <gateway-url>
+# Enroll the OramaOS node — --code is the value printed on the node's console
+orama node enroll --node-ip <vps-public-ip> --code <registration-code> --token <invite-token> --gateway <gateway-url>
 ```
 
 The enrollment command:
-1. Fetches the registration code from the node (port 9999)
-2. Sends the code + invite token to the Gateway
-3. Gateway validates everything, assigns a WireGuard IP, and pushes config to the node
-4. Node configures WireGuard, formats the LUKS-encrypted data partition
-5. LUKS key is split via Shamir and distributed to peer vault-guardians
-6. Services start in sandboxed namespaces
-7. Port 9999 closes permanently
+1. Sends the console code + invite token + public node IP to the Gateway
+2. Gateway validates the invite, assigns a WireGuard IP, and pushes config sealed under the code
+3. Node configures WireGuard, formats the LUKS-encrypted data partition
+4. LUKS key is split via Shamir and distributed to peer vault-guardians
+5. Services start in sandboxed namespaces
+6. Port 9999 closes permanently
 
 ### Step 4: Verify
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -142,13 +142,15 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - The agent's command receiver binds the node's overlay address and requires a per-node bearer token on every route. It bound every interface — under a comment claiming WireGuard only — and checked nothing, so restarting any service on any node took one POST from anywhere that could route to it. Being on the mesh is not the credential: every namespace's services are on that mesh
 - The token is minted by the node at enrollment, written `0600` on its encrypted data partition, and stored on the gateway encrypted with a key derived from the cluster secret (`HKDF(cluster secret, "node-agent-token")`), because the gateway has to present it and so cannot hash it
 - A node with no address or no token starts **no** receiver. Falling back to listening on everything without a credential is the state this exists to end
-- Enrollment is sealed under the registration code the operator carries from the node's console: AES-256-GCM with `HKDF(code, "orama-enrollment-seal-v1")`, in both directions. The cluster secret, the swarm key and the WireGuard configuration used to cross the network as plaintext JSON over HTTP on the node's public IP, to an endpoint that accepted any POST — so anyone who reached a booting node first could enrol it into their own cluster
-- The code is never served. A `GET` on `:9999` returned it to whoever asked, which published the one secret the operator carried and let anyone race them for it. The gateway proves it holds the code instead of fetching it, and a wrong one fails to decrypt at the node
-- The code is 80 bits, up from 32. It keys the payload that carries the cluster secret, so it is a key rather than an identifier
+- Enrollment is sealed under the registration code the operator carries from the node's console: AES-256-GCM with `HKDF(code, "orama-enrollment-seal-v1")`, in both directions. The cluster secret and the WireGuard configuration used to cross the network as plaintext JSON over HTTP on the node's public IP, to an endpoint that accepted any POST — so anyone who reached a booting node first could enrol it into their own cluster
+- The code is never served. A `GET` on `:9999` returned it to whoever asked, which published the one secret the operator carried and let anyone race them for it. The gateway proves it holds the code by producing a payload that decrypts under it. The code is not sent as an HTTP header (that put the seal key on the wire next to the ciphertext). A second `POST` to `/complete` is `409`
+- The code is printed to the console TTY, not `log.Printf` / the journal. It is 80 bits, up from 32. It keys the payload that carries the cluster secret, so it is a key rather than an identifier
 - The seal has a copy in each of two Go modules, which cannot import each other. `contracts/enrollment/seal.json` pins the derivation, and each side's tests check against it
 
 **Node enrolment (`/v1/node/enroll`)**
 - `node_ip` is parsed as IPv4 and stored canonicalised. It is rendered into `Endpoint =` in the `wg0.conf` of every other node, so an unvalidated value is a WireGuard config injection
+- `node_ip` must be a public IPv4 address. Loopback, RFC1918, link-local, CGNAT and unspecified addresses are refused before the invite token is consumed: they are a useless mesh endpoint and an SSRF (the gateway POSTs to `http://<node_ip>:9999/...`)
+- `orama node enroll` requires `--code` from the console. It used to GET `:9999/` for the code; that endpoint no longer exists
 
 **RQLite Authentication (Step 1.7 / feat-269)**
 - Credentials are generated at genesis (`rqlite-auth.json` / `rqlite-password`) and written into `node.yaml`

--- a/os/agent/internal/boot/boot.go
+++ b/os/agent/internal/boot/boot.go
@@ -44,10 +44,6 @@ const (
 	// WireGuardConfigPath is the path to the WireGuard configuration baked into rootfs
 	// during enrollment, or written during first boot.
 	WireGuardConfigPath = "/etc/wireguard/wg0.conf"
-
-	// GatewayEndpoint is the default gateway URL for enrollment WebSocket.
-	// Overridden by /etc/orama/gateway-url if present.
-	GatewayEndpoint = "wss://gateway.orama.network/v1/agent/enroll"
 )
 
 // Agent is the main orchestrator for the OramaOS node.
@@ -94,7 +90,7 @@ func (a *Agent) enrollmentBoot() error {
 	log.Println("ENROLLMENT MODE: first boot detected")
 
 	// 1. Start enrollment server on port 9999
-	enrollServer := enroll.NewServer(resolveGatewayEndpoint())
+	enrollServer := enroll.NewServer()
 	result, agentToken, err := enrollServer.Run()
 	if err != nil {
 		return fmt.Errorf("enrollment failed: %w", err)
@@ -317,13 +313,4 @@ func (a *Agent) Shutdown() {
 	if a.supervisor != nil {
 		a.supervisor.StopAll()
 	}
-}
-
-// resolveGatewayEndpoint reads the gateway URL from config or uses the default.
-func resolveGatewayEndpoint() string {
-	data, err := os.ReadFile("/etc/orama/gateway-url")
-	if err == nil {
-		return string(data)
-	}
-	return GatewayEndpoint
 }

--- a/os/agent/internal/enroll/sealed.go
+++ b/os/agent/internal/enroll/sealed.go
@@ -15,10 +15,9 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// Enrollment hands a booting node the cluster secret, the swarm key and its
-// WireGuard configuration — everything needed to be a member of the cluster.
-// That exchange used to happen over plaintext HTTP on the node's public IP,
-// with no authentication in either direction:
+// Enrollment hands a booting node the cluster secret and its WireGuard
+// configuration. That exchange used to happen over plaintext HTTP on the
+// node's public IP, with no authentication in either direction:
 //
 //   - the node served its registration code to whoever asked first, so the
 //     secret meant to prove the operator's identity was published;
@@ -30,19 +29,14 @@ import (
 // The registration code is the only secret both ends share before the node is
 // a member of anything, and the operator carries it from the node's console to
 // the gateway. So it is what authenticates the exchange and what the payload is
-// encrypted under. The code is never sent anywhere it could be read: the
-// gateway proves it knows it, rather than asking for it.
+// encrypted under. Successful decrypt is the proof: the code is not sent as a
+// header, which used to put the seal key on the wire next to the ciphertext.
 //
 // Phase 1 of the auth redesign replaces this with a node principal credential
 // issued at join. Until then this is a code the operator physically carried,
 // used as a code should be.
 
 const (
-	// HeaderEnrollmentCode carries the registration code the operator read off
-	// the node's console. It proves the caller is the gateway the operator
-	// spoke to, and it keys the payload.
-	HeaderEnrollmentCode = "X-Orama-Enrollment-Code"
-
 	// sealPurpose is the HKDF domain separator, so the key that encrypts an
 	// enrollment payload is unrelated to anything else derived from the code.
 	sealPurpose = "orama-enrollment-seal-v1"

--- a/os/agent/internal/enroll/sealed_test.go
+++ b/os/agent/internal/enroll/sealed_test.go
@@ -8,9 +8,8 @@ import (
 
 const testCode = "a1b2c3d4e5f60718293a"
 
-// Enrollment carries the cluster secret, the swarm key and the node's WireGuard
-// configuration. It used to cross the network as plaintext JSON on the node's
-// public IP.
+// Enrollment carries the cluster secret and the node's WireGuard configuration.
+// It used to cross the network as plaintext JSON on the node's public IP.
 func TestSealAndOpen_roundTrip(t *testing.T) {
 	payload := []byte(`{"cluster_secret":"the-cluster-secret"}`)
 

--- a/os/agent/internal/enroll/server.go
+++ b/os/agent/internal/enroll/server.go
@@ -2,24 +2,26 @@
 //
 // On first boot the agent prints a registration code on the console and listens
 // on port 9999. The operator reads the code off the console and gives it to the
-// gateway (`orama node enroll`). The gateway proves it holds that code and
-// sends the cluster configuration encrypted under it.
+// gateway (`orama node enroll`). The gateway proves it holds that code by
+// sending a payload that decrypts under it.
 //
 // The code is never served over the network. It used to be: a GET on / handed
 // it to whoever asked first, which both published the secret and let anyone
-// race the operator for it.
+// race the operator for it. It was also sent as an HTTP header on the
+// completion POST, which put the seal key on the wire next to the ciphertext.
 package enroll
 
 import (
 	"context"
 	"crypto/rand"
-	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/DeBrosOfficial/orama-os/agent/internal/types"
@@ -56,15 +58,13 @@ type completionResponse struct {
 
 // Server is the enrollment HTTP server.
 type Server struct {
-	gatewayURL string
-	done       chan struct{}
+	done chan struct{}
 }
 
 // NewServer creates a new enrollment server.
-func NewServer(gatewayURL string) *Server {
+func NewServer() *Server {
 	return &Server{
-		gatewayURL: gatewayURL,
-		done:       make(chan struct{}),
+		done: make(chan struct{}),
 	}
 }
 
@@ -81,8 +81,10 @@ func (s *Server) Run() (*Result, string, error) {
 		return nil, "", fmt.Errorf("failed to generate agent token: %w", err)
 	}
 
-	// The console is the only place this is printed. Nothing serves it.
-	log.Printf("ENROLLMENT CODE: %s", code)
+	// The console is the only place this is printed. The journal used to
+	// receive it via log.Printf, so anyone who could read `orama node logs`
+	// during the window had the seal key.
+	printEnrollmentCode(code)
 	log.Printf("Waiting for enrollment on port 9999...")
 
 	enrollCh := make(chan *Result, 1)
@@ -116,23 +118,32 @@ func (s *Server) Run() (*Result, string, error) {
 	}
 }
 
+// printEnrollmentCode writes the registration code to the console TTY, not the
+// process logger. The unit captures stdout/stderr into the journal.
+func printEnrollmentCode(code string) {
+	line := fmt.Sprintf("ENROLLMENT CODE: %s\n", code)
+	f, err := os.OpenFile("/dev/console", os.O_WRONLY, 0)
+	if err != nil {
+		// Tests and hosts without a console still need the operator to see it.
+		_, _ = os.Stderr.WriteString(line)
+		return
+	}
+	defer f.Close()
+	_, _ = io.WriteString(f, line)
+}
+
 // completeHandler accepts the cluster configuration, from a caller that proves
-// it holds the registration code.
+// it holds the registration code by producing a payload that decrypts under it.
 //
 // This endpoint used to accept any POST at all: reaching a booting node before
 // its operator's gateway did was enough to enrol it into another cluster, with
-// another cluster's WireGuard peers.
+// another cluster's WireGuard peers. It then required the code in a header,
+// which put the seal key on the wire next to the ciphertext.
 func (s *Server) completeHandler(code, agentToken string, enrolled chan<- *Result) http.HandlerFunc {
+	var taken atomic.Bool
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		presented := r.Header.Get(HeaderEnrollmentCode)
-		if subtle.ConstantTimeCompare([]byte(presented), []byte(code)) != 1 {
-			log.Printf("refused an enrollment attempt with the wrong registration code from %s", r.RemoteAddr)
-			http.Error(w, "registration code mismatch", http.StatusUnauthorized)
 			return
 		}
 
@@ -142,11 +153,9 @@ func (s *Server) completeHandler(code, agentToken string, enrolled chan<- *Resul
 			return
 		}
 
-		// The code authenticated the header; this authenticates the payload,
-		// and is what makes the cluster secret unreadable on the wire.
 		plaintext, err := Open(code, string(body))
 		if err != nil {
-			log.Printf("refused an enrollment payload that did not decrypt: %v", err)
+			log.Printf("refused an enrollment payload that did not decrypt from %s: %v", r.RemoteAddr, err)
 			http.Error(w, "the enrollment payload did not decrypt", http.StatusBadRequest)
 			return
 		}
@@ -160,6 +169,11 @@ func (s *Server) completeHandler(code, agentToken string, enrolled chan<- *Resul
 		sealed, err := Seal(code, mustJSON(completionResponse{Status: "ok", AgentToken: agentToken}))
 		if err != nil {
 			http.Error(w, "could not seal the response", http.StatusInternalServerError)
+			return
+		}
+
+		if !taken.CompareAndSwap(false, true) {
+			http.Error(w, "enrollment already complete", http.StatusConflict)
 			return
 		}
 

--- a/os/agent/internal/enroll/server_test.go
+++ b/os/agent/internal/enroll/server_test.go
@@ -8,63 +8,42 @@ import (
 	"testing"
 )
 
-func completeRequest(t *testing.T, code string, payload any) *http.Request {
+func completeRequest(t *testing.T, sealUnder string, payload any) *http.Request {
 	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	sealed, err := Seal(testCode, body)
+	sealed, err := Seal(sealUnder, body)
 	if err != nil {
 		t.Fatalf("seal: %v", err)
 	}
-	r := httptest.NewRequest(http.MethodPost, "/v1/agent/enroll/complete", strings.NewReader(sealed))
-	if code != "" {
-		r.Header.Set(HeaderEnrollmentCode, code)
-	}
-	return r
+	return httptest.NewRequest(http.MethodPost, "/v1/agent/enroll/complete", strings.NewReader(sealed))
 }
 
 // The endpoint used to accept any POST at all: reaching a booting node before
 // its operator's gateway did was enough to enrol it into another cluster, with
 // another cluster's WireGuard peers and cluster secret.
-func TestCompleteHandler_refusesWithoutTheCode(t *testing.T) {
-	s := NewServer("")
-	enrolled := make(chan *Result, 1)
-	w := httptest.NewRecorder()
-
-	s.completeHandler(testCode, "token", enrolled)(w, completeRequest(t, "", Result{NodeID: "attacker"}))
-
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status %d, want 401", w.Code)
-	}
-	select {
-	case r := <-enrolled:
-		t.Errorf("the node was enrolled as %q by a caller with no code", r.NodeID)
-	default:
-	}
-}
-
-func TestCompleteHandler_refusesTheWrongCode(t *testing.T) {
-	s := NewServer("")
+func TestCompleteHandler_refusesAPayloadItCannotOpen(t *testing.T) {
+	s := NewServer()
 	enrolled := make(chan *Result, 1)
 	w := httptest.NewRecorder()
 
 	s.completeHandler(testCode, "token", enrolled)(w,
 		completeRequest(t, "00000000000000000000", Result{NodeID: "attacker"}))
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status %d, want 401", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status %d, want 400", w.Code)
 	}
 	select {
-	case <-enrolled:
-		t.Error("the node was enrolled by a caller with the wrong code")
+	case r := <-enrolled:
+		t.Errorf("the node was enrolled as %q by a caller who did not know the code", r.NodeID)
 	default:
 	}
 }
 
 func TestCompleteHandler_acceptsTheOperatorsGateway(t *testing.T) {
-	s := NewServer("")
+	s := NewServer()
 	enrolled := make(chan *Result, 1)
 	w := httptest.NewRecorder()
 
@@ -85,11 +64,34 @@ func TestCompleteHandler_acceptsTheOperatorsGateway(t *testing.T) {
 	}
 }
 
+// Successful decrypt is the proof. A header carrying the code used to put the
+// seal key on the wire next to the ciphertext; the handler must not need one.
+func TestCompleteHandler_doesNotRequireACodeHeader(t *testing.T) {
+	s := NewServer()
+	enrolled := make(chan *Result, 1)
+	w := httptest.NewRecorder()
+
+	r := completeRequest(t, testCode, Result{NodeID: "node-1"})
+	if r.Header.Get("X-Orama-Enrollment-Code") != "" {
+		t.Fatal("the test request still carries the enrollment-code header")
+	}
+	s.completeHandler(testCode, "token", enrolled)(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200: %s", w.Code, w.Body.String())
+	}
+	select {
+	case <-enrolled:
+	default:
+		t.Fatal("a payload that decrypted was refused because no header was sent")
+	}
+}
+
 // The agent mints its own credential and hands it back sealed. The gateway
 // presents it on every later command; anyone watching the exchange must not
 // learn it.
 func TestCompleteHandler_returnsTheAgentTokenSealed(t *testing.T) {
-	s := NewServer("")
+	s := NewServer()
 	enrolled := make(chan *Result, 1)
 	w := httptest.NewRecorder()
 
@@ -113,42 +115,49 @@ func TestCompleteHandler_returnsTheAgentTokenSealed(t *testing.T) {
 	}
 }
 
-// A payload sealed under a different code cannot be opened, so a caller who
-// somehow learned the code header but not the code itself gets nowhere.
-func TestCompleteHandler_refusesAPayloadItCannotOpen(t *testing.T) {
-	s := NewServer("")
-	enrolled := make(chan *Result, 1)
-	w := httptest.NewRecorder()
-
-	sealed, err := Seal("00000000000000000000", []byte(`{"node_id":"attacker"}`))
-	if err != nil {
-		t.Fatalf("seal: %v", err)
-	}
-	r := httptest.NewRequest(http.MethodPost, "/v1/agent/enroll/complete", strings.NewReader(sealed))
-	r.Header.Set(HeaderEnrollmentCode, testCode)
-
-	s.completeHandler(testCode, "token", enrolled)(w, r)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status %d, want 400", w.Code)
-	}
-	select {
-	case <-enrolled:
-		t.Error("a payload that did not decrypt enrolled the node")
-	default:
-	}
-}
-
 func TestCompleteHandler_refusesOtherMethods(t *testing.T) {
-	s := NewServer("")
+	s := NewServer()
 	enrolled := make(chan *Result, 1)
 	w := httptest.NewRecorder()
 
 	r := httptest.NewRequest(http.MethodGet, "/v1/agent/enroll/complete", nil)
-	r.Header.Set(HeaderEnrollmentCode, testCode)
 	s.completeHandler(testCode, "token", enrolled)(w, r)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status %d, want 405", w.Code)
+	}
+}
+
+// A second POST that decrypts used to land on a size-1 channel after a 200,
+// so the first writer won and the second blocked. The second is 409.
+func TestCompleteHandler_refusesASecondComplete(t *testing.T) {
+	s := NewServer()
+	enrolled := make(chan *Result, 2)
+	h := s.completeHandler(testCode, "token", enrolled)
+
+	first := httptest.NewRecorder()
+	h(first, completeRequest(t, testCode, Result{NodeID: "first"}))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status %d, want 200", first.Code)
+	}
+
+	second := httptest.NewRecorder()
+	h(second, completeRequest(t, testCode, Result{NodeID: "second"}))
+	if second.Code != http.StatusConflict {
+		t.Fatalf("second status %d, want 409", second.Code)
+	}
+
+	select {
+	case got := <-enrolled:
+		if got.NodeID != "first" {
+			t.Errorf("enrolled as %q, want first", got.NodeID)
+		}
+	default:
+		t.Fatal("the first completion never enrolled the node")
+	}
+	select {
+	case got := <-enrolled:
+		t.Errorf("a second completion enrolled the node as %q", got.NodeID)
+	default:
 	}
 }

--- a/os/agent/internal/wireguard/manager.go
+++ b/os/agent/internal/wireguard/manager.go
@@ -36,6 +36,11 @@ func NewManager() *Manager {
 // Configure writes the WireGuard configuration to disk.
 // Called during enrollment with config received from the Gateway.
 func (m *Manager) Configure(config string) error {
+	priv, err := privateKeyFromConfig(config)
+	if err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll("/etc/wireguard", 0700); err != nil {
 		return fmt.Errorf("failed to create wireguard dir: %w", err)
 	}
@@ -44,8 +49,38 @@ func (m *Manager) Configure(config string) error {
 		return fmt.Errorf("failed to write WG config: %w", err)
 	}
 
+	// LUKS share distribution derives this node's vault identity as
+	// SHA-256 of this file. Writing only wg0.conf left that file missing,
+	// so enrollment failed after the gateway had already pushed config.
+	if err := os.WriteFile(PrivateKeyPath, []byte(priv+"\n"), 0600); err != nil {
+		return fmt.Errorf("failed to write WG private key: %w", err)
+	}
+
 	log.Println("WireGuard configuration written")
 	return nil
+}
+
+// privateKeyFromConfig extracts the Interface PrivateKey from a wg0.conf body.
+func privateKeyFromConfig(config string) (string, error) {
+	for _, line := range strings.Split(config, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) != "PrivateKey" {
+			continue
+		}
+		priv := strings.TrimSpace(val)
+		if priv == "" {
+			return "", fmt.Errorf("WireGuard config PrivateKey is empty")
+		}
+		return priv, nil
+	}
+	return "", fmt.Errorf("WireGuard config has no PrivateKey")
 }
 
 // Up brings the WireGuard interface up using wg-quick.

--- a/os/agent/internal/wireguard/manager_test.go
+++ b/os/agent/internal/wireguard/manager_test.go
@@ -1,0 +1,20 @@
+package wireguard
+
+import "testing"
+
+func TestPrivateKeyFromConfig(t *testing.T) {
+	got, err := privateKeyFromConfig("[Interface]\nPrivateKey = abcDEF==\nAddress = 10.0.0.4/24\n")
+	if err != nil {
+		t.Fatalf("privateKeyFromConfig: %v", err)
+	}
+	if got != "abcDEF==" {
+		t.Errorf("got %q", got)
+	}
+
+	if _, err := privateKeyFromConfig("[Interface]\nAddress = 10.0.0.4/24\n"); err == nil {
+		t.Fatal("a config with no PrivateKey was accepted")
+	}
+	if _, err := privateKeyFromConfig("[Interface]\nPrivateKey =\n"); err == nil {
+		t.Fatal("an empty PrivateKey was accepted")
+	}
+}

--- a/website/src/docs/contributor/architecture.mdx
+++ b/website/src/docs/contributor/architecture.mdx
@@ -203,7 +203,7 @@ For mainnet, devnet, and testnet, nodes run **OramaOS** — a custom minimal Lin
 - **Service sandboxing** — Linux namespaces + seccomp per service
 - **Single root process** — the orama-agent manages boot, WireGuard, services, and updates
 
-Nodes join via `orama node enroll` (not `orama node install`). The enrollment uses a registration code + invite token + wallet verification to push cluster config to the node.
+Nodes join via `orama node enroll` (not `orama node install`). The operator reads an 80-bit registration code off the node's console and gives it to the CLI with an invite token; the gateway pushes cluster config sealed under that code.
 
 Sandbox clusters remain on Ubuntu for development convenience.
 

--- a/website/src/docs/operator/orama-os.mdx
+++ b/website/src/docs/operator/orama-os.mdx
@@ -44,9 +44,11 @@ Download the OramaOS image and flash it to your VPS via your hosting provider's 
 ### 2. First Boot
 
 On first boot, the agent enters enrollment mode:
-- Generates a random 8-character registration code
-- Opens a temporary HTTP server on port 9999
-- Waits for enrollment to complete
+- Generates an 80-bit registration code (20 hex characters)
+- Prints it on the console TTY (not the journal)
+- Opens a temporary HTTP server on port 9999 and waits for a payload sealed under that code
+
+The code is not served over the network.
 
 ### 3. Enroll from CLI
 
@@ -56,14 +58,15 @@ On your local machine with the `orama` CLI and rootwallet:
 # Generate an invite token on any existing cluster node
 orama node invite --expiry 24h
 
-# Enroll the new OramaOS node
+# Enroll the new OramaOS node — --code is printed on the node's console
 orama node enroll \
   --node-ip <vps-public-ip> \
+  --code <registration-code> \
   --token <invite-token> \
   --gateway <gateway-url>
 ```
 
-This fetches the registration code, validates it with the Gateway, assigns a WireGuard IP, pushes the cluster config to the node, and triggers LUKS encryption of the data partition. The LUKS key is split via Shamir's Secret Sharing and distributed to peer vault-guardians. Port 9999 closes permanently after enrollment.
+The CLI sends the console code, invite token and public node IP to the Gateway, which assigns a WireGuard IP and pushes cluster config sealed under the code. The node configures WireGuard, LUKS-encrypts the data partition, and splits the LUKS key via Shamir across peer vault-guardians. Port 9999 closes permanently after enrollment.
 
 ### 4. Verify
 
@@ -172,7 +175,7 @@ OramaOS nodes cannot be cleaned with `orama node clean` (no SSH). Options:
 
 ### Enrollment doesn't complete
 
-Check that port 9999 is open in your VPS provider's external firewall (Hetzner firewall, AWS security groups). OramaOS opens it internally, but provider-level firewalls need manual configuration.
+Read the registration code from the node's console (`--code` is required; it is not served on port 9999). Check that port 9999 is open in your VPS provider's external firewall (Hetzner firewall, AWS security groups). There is no WebSocket enrollment path.
 
 ### LUKS unlock fails after reboot
 


### PR DESCRIPTION
Stacked on #125 (`feat-213`).

Finish the enrollment seal that already shipped (bug-354). Do not rewrite it as TLS + node-generated WG keys + a nonce.

## What changed

**BUG-44 / BUG-45 residual — code is not on the wire**
- `/v1/agent/enroll/complete` authenticates by decrypting the body under the console code. `X-Orama-Enrollment-Code` is gone; that header put the seal key next to the ciphertext.
- Gateway push no longer sets the header. Redirects on the enroll POST are refused.

**BUG-48 — second complete is 409**
- First payload that decrypts enrolls the node. A second is `409 Conflict`, not a blocked send on a size-1 channel.

**BUG-49 leftover / CLI**
- `orama node enroll` requires `--code` from the console. The GET `:9999/` that used to fetch it is deleted (the agent no longer serves it).

**BUG-90 — SSRF**
- `node_ip` must be a public IPv4. Loopback, RFC1918, link-local, CGNAT and unspecified are refused **before** the invite token is consumed.

**BUG-92 — journal**
- The code is written to `/dev/console`, not `log.Printf` / the unit journal.

**BUG-96 / BUG-88 — dead WebSocket path**
- Deleted `gatewayURL`, `wss://gateway.orama.network/v1/agent/enroll`, and the unsigned `/etc/orama/gateway-url` read. Enrollment is inbound HTTP on `:9999`.

**Happy-path hole**
- `Configure` writes `/etc/wireguard/private.key` from the received `wg0.conf`. LUKS identity is `SHA-256` of that file; writing only the conf left it missing.

## Already done on this stack (not re-implemented)

- RegisterPeer on-mesh + secret (CHG-287 / overlay).
- `INSERT OR REPLACE` gone (`pkg/overlay.Register`).
- Allocator and internal-auth both `10.0.0.0/24`.
- Seal itself (bug-354).

## Docs

`ORAMAOS_DEPLOYMENT.md`, `SECURITY.md`, `ARCHITECTURE.md`, `COMMON_PROBLEMS.md`, `DEV_DEPLOY.md`, `CLI_REFERENCE.md` (generated), website operator/architecture pages match the seal.

## Not in this PR

- Node-generated WG keypair (new protocol; follow-up CHG).
- TLS on `:9999` (seal is the confidentiality design).
- BUG-97 invite CLI → RQLite auth (belongs with `rqlite_enforce_auth`).
- BUG-98 leftover: `orama node setup` still mints a bare token (join UX).
- Deploy to devnet/testnet.