### PR TITLE
CHG-248: make stored-secret rotation possible

### DIFF
--- a/core/cmd/orama/internal/cmd/operatorcmd/operator.go
+++ b/core/cmd/orama/internal/cmd/operatorcmd/operator.go
@@ -66,6 +66,67 @@ invalidates every token in the cluster at once.`,
 	},
 }
 
+var rotateSecretsRotate bool
+
+var rotateSecretsCmd = &cobra.Command{
+	Use:   "rotate-secrets",
+	Short: "Re-encrypt stored secrets, optionally under a new encryption root",
+	Long: `Rewrite function secrets, push tokens, TURN secrets, deployment
+environments and agent tokens onto the versioned envelope (enc:v1:<id>:).
+
+Without --rotate the IKM does not change: leftover plaintext and the legacy
+enc: form are rewritten so a captured snapshot of the old format is no longer
+the live one, and Decrypt can fail closed.
+
+With --rotate a new encryption root is generated. Existing ciphertext is
+re-encrypted under it. A disk that holds only the previous root cannot open
+the new rows. IPFS-Cluster and the mesh bearer are not touched.
+
+Do not run this until every gateway is on a binary that can read enc:v1:.
+The walker is idempotent; if it is interrupted, run it again.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		body := map[string]bool{"rotate": rotateSecretsRotate}
+		raw, err := shared.Request("POST", "/v1/operator/rotate-secrets", body)
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			KeyID      string `json:"key_id"`
+			PreviousID string `json:"previous_id"`
+			Rotated    bool   `json:"rotated"`
+			Index      struct {
+				Scanned  int      `json:"scanned"`
+				Rewrote  int      `json:"rewrote"`
+				Skipped  int      `json:"skipped"`
+				Failures []string `json:"failures"`
+			} `json:"index"`
+		}
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			return clierr.Failure("could not parse the gateway's reply: %w", err)
+		}
+		fmt.Printf("Stored secrets rewritten.\n\n")
+		fmt.Printf("  Key id:     %s\n", resp.KeyID)
+		if resp.PreviousID != "" {
+			fmt.Printf("  Previous:   %s\n", resp.PreviousID)
+		}
+		if resp.Rotated {
+			fmt.Printf("  IKM:        replaced (a captured previous root cannot open new rows)\n")
+		} else {
+			fmt.Printf("  IKM:        unchanged (format rewrite only)\n")
+		}
+		fmt.Printf("  Index:      scanned %d, rewrote %d, skipped %d\n",
+			resp.Index.Scanned, resp.Index.Rewrote, resp.Index.Skipped)
+		if len(resp.Index.Failures) > 0 {
+			fmt.Printf("  Failures:   %d\n", len(resp.Index.Failures))
+		}
+		return nil
+	},
+}
+
 func init() {
+	rotateSecretsCmd.Flags().BoolVar(&rotateSecretsRotate, "rotate", false,
+		"Generate a new encryption root and re-encrypt under it")
 	Cmd.AddCommand(rotateSigningKeyCmd)
+	Cmd.AddCommand(rotateSecretsCmd)
 }

--- a/core/cmd/orama/internal/production/install/orchestrator.go
+++ b/core/cmd/orama/internal/production/install/orchestrator.go
@@ -539,6 +539,26 @@ func (o *Orchestrator) saveSecretsFromJoinResponse(resp *joinhandlers.JoinRespon
 
 	// Write TURN shared secret (feat-124 #913) — identical on every node so
 	// WebRTC TURN credentials validate cluster-wide and survive config regen.
+	if resp.EncryptionRoot != "" {
+		if err := os.WriteFile(filepath.Join(secretsDir, "encryption-root"), []byte(resp.EncryptionRoot), 0600); err != nil {
+			return fmt.Errorf("failed to write encryption-root: %w", err)
+		}
+		id := resp.EncryptionRootID
+		if id == "" {
+			id = "1"
+		}
+		if err := os.WriteFile(filepath.Join(secretsDir, "encryption-root.id"), []byte(id), 0600); err != nil {
+			return fmt.Errorf("failed to write encryption-root.id: %w", err)
+		}
+	} else if resp.ClusterSecret != "" {
+		if err := os.WriteFile(filepath.Join(secretsDir, "encryption-root"), []byte(resp.ClusterSecret), 0600); err != nil {
+			return fmt.Errorf("failed to write encryption-root: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(secretsDir, "encryption-root.id"), []byte("1"), 0600); err != nil {
+			return fmt.Errorf("failed to write encryption-root.id: %w", err)
+		}
+	}
+
 	if resp.TURNSecret != "" {
 		if err := os.WriteFile(filepath.Join(secretsDir, "turn-secret"), []byte(resp.TURNSecret), 0600); err != nil {
 			return fmt.Errorf("failed to write turn-secret: %w", err)

--- a/core/migrations/057_encryption_roots.sql
+++ b/core/migrations/057_encryption_roots.sql
@@ -1,0 +1,15 @@
+-- The IKM stored-ciphertext keys are derived from. It used to be the cluster
+-- secret, so rotating stored secrets meant rotating IPFS-Cluster's PSK and the
+-- mesh bearer at the same time — which is why it never happened.
+--
+-- Two slots: current, and previous while a rotate is rewriting rows. The IKM
+-- is the secret; this table is the cluster-wide copy so every gateway derives
+-- the same keys (the same reason function secrets moved off a per-node file).
+
+CREATE TABLE IF NOT EXISTS encryption_roots (
+    slot            TEXT PRIMARY KEY,          -- 'current' | 'previous'
+    key_id          TEXT NOT NULL,             -- generation, starting at '1'
+    ikm             TEXT NOT NULL,             -- 64 hex chars
+    write_versioned INTEGER NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/core/pkg/deployments/envcodec.go
+++ b/core/pkg/deployments/envcodec.go
@@ -9,10 +9,10 @@ import (
 )
 
 // EnvEncryptionPurpose is the HKDF info label that separates the deployment
-// environment key from every other key derived from the cluster secret.
+// environment key from every other key derived from the encryption root.
 //
-// Changing it is a deliberate rotation that makes every stored environment
-// unreadable, so it must never be edited casually.
+// This label is a domain separator, not a rotation handle. Rotating stored
+// secrets is `orama operator rotate-secrets --rotate`.
 const EnvEncryptionPurpose = "orama-deployment-environment-v1"
 
 // EnvCodec turns a deployment's environment into the single column it is stored
@@ -25,15 +25,23 @@ const EnvEncryptionPurpose = "orama-deployment-environment-v1"
 // key derived from the cluster secret, so a node's database file is not a list
 // of every tenant's credentials.
 type EnvCodec struct {
-	key []byte
+	key    []byte
+	holder *secrets.Holder
 }
 
-// NewEnvCodec derives the environment key from the cluster secret.
+// SetHolder lets a rotate take effect without restarting this process.
+func (c *EnvCodec) SetHolder(h *secrets.Holder) {
+	if c != nil {
+		c.holder = h
+	}
+}
+
+// NewEnvCodec derives the environment key from the encryption-root IKM.
 //
-// It refuses an empty secret rather than storing plaintext: the caller decides
+// It refuses an empty IKM rather than storing plaintext: the caller decides
 // what to do without one, and nothing decides to write secrets in the clear.
-func NewEnvCodec(clusterSecret string) (*EnvCodec, error) {
-	key, err := secrets.DeriveKey(strings.TrimSpace(clusterSecret), EnvEncryptionPurpose)
+func NewEnvCodec(ikm string) (*EnvCodec, error) {
+	key, err := secrets.DeriveKey(strings.TrimSpace(ikm), EnvEncryptionPurpose)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive the deployment environment key: %w", err)
 	}
@@ -55,7 +63,7 @@ func (c *EnvCodec) Encode(env map[string]string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to encode the deployment environment: %w", err)
 	}
-	sealed, err := secrets.Encrypt(string(plain), c.key)
+	sealed, err := secrets.Seal(c.holder, EnvEncryptionPurpose, c.key, string(plain))
 	if err != nil {
 		return "", fmt.Errorf("failed to encrypt the deployment environment: %w", err)
 	}
@@ -82,7 +90,7 @@ func (c *EnvCodec) Decode(stored string) (map[string]string, error) {
 	plain := stored
 	if secrets.IsEncrypted(stored) {
 		var err error
-		plain, err = secrets.Decrypt(stored, c.key)
+		plain, err = secrets.Open(c.holder, EnvEncryptionPurpose, c.key, stored)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt the deployment environment: %w", err)
 		}

--- a/core/pkg/gateway/dependencies.go
+++ b/core/pkg/gateway/dependencies.go
@@ -126,6 +126,10 @@ type Dependencies struct {
 
 	// Authentication service
 	AuthService *auth.Service
+
+	// EncHolder is the process-wide encryption root for stored ciphertext.
+	EncHolder  *secrets.Holder
+	SecretsMgr *hostfunctions.DBSecretsManager
 }
 
 // NewDependencies creates and initializes all gateway dependencies based on the provided configuration.
@@ -663,24 +667,26 @@ func initializeServerless(logger *logging.ColoredLogger, cfg *Config, deps *Depe
 
 	// Create secrets manager for serverless functions (AES-256-GCM encrypted).
 	//
-	// The encryption key is DERIVED from the cluster secret via HKDF
-	// (resolveSecretsEncryptionKeyHex), so every gateway in the cluster computes
-	// the identical key and a secret written on one node decrypts on every other
-	// node and survives rolling upgrades. This replaces the old per-node
-	// crypto/rand key file, whose divergence across an upgraded cluster kept
-	// get_secret broken (bugboard #837). The file key (cfg.SecretsEncryptionKey)
-	// remains only as a fallback when no cluster secret is available (legacy /
-	// single-node test rigs). allowEphemeral=false: a missing/invalid key fails
-	// loudly here and disables get_secret rather than silently corrupting
-	// secrets.
+	// The encryption key is derived from the encryption root via HKDF, so every
+	// gateway computes the identical key. The root starts as a copy of the
+	// cluster secret so existing rows stay readable; an operator rotate
+	// replaces the IKM without touching IPFS-Cluster or the mesh bearer.
+	deps.EncHolder = bootstrapEncryptionRoot(cfg, deps)
+	ikm := deps.EncHolder.Get().CurrentIKM
+	if ikm == "" {
+		ikm = cfg.ClusterSecret
+	}
+
 	var secretsMgr serverless.SecretsManager
-	if secretsKeyHex, keyErr := resolveSecretsEncryptionKeyHex(cfg.ClusterSecret, cfg.SecretsEncryptionKey); keyErr != nil {
+	if secretsKeyHex, keyErr := resolveSecretsEncryptionKeyHex(ikm, cfg.SecretsEncryptionKey); keyErr != nil {
 		logger.ComponentWarn(logging.ComponentGeneral, "Failed to derive secrets encryption key; get_secret will be unavailable",
 			zap.Error(keyErr))
 	} else if smImpl, secretsErr := hostfunctions.NewDBSecretsManager(deps.ORMClient, secretsKeyHex, false, logger.Logger); secretsErr != nil {
 		logger.ComponentWarn(logging.ComponentGeneral, "Failed to initialize secrets manager; get_secret will be unavailable",
 			zap.Error(secretsErr))
 	} else {
+		smImpl.SetHolder(deps.EncHolder)
+		deps.SecretsMgr = smImpl
 		secretsMgr = smImpl
 	}
 
@@ -695,7 +701,7 @@ func initializeServerless(logger *logging.ColoredLogger, cfg *Config, deps *Depe
 	//
 	// PushDispatcher (legacy) is set only when YAML defaults exist —
 	// kept for back-compat with code that hasn't migrated to Manager.
-	pushDispatcher, pushStore, pushManager, pushCfgStore, pushCredManager, err := buildPushDispatcher(cfg, deps.ORMClient, deps.Client, logger)
+	pushDispatcher, pushStore, pushManager, pushCfgStore, pushCredManager, err := buildPushDispatcher(cfg, deps.ORMClient, deps.Client, logger, ikm, deps.EncHolder)
 	if err != nil {
 		// Non-fatal: log and continue. Functions calling push_send will get nil
 		// (silent no-op) and HTTP /v1/push/* endpoints return 503.
@@ -1140,16 +1146,24 @@ func buildPushDispatcher(
 	db rqlite.Client,
 	globalDB client.NetworkClient,
 	logger *logging.ColoredLogger,
+	ikm string,
+	holder *secrets.Holder,
 ) (*push.PushDispatcher, push.PushDeviceStore, *push.Manager, push.ConfigStore, *pushcreds.Manager, error) {
-	if cfg.ClusterSecret == "" {
-		// Without the cluster secret we can't encrypt credentials at rest.
+	if strings.TrimSpace(ikm) == "" {
+		ikm = cfg.ClusterSecret
+	}
+	if ikm == "" {
+		// Without an IKM we can't encrypt credentials at rest.
 		// Disable the whole push subsystem; HTTP routes return 503.
 		return nil, nil, nil, nil, nil, nil
 	}
 
-	store, err := push.NewRqliteDeviceStore(db, cfg.ClusterSecret, logger.Logger)
+	store, err := push.NewRqliteDeviceStore(db, ikm, logger.Logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("init push device store: %w", err)
+	}
+	if h, ok := any(store).(interface{ SetHolder(*secrets.Holder) }); ok {
+		h.SetHolder(holder)
 	}
 
 	// Backfill token_fp for rows registered before the bugboard #981 migration
@@ -1183,18 +1197,24 @@ func buildPushDispatcher(
 		}
 	}()
 
-	cfgStore, err := push.NewRqliteConfigStore(db, cfg.ClusterSecret, logger.Logger)
+	cfgStore, err := push.NewRqliteConfigStore(db, ikm, logger.Logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("init push config store: %w", err)
+	}
+	if h, ok := any(cfgStore).(interface{ SetHolder(*secrets.Holder) }); ok {
+		h.SetHolder(holder)
 	}
 
 	// Per-namespace, per-provider credentials (feature #72). Generic
 	// store — used by APNs, ntfy (post-migration), FCM-direct (future).
 	// Provider packages register their Validator at gateway startup
 	// (see pushcreds.Register calls below).
-	credStore, err := pushcreds.NewRqliteStore(db, cfg.ClusterSecret, logger.Logger)
+	credStore, err := pushcreds.NewRqliteStore(db, ikm, logger.Logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("init push credentials store: %w", err)
+	}
+	if h, ok := any(credStore).(interface{ SetHolder(*secrets.Holder) }); ok {
+		h.SetHolder(holder)
 	}
 	credManager := pushcreds.NewManager(credStore, logger.Logger)
 
@@ -1369,4 +1389,31 @@ func signingKeyNamespace(clientNamespace string) string {
 		return ""
 	}
 	return ns
+}
+
+func bootstrapEncryptionRoot(cfg *Config, deps *Dependencies) *secrets.Holder {
+	dir := ""
+	cs := ""
+	if cfg != nil {
+		cs = cfg.ClusterSecret
+		if cfg.DataDir != "" {
+			dir = secrets.SecretsDir(cfg.DataDir)
+		}
+	}
+	var store secrets.Store
+	if deps != nil {
+		if deps.GlobalORMClient != nil {
+			store = deps.GlobalORMClient
+		} else {
+			store = deps.ORMClient
+		}
+	}
+	r, err := secrets.LoadOrMaterialize(context.Background(), store, dir, cs)
+	if err != nil {
+		if strings.TrimSpace(cs) != "" {
+			return secrets.NewHolder(secrets.Root{CurrentID: secrets.FirstID, CurrentIKM: strings.TrimSpace(cs)})
+		}
+		return secrets.NewHolder(secrets.Root{})
+	}
+	return secrets.NewHolder(r)
 }

--- a/core/pkg/gateway/gateway.go
+++ b/core/pkg/gateway/gateway.go
@@ -45,6 +45,7 @@ import (
 	nodehealth "github.com/DeBrosOfficial/network/pkg/peerhealth"
 	"github.com/DeBrosOfficial/network/pkg/ratelimit"
 	"github.com/DeBrosOfficial/network/pkg/rqlite"
+	"github.com/DeBrosOfficial/network/pkg/secrets"
 	"github.com/DeBrosOfficial/network/pkg/serverless"
 	"github.com/DeBrosOfficial/network/pkg/serverless/persistent"
 	"github.com/DeBrosOfficial/network/pkg/serverless/triggers"
@@ -84,6 +85,12 @@ type Gateway struct {
 	sqlDB     *sql.DB
 	ormClient rqlite.Client
 	ormHTTP   *rqlite.HTTPGateway
+
+	// encHolder is the process-wide encryption root. Stored-ciphertext
+	// keys are derived from it so a rotate takes effect without a restart.
+	encHolder *secrets.Holder
+	registry  rqlite.Client
+	envCodec  *deployments.EnvCodec
 
 	// Global RQLite client for API key validation (namespace gateways only)
 	authClient client.NetworkClient
@@ -359,6 +366,8 @@ func New(logger *logging.ColoredLogger, cfg *Config) (*Gateway, error) {
 		sqlDB:                  deps.SQLDB,
 		ormClient:              deps.ORMClient,
 		ormHTTP:                deps.ORMHTTP,
+		registry:               deps.GlobalORMClient,
+		encHolder:              deps.EncHolder,
 		olricClient:            deps.OlricClient,
 		ipfsClient:             deps.IPFSClient,
 		serverlessEngine:       deps.ServerlessEngine,
@@ -662,11 +671,22 @@ func New(logger *logging.ColoredLogger, cfg *Config) (*Gateway, error) {
 	// secret. Without that secret there is no key, so the deployment system
 	// does not start rather than storing every tenant's credentials in the
 	// clear in a Raft-replicated table.
-	envCodec, envCodecErr := deployments.NewEnvCodec(cfg.ClusterSecret)
+	if gw.encHolder == nil {
+		gw.encHolder = bootstrapEncryptionRoot(cfg, deps)
+	}
+	envIKM := gw.encHolder.Get().CurrentIKM
+	if envIKM == "" {
+		envIKM = cfg.ClusterSecret
+	}
+	envCodec, envCodecErr := deployments.NewEnvCodec(envIKM)
 	if envCodecErr != nil {
-		logger.Logger.Error("deployments are unavailable on this gateway: without a cluster secret "+
+		logger.Logger.Error("deployments are unavailable on this gateway: without an encryption root "+
 			"there is no key to encrypt deployment environments with",
 			zap.Error(envCodecErr))
+	}
+	if envCodec != nil {
+		envCodec.SetHolder(gw.encHolder)
+		gw.envCodec = envCodec
 	}
 	if deps.ORMClient != nil && deps.IPFSClient != nil && envCodec != nil {
 		// Convert rqlite.Client to health.Database for the deployment checker

--- a/core/pkg/gateway/handlers/enroll/agent_token.go
+++ b/core/pkg/gateway/handlers/enroll/agent_token.go
@@ -72,12 +72,30 @@ func (h *Handler) AgentToken(ctx context.Context, nodeID string) (string, error)
 	return token, nil
 }
 
-// agentTokenKey derives the encryption key from the cluster secret on disk.
+// agentTokenKey derives the encryption key from the encryption root on disk,
+// falling back to the cluster secret so a node that has not materialised the
+// root file yet still reads tokens written before this release.
 func (h *Handler) agentTokenKey() ([]byte, error) {
-	raw, err := os.ReadFile(h.oramaDir + "/secrets/cluster-secret")
+	ikm, err := readIKM(h.oramaDir)
 	if err != nil {
-		return nil, fmt.Errorf("could not read the cluster secret, so agent tokens cannot be "+
-			"encrypted or read: %w", err)
+		return nil, err
 	}
-	return secrets.DeriveKey(strings.TrimSpace(string(raw)), agentTokenPurpose)
+	return secrets.DeriveKey(ikm, agentTokenPurpose)
+}
+
+func readIKM(oramaDir string) (string, error) {
+	if raw, err := os.ReadFile(oramaDir + "/secrets/" + secrets.FileName); err == nil {
+		if v := strings.TrimSpace(string(raw)); v != "" {
+			return v, nil
+		}
+	}
+	raw, err := os.ReadFile(oramaDir + "/secrets/cluster-secret")
+	if err != nil {
+		return "", fmt.Errorf("could not read the encryption root or cluster secret, so agent tokens cannot be encrypted or read: %w", err)
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" {
+		return "", fmt.Errorf("encryption root and cluster secret are empty")
+	}
+	return v, nil
 }

--- a/core/pkg/gateway/handlers/join/handler.go
+++ b/core/pkg/gateway/handlers/join/handler.go
@@ -57,6 +57,10 @@ type JoinResponse struct {
 	// TURN shared secret (feat-124 #913) — must be identical on every node so
 	// WebRTC TURN credentials validate cluster-wide.
 	TURNSecret string `json:"turn_secret,omitempty"`
+	// EncryptionRoot is the IKM stored-ciphertext keys are derived from.
+	// Starts as a copy of the cluster secret; an operator rotate replaces it.
+	EncryptionRoot   string `json:"encryption_root,omitempty"`
+	EncryptionRootID string `json:"encryption_root_id,omitempty"`
 
 	// Cluster join info (all using WG IPs)
 	RQLiteJoinAddress  string   `json:"rqlite_join_address"`
@@ -364,6 +368,8 @@ func (h *Handler) HandleJoin(w http.ResponseWriter, r *http.Request) {
 		RQLitePassword:       secrets.RQLitePassword,
 		SecretsEncryptionKey: secrets.SecretsEncryptionKey,
 		TURNSecret:           secrets.TURNSecret,
+		EncryptionRoot:       secrets.EncryptionRoot,
+		EncryptionRootID:     secrets.EncryptionRootID,
 		RQLiteJoinAddress:    constants.RQLiteRaftAddrFor(myWGIP),
 		IPFSPeer:             ipfsPeer,
 		IPFSClusterPeer:      ipfsClusterPeer,
@@ -577,6 +583,8 @@ type joinSecrets struct {
 	RQLitePassword       string
 	SecretsEncryptionKey string
 	TURNSecret           string
+	EncryptionRoot       string
+	EncryptionRootID     string
 }
 
 // readJoinSecrets loads every secret the response carries.
@@ -608,10 +616,18 @@ func (h *Handler) readJoinSecrets() (joinSecrets, error) {
 		{"rqlite-password", &out.RQLitePassword},
 		{"secrets-encryption-key", &out.SecretsEncryptionKey},
 		{"turn-secret", &out.TURNSecret},
+		{"encryption-root", &out.EncryptionRoot},
+		{"encryption-root.id", &out.EncryptionRootID},
 	} {
 		if data, err := os.ReadFile(h.oramaDir + "/secrets/" + opt.file); err == nil {
 			*opt.dst = strings.TrimSpace(string(data))
 		}
+	}
+	if out.EncryptionRoot == "" {
+		out.EncryptionRoot = out.ClusterSecret
+	}
+	if out.EncryptionRootID == "" && out.EncryptionRoot != "" {
+		out.EncryptionRootID = "1"
 	}
 
 	return out, nil

--- a/core/pkg/gateway/handlers/join/handler_test.go
+++ b/core/pkg/gateway/handlers/join/handler_test.go
@@ -167,6 +167,7 @@ func TestReadJoinSecrets_readsEverythingPresent(t *testing.T) {
 	want := joinSecrets{
 		ClusterSecret: "cs", SwarmKey: "sk", APIKeyHMACSecret: "hmac",
 		RQLitePassword: "pw", SecretsEncryptionKey: "sek", TURNSecret: "turn",
+		EncryptionRoot: "cs", EncryptionRootID: "1",
 	}
 	if got != want {
 		t.Fatalf("got %+v, want %+v", got, want)
@@ -207,6 +208,9 @@ func TestReadJoinSecrets_optionalSecretsMayBeAbsent(t *testing.T) {
 	if got.APIKeyHMACSecret != "" || got.RQLitePassword != "" ||
 		got.SecretsEncryptionKey != "" || got.TURNSecret != "" {
 		t.Fatalf("expected the optional secrets to be empty, got %+v", got)
+	}
+	if got.EncryptionRoot != "cs" || got.EncryptionRootID != "1" {
+		t.Fatalf("encryption root should fall back to the cluster secret, got %+v", got)
 	}
 }
 

--- a/core/pkg/gateway/handlers/namespace/core_wire.go
+++ b/core/pkg/gateway/handlers/namespace/core_wire.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DeBrosOfficial/network/pkg/encryption"
 	"github.com/DeBrosOfficial/network/pkg/gateway"
@@ -38,8 +39,14 @@ func WireCoreGateway(ctx context.Context, apiGateway *gateway.Gateway, cfg *gate
 	baseDataDir := filepath.Join(oramaDir, "data", "namespaces")
 
 	var turnEncKey []byte
-	if cfg.ClusterSecret != "" {
-		if key, keyErr := secrets.DeriveKey(cfg.ClusterSecret, "turn-encryption"); keyErr == nil {
+	turnIKM := cfg.ClusterSecret
+	if raw, err := os.ReadFile(filepath.Join(oramaDir, "secrets", secrets.FileName)); err == nil {
+		if v := strings.TrimSpace(string(raw)); v != "" {
+			turnIKM = v
+		}
+	}
+	if turnIKM != "" {
+		if key, keyErr := secrets.DeriveKey(turnIKM, "turn-encryption"); keyErr == nil {
 			turnEncKey = key
 		}
 	}

--- a/core/pkg/gateway/middleware_test.go
+++ b/core/pkg/gateway/middleware_test.go
@@ -178,6 +178,7 @@ func TestIsPublicPath(t *testing.T) {
 		{"internal join", "/v1/internal/join", true},
 		{"internal namespace spawn", "/v1/internal/namespace/spawn", true},
 		{"internal namespace repair", "/v1/internal/namespace/repair", true},
+		{"internal secrets reencrypt", "/v1/internal/secrets/reencrypt", true},
 		// The internal WebRTC mgmt endpoints were removed: nothing in the
 		// repository called them — `orama namespace enable webrtc` goes to the
 		// public route, which does the work itself — and they were three paths

--- a/core/pkg/gateway/route_policy.go
+++ b/core/pkg/gateway/route_policy.go
@@ -127,6 +127,7 @@ func buildRoutePolicies() *routepolicy.Table {
 		// RQLite does not have it.
 		// Signed internal header plus a WireGuard-peer source check.
 		"/v1/internal/namespace/spawn", "/v1/internal/namespace/repair",
+		"/v1/internal/secrets/reencrypt",
 		"/v1/internal/storage/evict",
 		"/v1/internal/deployments/replica/setup", "/v1/internal/deployments/replica/update",
 		"/v1/internal/deployments/replica/rollback", "/v1/internal/deployments/replica/teardown",
@@ -205,7 +206,7 @@ func buildRoutePolicies() *routepolicy.Table {
 		"/v1/network/connect", "/v1/network/disconnect",
 		"/v1/node/command", "/v1/node/leave",
 		"/v1/operator/nodes", "/v1/operator/node/register",
-		"/v1/operator/rotate-signing-key")
+		"/v1/operator/rotate-signing-key", "/v1/operator/rotate-secrets")
 	t.Add(policyUnrestricted, "/v1/operator/invite")
 
 	// --- Control plane on a namespace's own resources ------------------

--- a/core/pkg/gateway/route_policy_test.go
+++ b/core/pkg/gateway/route_policy_test.go
@@ -91,6 +91,7 @@ var publicRoutes = []string{
 	"/v1/internal/join",
 	"/v1/internal/namespace/repair",
 	"/v1/internal/namespace/spawn",
+	"/v1/internal/secrets/reencrypt",
 	"/v1/internal/node/enrol-key",
 	"/v1/internal/node/heartbeat",
 	"/v1/internal/node/register",

--- a/core/pkg/gateway/routes.go
+++ b/core/pkg/gateway/routes.go
@@ -69,6 +69,7 @@ func (g *Gateway) Routes() http.Handler {
 
 	// Namespace cluster repair (internal, handler does its own auth)
 	mux.HandleFunc("/v1/internal/namespace/repair", g.namespaceClusterRepairHandler)
+	mux.HandleFunc("/v1/internal/secrets/reencrypt", g.handleInternalReencrypt)
 
 	// Namespace WebRTC enable/disable/status (public, JWT/API key auth via middleware)
 	mux.HandleFunc("/v1/namespace/webrtc/enable", g.namespaceWebRTCEnablePublicHandler)
@@ -201,6 +202,7 @@ func (g *Gateway) Routes() http.Handler {
 		mux.HandleFunc("/v1/operator/nodes", g.operatorHandler.HandleListNodes)
 		mux.HandleFunc("/v1/operator/node/register", g.operatorHandler.HandleRegister)
 		mux.HandleFunc("/v1/operator/rotate-signing-key", g.handleRotateSigningKey)
+		mux.HandleFunc("/v1/operator/rotate-secrets", g.handleRotateSecrets)
 	}
 
 	// vault proxy (public, rate-limited per identity within handler)

--- a/core/pkg/gateway/secrets_key.go
+++ b/core/pkg/gateway/secrets_key.go
@@ -8,33 +8,26 @@ import (
 )
 
 // secretsEncryptionDerivePurpose is the HKDF info label used to derive the
-// function-secrets AES-256 key from the cluster secret. Deriving it (instead of
-// generating a per-node crypto/rand key file) guarantees every gateway in the
-// cluster computes the IDENTICAL key, so a secret written on one node decrypts
-// on every other node and survives rolling upgrades — eliminating the
-// key-divergence / convergence-window class that kept get_secret broken for
-// days (bugboard #837). Same pattern as the cluster-wide JWT signing key
-// (jwtEdDSADerivePurpose) and the TURN encryption key ("turn-encryption").
+// function-secrets AES-256 key from the encryption root. Deriving it (instead
+// of generating a per-node crypto/rand key file) guarantees every gateway in
+// the cluster computes the IDENTICAL key — eliminating the key-divergence
+// class that kept get_secret broken for days (bugboard #837).
 //
-// Bumping the version label (e.g. "...-v2") is a DELIBERATE rotation that
-// invalidates every stored function secret (they must be re-`set`). It must
-// never be changed casually.
+// This label is a domain separator, not a rotation handle. Rotating stored
+// secrets is `orama operator rotate-secrets --rotate`, which changes the IKM
+// and re-encrypts. Editing this string orphans every stored function secret.
 const secretsEncryptionDerivePurpose = "orama-secrets-encryption-v1"
 
 // resolveSecretsEncryptionKeyHex returns the hex-encoded AES-256 key the
 // serverless secrets manager should use to encrypt/decrypt function secrets.
 //
-// Primary: derive deterministically from the cluster secret via HKDF, so the
-// key is identical on every gateway in the cluster and stable across restarts
-// and rolling upgrades. The cluster secret is TrimSpace'd first so a stray
-// trailing newline on one node's secret file can't silently diverge its derived
-// key from the rest of the cluster (the host gateway reads the file untrimmed
-// while the namespace gateway trims it — without this they could derive
-// different keys and reintroduce #837).
+// Primary: derive from the encryption-root IKM via HKDF (the caller passes
+// that IKM; it starts as a copy of the cluster secret). TrimSpace so a stray
+// newline cannot silently diverge keys across nodes (bugboard #837).
 //
-// Fallback: when no cluster secret is available (single-node test rigs / legacy
-// deployments without a shared secret), fall back to an explicitly-configured
-// key file. An empty result then makes the production secrets manager fail loud
+// Fallback: when no IKM is available (single-node test rigs / legacy
+// deployments), fall back to an explicitly-configured key file. An empty
+// result then makes the production secrets manager fail loud
 // (NewDBSecretsManager with allowEphemeral=false), rather than silently using a
 // per-process ephemeral key.
 func resolveSecretsEncryptionKeyHex(clusterSecret, fileKeyHex string) (string, error) {

--- a/core/pkg/gateway/secrets_rotate.go
+++ b/core/pkg/gateway/secrets_rotate.go
@@ -1,0 +1,272 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	nodeauth "github.com/DeBrosOfficial/network/pkg/auth"
+	gwauth "github.com/DeBrosOfficial/network/pkg/gateway/auth"
+	"github.com/DeBrosOfficial/network/pkg/secrets"
+)
+
+type rotateSecretsRequest struct {
+	Rotate bool `json:"rotate"`
+}
+
+type rotateSecretsResponse struct {
+	KeyID      string             `json:"key_id"`
+	PreviousID string             `json:"previous_id,omitempty"`
+	Rotated    bool               `json:"rotated"`
+	Index      secrets.WalkResult `json:"index"`
+	Namespaces []nsWalkResult     `json:"namespaces,omitempty"`
+}
+
+type nsWalkResult struct {
+	Namespace string             `json:"namespace"`
+	Target    string             `json:"target"`
+	Result    secrets.WalkResult `json:"result"`
+	Error     string             `json:"error,omitempty"`
+}
+
+type internalReencryptRequest struct {
+	Root secrets.Root `json:"root"`
+}
+
+// handleRotateSecrets serves POST /v1/operator/rotate-secrets.
+//
+// Without {"rotate":true} it rewrites leftover plaintext and the legacy enc:
+// envelope onto enc:v1:<id>: under the current IKM. With rotate:true it
+// generates a new IKM first, so a captured cluster-secret / old encryption-root
+// cannot open the new rows.
+//
+// Run this only after every gateway is on a binary that can read enc:v1:.
+func (g *Gateway) handleRotateSecrets(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if g.operatorHandler == nil {
+		writeError(w, http.StatusServiceUnavailable, "operator endpoints are not enabled on this gateway")
+		return
+	}
+	if _, ok := g.operatorHandler.Authorize(w, r); !ok {
+		return
+	}
+	if g.cfg == nil || g.cfg.DataDir == "" {
+		writeError(w, http.StatusServiceUnavailable, "this gateway has no data directory")
+		return
+	}
+
+	var req rotateSecretsRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(io.LimitReader(r.Body, 1<<12)).Decode(&req)
+	}
+
+	ctx := r.Context()
+	registry := g.registryStore()
+	dir := secrets.SecretsDir(g.cfg.DataDir)
+
+	if g.encHolder == nil {
+		g.encHolder = secrets.NewHolder(secrets.Root{})
+	}
+	root := g.encHolder.Get()
+	if root.CurrentIKM == "" {
+		loaded, err := secrets.LoadOrMaterialize(ctx, registry, dir, g.cfg.ClusterSecret)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "encryption root: "+err.Error())
+			return
+		}
+		root = loaded
+		g.encHolder.Swap(root)
+	}
+
+	var err error
+	if req.Rotate {
+		root, err = secrets.Rotate(ctx, registry, dir, root)
+	} else {
+		root, err = secrets.EnableVersionedWrites(ctx, registry, dir, root)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if g.encHolder == nil {
+		g.encHolder = secrets.NewHolder(root)
+	} else {
+		g.encHolder.Swap(root)
+	}
+
+	cols := secrets.NamespaceColumns()
+	if !isNamespaceGateway(g.cfg) {
+		cols = append(secrets.IndexColumns(), secrets.NamespaceColumns()...)
+	}
+	localRes, err := secrets.Walk(ctx, g.ormClient, root, cols)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "walk: "+err.Error())
+		return
+	}
+	if isNamespaceGateway(g.cfg) {
+		respondRotate(w, r, g, root, req.Rotate, localRes, []nsWalkResult{{
+			Namespace: g.cfg.ClientNamespace,
+			Target:    "local",
+			Result:    localRes,
+		}})
+		return
+	}
+
+	nsResults := g.fanoutReencrypt(ctx, root)
+	respondRotate(w, r, g, root, req.Rotate, localRes, nsResults)
+}
+
+func respondRotate(w http.ResponseWriter, r *http.Request, g *Gateway, root secrets.Root, rotated bool, index secrets.WalkResult, ns []nsWalkResult) {
+	if g.authService != nil {
+		g.authService.Audit().RecordFromRequest(r.Context(), r, gwauth.AuditEvent{
+			Actor:    gwauth.ActorFromRequest(r),
+			Action:   gwauth.AuditOperatorAction,
+			Resource: "secrets.rotate",
+			Result:   gwauth.AuditSuccess,
+			Metadata: map[string]string{"key_id": root.CurrentID, "rotated": fmt.Sprintf("%v", rotated)},
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(rotateSecretsResponse{
+		KeyID:      root.CurrentID,
+		PreviousID: root.PreviousID,
+		Rotated:    rotated,
+		Index:      index,
+		Namespaces: ns,
+	})
+}
+
+func (g *Gateway) handleInternalReencrypt(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !g.verifyCoordination(r) {
+		unauthorized(w, CodeAuthMissing, "this route is reached from inside the cluster and the caller did not present what it requires", nil)
+		return
+	}
+	var req internalReencryptRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil || req.Root.CurrentIKM == "" {
+		writeError(w, http.StatusBadRequest, "root is required")
+		return
+	}
+	root := req.Root
+	if g.encHolder == nil {
+		g.encHolder = secrets.NewHolder(root)
+	} else {
+		g.encHolder.Swap(root)
+	}
+	if g.cfg != nil && g.cfg.DataDir != "" {
+		_ = secrets.Persist(secrets.SecretsDir(g.cfg.DataDir), root)
+	}
+
+	cols := secrets.NamespaceColumns()
+	if !isNamespaceGateway(g.cfg) {
+		cols = secrets.IndexColumns()
+	}
+	res, err := secrets.Walk(r.Context(), g.ormClient, req.Root, cols)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+func (g *Gateway) fanoutReencrypt(ctx context.Context, root secrets.Root) []nsWalkResult {
+	type target struct {
+		Namespace  string `db:"namespace_name"`
+		InternalIP string `db:"internal_ip"`
+		Port       int    `db:"gateway_http_port"`
+	}
+	var rows []target
+	q := `
+		SELECT DISTINCT nc.namespace_name,
+		       COALESCE(dn.internal_ip, dn.ip_address) AS internal_ip,
+		       pa.gateway_http_port
+		  FROM namespace_clusters nc
+		  JOIN namespace_port_allocations pa ON pa.namespace_cluster_id = nc.id
+		  JOIN dns_nodes dn ON dn.id = pa.node_id
+		 WHERE pa.gateway_http_port IS NOT NULL AND pa.gateway_http_port > 0`
+	if err := g.ormClient.Query(ctx, &rows, q); err != nil {
+		return []nsWalkResult{{Error: err.Error()}}
+	}
+
+	body, err := json.Marshal(internalReencryptRequest{Root: root})
+	if err != nil {
+		return []nsWalkResult{{Error: err.Error()}}
+	}
+	key, err := nodeauth.CoordinationKey(g.cfg.ClusterSecret)
+	if err != nil {
+		return []nsWalkResult{{Error: err.Error()}}
+	}
+
+	out := make([]nsWalkResult, 0, len(rows))
+	seen := map[string]bool{}
+	client := &http.Client{Timeout: 60 * time.Second}
+	for _, row := range rows {
+		if row.InternalIP == "" || row.Port == 0 {
+			continue
+		}
+		url := fmt.Sprintf("http://%s:%d/v1/internal/secrets/reencrypt", row.InternalIP, row.Port)
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		nr := nsWalkResult{Namespace: row.Namespace, Target: url}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			nr.Error = err.Error()
+			out = append(out, nr)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if err := nodeauth.SignCoordination(key, req, time.Now()); err != nil {
+			nr.Error = err.Error()
+			out = append(out, nr)
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			nr.Error = err.Error()
+			out = append(out, nr)
+			continue
+		}
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			nr.Error = strings.TrimSpace(string(raw))
+			if nr.Error == "" {
+				nr.Error = resp.Status
+			}
+			out = append(out, nr)
+			continue
+		}
+		_ = json.Unmarshal(raw, &nr.Result)
+		out = append(out, nr)
+	}
+	return out
+}
+
+func (g *Gateway) registryStore() secrets.Store {
+	if g == nil {
+		return nil
+	}
+	// Namespace gateways must persist the root on the cluster registry.
+	if isNamespaceGateway(g.cfg) && g.globalORM() != nil {
+		return g.globalORM()
+	}
+	return g.ormClient
+}
+
+func (g *Gateway) globalORM() secrets.Store {
+	return g.registry
+}

--- a/core/pkg/push/config_store.go
+++ b/core/pkg/push/config_store.go
@@ -98,7 +98,15 @@ var ErrConfigNotFound = errors.New("push config not found for namespace")
 type rqliteConfigStore struct {
 	db     rqlite.Client
 	encKey []byte
+	holder *secrets.Holder
 	logger *zap.Logger
+}
+
+// SetHolder lets a rotate take effect without restarting this process.
+func (s *rqliteConfigStore) SetHolder(h *secrets.Holder) {
+	if s != nil {
+		s.holder = h
+	}
 }
 
 // NewRqliteConfigStore wires the store to RQLite with a cluster-secret-
@@ -156,14 +164,14 @@ func (s *rqliteConfigStore) Get(ctx context.Context, namespace string) (*Config,
 		UpdatedBy:   r.UpdatedBy,
 	}
 	if r.NtfyAuthTokenEncrypted != "" {
-		v, err := secrets.Decrypt(r.NtfyAuthTokenEncrypted, s.encKey)
+		v, err := secrets.Open(s.holder, purposeNamespacePushConfig, s.encKey, r.NtfyAuthTokenEncrypted)
 		if err != nil {
 			return nil, fmt.Errorf("push config: decrypt ntfy auth token: %w", err)
 		}
 		cfg.NtfyAuthToken = v
 	}
 	if r.ExpoAccessTokenEncrypted != "" {
-		v, err := secrets.Decrypt(r.ExpoAccessTokenEncrypted, s.encKey)
+		v, err := secrets.Open(s.holder, purposeNamespacePushConfig, s.encKey, r.ExpoAccessTokenEncrypted)
 		if err != nil {
 			return nil, fmt.Errorf("push config: decrypt expo access token: %w", err)
 		}
@@ -181,14 +189,14 @@ func (s *rqliteConfigStore) Upsert(ctx context.Context, cfg Config) error {
 
 	var ntfyEnc, expoEnc string
 	if cfg.NtfyAuthToken != "" {
-		v, err := secrets.Encrypt(cfg.NtfyAuthToken, s.encKey)
+		v, err := secrets.Seal(s.holder, purposeNamespacePushConfig, s.encKey, cfg.NtfyAuthToken)
 		if err != nil {
 			return fmt.Errorf("push config: encrypt ntfy auth token: %w", err)
 		}
 		ntfyEnc = v
 	}
 	if cfg.ExpoAccessToken != "" {
-		v, err := secrets.Encrypt(cfg.ExpoAccessToken, s.encKey)
+		v, err := secrets.Seal(s.holder, purposeNamespacePushConfig, s.encKey, cfg.ExpoAccessToken)
 		if err != nil {
 			return fmt.Errorf("push config: encrypt expo access token: %w", err)
 		}

--- a/core/pkg/push/credentials/store.go
+++ b/core/pkg/push/credentials/store.go
@@ -24,7 +24,15 @@ const purposeNamespacePushCredentials = "namespace-push-credentials"
 type rqliteStore struct {
 	db     rqlite.Client
 	encKey []byte
+	holder *secrets.Holder
 	logger *zap.Logger
+}
+
+// SetHolder lets a rotate take effect without restarting this process.
+func (s *rqliteStore) SetHolder(h *secrets.Holder) {
+	if s != nil {
+		s.holder = h
+	}
 }
 
 // NewRqliteStore wires the store to RQLite with a cluster-secret-
@@ -74,7 +82,7 @@ func (s *rqliteStore) Get(ctx context.Context, namespace, provider string) (*Cre
 		return nil, ErrNotFound
 	}
 	r := rows[0]
-	plain, err := secrets.Decrypt(r.CredentialsJSON, s.encKey)
+	plain, err := secrets.Open(s.holder, purposeNamespacePushCredentials, s.encKey, r.CredentialsJSON)
 	if err != nil {
 		return nil, fmt.Errorf("credentials Get: decrypt: %w", err)
 	}
@@ -101,7 +109,7 @@ func (s *rqliteStore) Upsert(ctx context.Context, cred Credential) error {
 	if len(cred.JSON) == 0 {
 		return fmt.Errorf("credentials Upsert: empty JSON payload")
 	}
-	enc, err := secrets.Encrypt(string(cred.JSON), s.encKey)
+	enc, err := secrets.Seal(s.holder, purposeNamespacePushCredentials, s.encKey, string(cred.JSON))
 	if err != nil {
 		return fmt.Errorf("credentials Upsert: encrypt: %w", err)
 	}

--- a/core/pkg/push/device_store_rqlite.go
+++ b/core/pkg/push/device_store_rqlite.go
@@ -29,7 +29,15 @@ type RqliteDeviceStore struct {
 	db     rqlite.Client
 	encKey []byte // derived once at construction (token encryption)
 	fpKey  []byte // derived once at construction (token fingerprint, bugboard #981)
+	holder *secrets.Holder
 	logger *zap.Logger
+}
+
+// SetHolder lets a rotate take effect without restarting this process.
+func (s *RqliteDeviceStore) SetHolder(h *secrets.Holder) {
+	if s != nil {
+		s.holder = h
+	}
 }
 
 // NewRqliteDeviceStore derives the per-cluster encryption + fingerprint keys
@@ -101,7 +109,7 @@ func (s *RqliteDeviceStore) Upsert(ctx context.Context, dev PushDevice) (string,
 		return "", ErrEmptyToken
 	}
 
-	encToken, err := secrets.Encrypt(dev.Token, s.encKey)
+	encToken, err := secrets.Seal(s.holder, SecretsKeyPurpose, s.encKey, dev.Token)
 	if err != nil {
 		return "", fmt.Errorf("encrypt token: %w", err)
 	}
@@ -232,7 +240,7 @@ func (s *RqliteDeviceStore) BackfillTokenFP(ctx context.Context) (int, error) {
 	}
 	updated := 0
 	for _, r := range rows {
-		token, err := secrets.Decrypt(r.TokenEncrypted, s.encKey)
+		token, err := secrets.Open(s.holder, SecretsKeyPurpose, s.encKey, r.TokenEncrypted)
 		if err != nil {
 			s.logger.Warn("backfill: failed to decrypt token; skipping row",
 				zap.String("device_row_id", r.ID),
@@ -293,7 +301,7 @@ func (s *RqliteDeviceStore) ListForUser(ctx context.Context, namespace, userID s
 
 	out := make([]PushDevice, 0, len(rows))
 	for _, r := range rows {
-		token, err := secrets.Decrypt(r.TokenEncrypted, s.encKey)
+		token, err := secrets.Open(s.holder, SecretsKeyPurpose, s.encKey, r.TokenEncrypted)
 		if err != nil {
 			s.logger.Warn("failed to decrypt push token; skipping device",
 				zap.String("device_id", r.DeviceID),

--- a/core/pkg/rqlite/schema_placement.go
+++ b/core/pkg/rqlite/schema_placement.go
@@ -69,6 +69,7 @@ var tablePlacement = map[string]tableNote{
 	"device_authorizations": {PlacementCluster, "started on one gateway, approved on another"},
 	"operators":             {PlacementCluster, "who may operate the cluster"},
 	"audit_events":          {PlacementCluster, "a record its own subject could delete is not a record"},
+	"encryption_roots":      {PlacementCluster, "the IKM stored secrets are derived from; a tenant copy would be a KEK they can rewrite"},
 
 	// --- the tenant's data plane: the namespace's own RQLite --------------
 	//

--- a/core/pkg/secrets/encrypt.go
+++ b/core/pkg/secrets/encrypt.go
@@ -1,5 +1,19 @@
 // Package secrets provides application-level encryption for sensitive data stored in RQLite.
-// Uses AES-256-GCM with HKDF key derivation from the cluster secret.
+//
+// Ciphertext is AES-256-GCM. Keys are HKDF-SHA256 of an IKM (the encryption
+// root) and a purpose label. The IKM used to be the cluster secret; it is now
+// its own value so stored secrets can rotate without partitioning IPFS-Cluster
+// or the mesh bearer.
+//
+// Two on-disk envelopes exist:
+//
+//	enc:<base64>                 — legacy; still the default write until an
+//	                               operator rotate rewrites the rows
+//	enc:v1:<keyid>:<base64>      — versioned; keyid selects the generation
+//
+// Decrypt fails closed on anything else. Callers that still hold a leftover
+// plaintext column (deployment env, TURN) check IsEncrypted themselves and
+// never send unprefixed input here.
 package secrets
 
 import (
@@ -15,16 +29,28 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// Prefix for encrypted values to distinguish from plaintext during migration.
-const encryptedPrefix = "enc:"
+const (
+	// encryptedPrefix is the legacy envelope. New writes keep using it until
+	// an operator rotate, so a mixed-version rolling upgrade can still read
+	// what a new binary writes.
+	encryptedPrefix = "enc:"
 
-// DeriveKey derives a 32-byte AES-256 key from the cluster secret using HKDF-SHA256.
+	// versionedPrefix is the envelope that carries a key id.
+	versionedPrefix = "enc:v1:"
+)
+
+// DeriveKey derives a 32-byte AES-256 key from ikm using HKDF-SHA256.
 // The purpose string provides domain separation (e.g., "turn-encryption").
-func DeriveKey(clusterSecret, purpose string) ([]byte, error) {
-	if clusterSecret == "" {
-		return nil, fmt.Errorf("cluster secret is empty")
+//
+// ikm is the encryption root, not the cluster secret, for stored ciphertext.
+// A nil salt is RFC 5869-legal for high-entropy IKM and is kept so existing
+// rows stay decryptable; a salt would be a key change and belongs inside a
+// rotate, not a silent upgrade.
+func DeriveKey(ikm, purpose string) ([]byte, error) {
+	if ikm == "" {
+		return nil, fmt.Errorf("encryption root is empty")
 	}
-	reader := hkdf.New(sha256.New, []byte(clusterSecret), nil, []byte(purpose))
+	reader := hkdf.New(sha256.New, []byte(ikm), nil, []byte(purpose))
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(reader, key); err != nil {
 		return nil, fmt.Errorf("HKDF key derivation failed: %w", err)
@@ -33,66 +59,132 @@ func DeriveKey(clusterSecret, purpose string) ([]byte, error) {
 }
 
 // Encrypt encrypts plaintext with AES-256-GCM using the given key.
-// Returns a base64-encoded string prefixed with "enc:" for identification.
+// Returns a base64-encoded string prefixed with "enc:" (the legacy envelope).
 func Encrypt(plaintext string, key []byte) (string, error) {
-	block, err := aes.NewCipher(key)
+	sealed, err := seal(plaintext, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to create cipher: %w", err)
+		return "", err
 	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return "", fmt.Errorf("failed to create GCM: %w", err)
-	}
-
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", fmt.Errorf("failed to generate nonce: %w", err)
-	}
-
-	// nonce is prepended to ciphertext
-	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
-	return encryptedPrefix + base64.StdEncoding.EncodeToString(ciphertext), nil
+	return encryptedPrefix + base64.StdEncoding.EncodeToString(sealed), nil
 }
 
-// Decrypt decrypts an "enc:"-prefixed ciphertext string with AES-256-GCM.
-// If the input is not prefixed with "enc:", it is returned as-is (plaintext passthrough
-// for backward compatibility during migration).
-func Decrypt(ciphertext string, key []byte) (string, error) {
-	if !strings.HasPrefix(ciphertext, encryptedPrefix) {
-		return ciphertext, nil // plaintext passthrough
+// EncryptVersioned encrypts plaintext and wraps it as enc:v1:<keyID>:<base64>.
+func EncryptVersioned(plaintext, keyID string, key []byte) (string, error) {
+	if keyID == "" {
+		return "", fmt.Errorf("refusing to write a versioned envelope with an empty key id")
 	}
-
-	data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(ciphertext, encryptedPrefix))
+	if strings.ContainsAny(keyID, ":\n\r") {
+		return "", fmt.Errorf("key id %q contains a separator", keyID)
+	}
+	sealed, err := seal(plaintext, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode ciphertext: %w", err)
+		return "", err
 	}
+	return versionedPrefix + keyID + ":" + base64.StdEncoding.EncodeToString(sealed), nil
+}
 
+func seal(plaintext string, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	return gcm.Seal(nonce, nonce, []byte(plaintext), nil), nil
+}
+
+// Envelope is a parsed ciphertext. Version 0 is the legacy enc: form.
+type Envelope struct {
+	Version int
+	KeyID   string
+	Data    []byte
+}
+
+// ParseEnvelope splits a stored value into its envelope fields.
+// Unprefixed input is an error: Decrypt fails closed.
+func ParseEnvelope(ciphertext string) (Envelope, error) {
+	if strings.HasPrefix(ciphertext, versionedPrefix) {
+		rest := strings.TrimPrefix(ciphertext, versionedPrefix)
+		keyID, encoded, ok := strings.Cut(rest, ":")
+		if !ok || keyID == "" || encoded == "" {
+			return Envelope{}, fmt.Errorf("malformed versioned envelope")
+		}
+		data, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return Envelope{}, fmt.Errorf("failed to decode ciphertext: %w", err)
+		}
+		return Envelope{Version: 1, KeyID: keyID, Data: data}, nil
+	}
+	if strings.HasPrefix(ciphertext, encryptedPrefix) {
+		data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(ciphertext, encryptedPrefix))
+		if err != nil {
+			return Envelope{}, fmt.Errorf("failed to decode ciphertext: %w", err)
+		}
+		return Envelope{Version: 0, Data: data}, nil
+	}
+	return Envelope{}, fmt.Errorf("ciphertext has no enc: prefix")
+}
+
+// Decrypt decrypts an enc:-prefixed or enc:v1:<id>:-prefixed ciphertext.
+// Unprefixed input is an error, not plaintext.
+func Decrypt(ciphertext string, key []byte) (string, error) {
+	env, err := ParseEnvelope(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	return open(env.Data, key)
+}
+
+// DecryptAny tries each key in order. Used while two generations are in flight.
+func DecryptAny(ciphertext string, keys ...[]byte) (string, error) {
+	var last error
+	tried := 0
+	for _, key := range keys {
+		if len(key) == 0 {
+			continue
+		}
+		tried++
+		plain, err := Decrypt(ciphertext, key)
+		if err == nil {
+			return plain, nil
+		}
+		last = err
+	}
+	if tried == 0 {
+		return "", fmt.Errorf("no decryption key")
+	}
+	return "", last
+}
+
+func open(data, key []byte) (string, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", fmt.Errorf("failed to create cipher: %w", err)
 	}
-
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return "", fmt.Errorf("failed to create GCM: %w", err)
 	}
-
 	nonceSize := gcm.NonceSize()
 	if len(data) < nonceSize {
 		return "", fmt.Errorf("ciphertext too short")
 	}
-
-	nonce, sealed := data[:nonceSize], data[nonceSize:]
-	plaintext, err := gcm.Open(nil, nonce, sealed, nil)
+	plain, err := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
 	if err != nil {
 		return "", fmt.Errorf("decryption failed (wrong key or corrupted data): %w", err)
 	}
-
-	return string(plaintext), nil
+	return string(plain), nil
 }
 
-// IsEncrypted returns true if the value has the "enc:" prefix.
+// IsEncrypted reports whether a stored value is in either envelope.
+// Callers use this to tell leftover plaintext (deployment env, TURN) from
+// ciphertext without asking Decrypt, which fails closed on plaintext.
 func IsEncrypted(value string) bool {
 	return strings.HasPrefix(value, encryptedPrefix)
 }

--- a/core/pkg/secrets/encrypt_test.go
+++ b/core/pkg/secrets/encrypt_test.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func testKey(t *testing.T, ikm, purpose string) []byte {
+	t.Helper()
+	k, err := DeriveKey(ikm, purpose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+func TestEncryptDecrypt_roundTrip(t *testing.T) {
+	key := testKey(t, "ikm-one", "purpose-a")
+	ct, err := Encrypt("hello", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(ct, "enc:") || strings.HasPrefix(ct, "enc:v1:") {
+		t.Fatalf("legacy encrypt wrote %q", ct)
+	}
+	got, err := Decrypt(ct, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEncryptVersioned_roundTripAndKeyID(t *testing.T) {
+	key := testKey(t, "ikm-one", "purpose-a")
+	ct, err := EncryptVersioned("hello", "1", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := ParseEnvelope(ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.Version != 1 || env.KeyID != "1" {
+		t.Fatalf("envelope %+v", env)
+	}
+	got, err := Decrypt(ct, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestDecrypt_failsClosedOnPlaintext(t *testing.T) {
+	key := testKey(t, "ikm-one", "purpose-a")
+	if _, err := Decrypt("not-encrypted", key); err == nil {
+		t.Fatal("plaintext passed through")
+	}
+	if _, err := Decrypt("", key); err == nil {
+		t.Fatal("empty passed through")
+	}
+}
+
+func TestDecrypt_wrongKeyFails(t *testing.T) {
+	a := testKey(t, "ikm-one", "purpose-a")
+	b := testKey(t, "ikm-two", "purpose-a")
+	ct, err := Encrypt("hello", a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decrypt(ct, b); err == nil {
+		t.Fatal("wrong key opened the ciphertext")
+	}
+}
+
+func TestDecryptAny_triesPrevious(t *testing.T) {
+	old := testKey(t, "ikm-old", "p")
+	cur := testKey(t, "ikm-new", "p")
+	ct, err := Encrypt("hello", old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecryptAny(ct, cur, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestDeriveKey_emptyIKM(t *testing.T) {
+	if _, err := DeriveKey("", "p"); err == nil {
+		t.Fatal("empty IKM derived a key")
+	}
+}
+
+func TestDeriveKey_sameInputsSameKey(t *testing.T) {
+	a := testKey(t, "cluster-secret-abc123", "orama-secrets-encryption-v1")
+	b := testKey(t, "cluster-secret-abc123", "orama-secrets-encryption-v1")
+	if hex.EncodeToString(a) != hex.EncodeToString(b) {
+		t.Fatal("not deterministic")
+	}
+}
+
+func TestIsEncrypted_bothEnvelopes(t *testing.T) {
+	if !IsEncrypted("enc:abc") {
+		t.Fatal("legacy")
+	}
+	if !IsEncrypted("enc:v1:1:abc") {
+		t.Fatal("versioned")
+	}
+	if IsEncrypted("{") {
+		t.Fatal("json")
+	}
+}
+
+func TestEncryptVersioned_rejectsEmptyOrSeparatorKeyID(t *testing.T) {
+	key := testKey(t, "ikm", "p")
+	if _, err := EncryptVersioned("x", "", key); err == nil {
+		t.Fatal("empty key id")
+	}
+	if _, err := EncryptVersioned("x", "1:2", key); err == nil {
+		t.Fatal("separator in key id")
+	}
+}

--- a/core/pkg/secrets/keyset.go
+++ b/core/pkg/secrets/keyset.go
@@ -1,0 +1,154 @@
+package secrets
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Keyset is the pair of AES keys for one purpose, derived from the current
+// (and, during a rotate, previous) encryption root.
+type Keyset struct {
+	Current        []byte
+	CurrentID      string
+	Previous       []byte
+	PreviousID     string
+	WriteVersioned bool
+}
+
+// Encrypt seals plaintext under the current key. After an operator rotate it
+// writes the versioned envelope; until then it writes the legacy enc: form so
+// a mixed-version rolling upgrade can still read new rows.
+func (k Keyset) Encrypt(plaintext string) (string, error) {
+	if len(k.Current) == 0 {
+		return "", fmt.Errorf("no current encryption key")
+	}
+	if k.WriteVersioned {
+		return EncryptVersioned(plaintext, k.CurrentID, k.Current)
+	}
+	return Encrypt(plaintext, k.Current)
+}
+
+// Decrypt opens a stored value. A versioned envelope is tried with the matching
+// generation; a legacy envelope is tried with current then previous.
+func (k Keyset) Decrypt(ciphertext string) (string, error) {
+	env, err := ParseEnvelope(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	if env.Version == 1 {
+		key := k.keyFor(env.KeyID)
+		if len(key) == 0 {
+			return "", fmt.Errorf("no key for id %q", env.KeyID)
+		}
+		return open(env.Data, key)
+	}
+	return DecryptAny(ciphertext, k.Current, k.Previous)
+}
+
+func (k Keyset) keyFor(id string) []byte {
+	if id == k.CurrentID {
+		return k.Current
+	}
+	if id == k.PreviousID {
+		return k.Previous
+	}
+	return nil
+}
+
+// Root is one generation of the encryption-root IKM, plus the previous
+// generation while a rotate is in flight.
+type Root struct {
+	CurrentID      string
+	CurrentIKM     string
+	PreviousID     string
+	PreviousIKM    string
+	WriteVersioned bool
+}
+
+// Keyset derives the purpose-separated AES keys from this root.
+func (r Root) Keyset(purpose string) (Keyset, error) {
+	if r.CurrentIKM == "" {
+		return Keyset{}, fmt.Errorf("encryption root is empty")
+	}
+	cur, err := DeriveKey(r.CurrentIKM, purpose)
+	if err != nil {
+		return Keyset{}, err
+	}
+	ks := Keyset{
+		Current:        cur,
+		CurrentID:      r.CurrentID,
+		WriteVersioned: r.WriteVersioned,
+		PreviousID:     r.PreviousID,
+	}
+	if r.PreviousIKM != "" {
+		prev, err := DeriveKey(r.PreviousIKM, purpose)
+		if err != nil {
+			return Keyset{}, err
+		}
+		ks.Previous = prev
+	}
+	return ks, nil
+}
+
+// Holder is the process-wide encryption root. Stores read it on each
+// encrypt/decrypt so a rotate takes effect without restarting the gateway.
+type Holder struct {
+	mu sync.RWMutex
+	r  Root
+}
+
+// NewHolder wraps r.
+func NewHolder(r Root) *Holder { return &Holder{r: r} }
+
+// Get returns a snapshot of the root.
+func (h *Holder) Get() Root {
+	if h == nil {
+		return Root{}
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.r
+}
+
+// Swap replaces the root. Called after a rotate lands in the registry.
+func (h *Holder) Swap(r Root) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.r = r
+	h.mu.Unlock()
+}
+
+// Keyset is Get().Keyset(purpose).
+func (h *Holder) Keyset(purpose string) (Keyset, error) {
+	return h.Get().Keyset(purpose)
+}
+
+// Seal encrypts with the holder's current keyset, or fallback if holder is nil.
+func Seal(holder *Holder, purpose string, fallback []byte, plaintext string) (string, error) {
+	if holder != nil {
+		ks, err := holder.Keyset(purpose)
+		if err == nil {
+			return ks.Encrypt(plaintext)
+		}
+	}
+	if len(fallback) == 0 {
+		return "", fmt.Errorf("no encryption key")
+	}
+	return Encrypt(plaintext, fallback)
+}
+
+// Open decrypts with the holder's keyset (current and previous), or fallback.
+func Open(holder *Holder, purpose string, fallback []byte, ciphertext string) (string, error) {
+	if holder != nil {
+		ks, err := holder.Keyset(purpose)
+		if err == nil {
+			return ks.Decrypt(ciphertext)
+		}
+	}
+	if len(fallback) == 0 {
+		return "", fmt.Errorf("no decryption key")
+	}
+	return Decrypt(ciphertext, fallback)
+}

--- a/core/pkg/secrets/keyset_test.go
+++ b/core/pkg/secrets/keyset_test.go
@@ -1,0 +1,89 @@
+package secrets
+
+import "testing"
+
+func TestKeyset_legacyWriteThenVersionedRead(t *testing.T) {
+	root := Root{CurrentID: "1", CurrentIKM: "ikm-one"}
+	ks, err := root.Keyset("purpose-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct, err := ks.Encrypt("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if IsEncrypted(ct) == false {
+		t.Fatal(ct)
+	}
+	got, err := ks.Decrypt(ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "secret" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestKeyset_rotateCannotOpenNewWithOld(t *testing.T) {
+	old := Root{CurrentID: "1", CurrentIKM: "ikm-old", WriteVersioned: true}
+	oldKS, err := old.Keyset("p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	next := Root{
+		CurrentID:      "2",
+		CurrentIKM:     "ikm-new",
+		PreviousID:     "1",
+		PreviousIKM:    "ikm-old",
+		WriteVersioned: true,
+	}
+	newKS, err := next.Keyset("p")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldCT, err := oldKS.Encrypt("old-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newCT, err := newKS.Encrypt("new-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := newKS.Decrypt(oldCT)
+	if err != nil {
+		t.Fatalf("new keyset should still open previous generation: %v", err)
+	}
+	if got != "old-value" {
+		t.Fatalf("got %q", got)
+	}
+
+	if _, err := oldKS.Decrypt(newCT); err == nil {
+		t.Fatal("old keyset opened a row sealed after rotate — snapshot did not age out")
+	}
+}
+
+func TestHolder_swapIsVisible(t *testing.T) {
+	h := NewHolder(Root{CurrentID: "1", CurrentIKM: "ikm-old"})
+	ks, err := h.Keyset("p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct, err := ks.Encrypt("v")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.Swap(Root{CurrentID: "2", CurrentIKM: "ikm-new", PreviousID: "1", PreviousIKM: "ikm-old", WriteVersioned: true})
+	ks2, err := h.Keyset("p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ks2.Decrypt(ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/core/pkg/secrets/root.go
+++ b/core/pkg/secrets/root.go
@@ -1,0 +1,306 @@
+package secrets
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	// FileName is the IKM file next to cluster-secret.
+	FileName = "encryption-root"
+	// FileIDName holds the current generation id.
+	FileIDName = "encryption-root.id"
+	// FilePrevName is the previous IKM while a rotate is in flight.
+	FilePrevName = "encryption-root.prev"
+	// FilePrevIDName is the previous generation id.
+	FilePrevIDName = "encryption-root.prev.id"
+
+	// FirstID is the generation assigned when the root is materialised from
+	// the cluster secret. Existing ciphertext was derived from that IKM.
+	FirstID = "1"
+
+	rootTable = "encryption_roots"
+)
+
+// Store is the slice of the registry the root is persisted in.
+type Store interface {
+	Query(ctx context.Context, dest any, query string, args ...any) error
+	Exec(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// LoadOrMaterialize returns the cluster's encryption root.
+//
+// Order: registry (source of truth) → files on disk → copy of clusterSecret.
+// A missing file on an existing cluster is materialised by copying the cluster
+// secret, so HKDF(encryption-root, purpose) equals today's keys. The file is
+// never regenerated because it is unreadable or the wrong length: that is how
+// IPFS-Cluster was silently partitioned, and it would orphan every stored
+// secret here.
+func LoadOrMaterialize(ctx context.Context, store Store, secretsDir, clusterSecret string) (Root, error) {
+	clusterSecret = strings.TrimSpace(clusterSecret)
+
+	if store != nil {
+		if r, err := loadFromRegistry(ctx, store); err == nil && r.CurrentIKM != "" {
+			_ = writeFiles(secretsDir, r)
+			return r, nil
+		}
+	}
+
+	r, ferr := loadFromFiles(secretsDir)
+	if ferr == nil && r.CurrentIKM != "" {
+		if store != nil {
+			_ = saveToRegistry(ctx, store, r)
+		}
+		return r, nil
+	}
+	if ferr != nil && !os.IsNotExist(ferr) {
+		return Root{}, ferr
+	}
+
+	if clusterSecret == "" {
+		if ferr != nil {
+			return Root{}, ferr
+		}
+		return Root{}, fmt.Errorf("no encryption root: no registry row, no %s file, and no cluster secret to copy", FileName)
+	}
+
+	r = Root{CurrentID: FirstID, CurrentIKM: clusterSecret}
+	if err := writeFiles(secretsDir, r); err != nil {
+		return Root{}, err
+	}
+	if store != nil {
+		// The table may not exist yet: schema apply runs in the readiness
+		// loop, after the secrets manager is constructed. The next persist
+		// (operator rotate, or a later boot) writes the row.
+		_ = saveToRegistry(ctx, store, r)
+	}
+	return r, nil
+}
+
+type rootRow struct {
+	Slot           string `db:"slot"`
+	KeyID          string `db:"key_id"`
+	IKM            string `db:"ikm"`
+	WriteVersioned int    `db:"write_versioned"`
+}
+
+func loadFromRegistry(ctx context.Context, store Store) (Root, error) {
+	var rows []rootRow
+	if err := store.Query(ctx, &rows, `SELECT slot, key_id, ikm, write_versioned FROM `+rootTable); err != nil {
+		return Root{}, err
+	}
+	var r Root
+	for _, row := range rows {
+		switch row.Slot {
+		case "current":
+			r.CurrentID = row.KeyID
+			r.CurrentIKM = strings.TrimSpace(row.IKM)
+			r.WriteVersioned = row.WriteVersioned != 0
+		case "previous":
+			r.PreviousID = row.KeyID
+			r.PreviousIKM = strings.TrimSpace(row.IKM)
+		}
+	}
+	if r.CurrentIKM == "" {
+		return Root{}, fmt.Errorf("registry encryption_roots has no current row")
+	}
+	return r, nil
+}
+
+func saveToRegistry(ctx context.Context, store Store, r Root) error {
+	if _, err := store.Exec(ctx,
+		`INSERT INTO `+rootTable+` (slot, key_id, ikm, write_versioned, updated_at)
+		 VALUES ('current', ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(slot) DO UPDATE SET
+			key_id = excluded.key_id,
+			ikm = excluded.ikm,
+			write_versioned = excluded.write_versioned,
+			updated_at = excluded.updated_at`,
+		r.CurrentID, r.CurrentIKM, boolToInt(r.WriteVersioned)); err != nil {
+		return err
+	}
+	if r.PreviousIKM == "" {
+		_, err := store.Exec(ctx, `DELETE FROM `+rootTable+` WHERE slot = 'previous'`)
+		return err
+	}
+	_, err := store.Exec(ctx,
+		`INSERT INTO `+rootTable+` (slot, key_id, ikm, write_versioned, updated_at)
+		 VALUES ('previous', ?, ?, 0, CURRENT_TIMESTAMP)
+		 ON CONFLICT(slot) DO UPDATE SET
+			key_id = excluded.key_id,
+			ikm = excluded.ikm,
+			updated_at = excluded.updated_at`,
+		r.PreviousID, r.PreviousIKM)
+	return err
+}
+
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func loadFromFiles(dir string) (Root, error) {
+	ikm, err := readSecretFile(filepath.Join(dir, FileName))
+	if err != nil {
+		return Root{}, err
+	}
+	id := FirstID
+	if s, err := readSecretFile(filepath.Join(dir, FileIDName)); err == nil && s != "" {
+		id = s
+	}
+	r := Root{CurrentID: id, CurrentIKM: ikm}
+	if prev, err := readSecretFile(filepath.Join(dir, FilePrevName)); err == nil && prev != "" {
+		r.PreviousIKM = prev
+		r.PreviousID = FirstID
+		if s, err := readSecretFile(filepath.Join(dir, FilePrevIDName)); err == nil && s != "" {
+			r.PreviousID = s
+		}
+	}
+	return r, nil
+}
+
+func writeFiles(dir string, r Root) error {
+	if dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("encryption-root dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return fmt.Errorf("encryption-root dir perms: %w", err)
+	}
+	if err := writeSecretFile(filepath.Join(dir, FileName), r.CurrentIKM); err != nil {
+		return err
+	}
+	if err := writeSecretFile(filepath.Join(dir, FileIDName), r.CurrentID); err != nil {
+		return err
+	}
+	if r.PreviousIKM == "" {
+		_ = os.Remove(filepath.Join(dir, FilePrevName))
+		_ = os.Remove(filepath.Join(dir, FilePrevIDName))
+		return nil
+	}
+	if err := writeSecretFile(filepath.Join(dir, FilePrevName), r.PreviousIKM); err != nil {
+		return err
+	}
+	return writeSecretFile(filepath.Join(dir, FilePrevIDName), r.PreviousID)
+}
+
+func readSecretFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	v := strings.TrimSpace(string(data))
+	if v == "" {
+		return "", fmt.Errorf("%s is empty; refusing to invent a replacement", path)
+	}
+	return v, nil
+}
+
+func writeSecretFile(path, value string) error {
+	if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+// Rotate generates a new IKM, demotes the current root to previous, and
+// persists both. Existing ciphertext stays readable under previous until the
+// walker re-encrypts it.
+func Rotate(ctx context.Context, store Store, secretsDir string, current Root) (Root, error) {
+	next, err := nextID(current.CurrentID)
+	if err != nil {
+		return Root{}, err
+	}
+	ikm, err := randomIKM()
+	if err != nil {
+		return Root{}, err
+	}
+	r := Root{
+		CurrentID:      next,
+		CurrentIKM:     ikm,
+		PreviousID:     current.CurrentID,
+		PreviousIKM:    current.CurrentIKM,
+		WriteVersioned: true,
+	}
+	if err := writeFiles(secretsDir, r); err != nil {
+		return Root{}, err
+	}
+	if store != nil {
+		if err := saveToRegistry(ctx, store, r); err != nil {
+			return Root{}, fmt.Errorf("persist rotated encryption root: %w", err)
+		}
+	}
+	return r, nil
+}
+
+// ForgetPrevious drops the previous generation after the walker has finished.
+func ForgetPrevious(ctx context.Context, store Store, secretsDir string, current Root) (Root, error) {
+	current.PreviousID = ""
+	current.PreviousIKM = ""
+	if err := writeFiles(secretsDir, current); err != nil {
+		return Root{}, err
+	}
+	if store != nil {
+		if err := saveToRegistry(ctx, store, current); err != nil {
+			return Root{}, err
+		}
+	}
+	return current, nil
+}
+
+// EnableVersionedWrites flips new Encrypts to the versioned envelope without
+// changing the IKM. Used by the format-only rewrite so a mixed-version
+// rollout is finished before anything writes enc:v1:.
+func EnableVersionedWrites(ctx context.Context, store Store, secretsDir string, current Root) (Root, error) {
+	current.WriteVersioned = true
+	if err := writeFiles(secretsDir, current); err != nil {
+		return Root{}, err
+	}
+	if store != nil {
+		if err := saveToRegistry(ctx, store, current); err != nil {
+			return Root{}, err
+		}
+	}
+	return current, nil
+}
+
+func nextID(current string) (string, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(current))
+	if err != nil || n < 1 {
+		return "", fmt.Errorf("encryption-root id %q is not a positive integer", current)
+	}
+	return strconv.Itoa(n + 1), nil
+}
+
+func randomIKM() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate encryption root: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// SecretsDir is <dataDir>/secrets, the same directory as cluster-secret.
+func SecretsDir(dataDir string) string {
+	return filepath.Join(dataDir, "secrets")
+}
+
+// Persist writes the root to the secrets directory. Used by a namespace
+// gateway that received a rotated root from the index.
+func Persist(secretsDir string, r Root) error {
+	return writeFiles(secretsDir, r)
+}

--- a/core/pkg/secrets/root_test.go
+++ b/core/pkg/secrets/root_test.go
@@ -1,0 +1,109 @@
+package secrets
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/rqlite"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestLoadOrMaterialize_copiesClusterSecretAndDoesNotRegenerate(t *testing.T) {
+	dir := t.TempDir()
+	secretsDir := filepath.Join(dir, "secrets")
+	const cs = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	r, err := LoadOrMaterialize(context.Background(), nil, secretsDir, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.CurrentIKM != cs || r.CurrentID != FirstID {
+		t.Fatalf("got %+v", r)
+	}
+
+	// A second load reads the file, not a new value.
+	r2, err := LoadOrMaterialize(context.Background(), nil, secretsDir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2.CurrentIKM != cs {
+		t.Fatalf("regenerated or ignored the file: %q", r2.CurrentIKM)
+	}
+}
+
+func TestLoadOrMaterialize_emptyFileIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	secretsDir := filepath.Join(dir, "secrets")
+	if err := os.MkdirAll(secretsDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, FileName), []byte("\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOrMaterialize(context.Background(), nil, secretsDir, "cluster"); err == nil {
+		t.Fatal("empty file was replaced")
+	}
+}
+
+func TestRotate_newIKMCannotDeriveFromOld(t *testing.T) {
+	dir := t.TempDir()
+	secretsDir := filepath.Join(dir, "secrets")
+	const cs = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	cur, err := LoadOrMaterialize(context.Background(), nil, secretsDir, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	next, err := Rotate(context.Background(), nil, secretsDir, cur)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.CurrentIKM == cur.CurrentIKM {
+		t.Fatal("rotate reused the IKM")
+	}
+	if next.PreviousIKM != cur.CurrentIKM {
+		t.Fatal("previous was not the old current")
+	}
+	if next.CurrentID != "2" || next.PreviousID != "1" {
+		t.Fatalf("ids %+v", next)
+	}
+
+	oldKS, _ := cur.Keyset("p")
+	newKS, _ := next.Keyset("p")
+	ct, err := newKS.Encrypt("after")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oldKS.Decrypt(ct); err == nil {
+		t.Fatal("pre-rotate key opened post-rotate ciphertext")
+	}
+}
+
+func TestLoadOrMaterialize_registryWins(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE encryption_roots (
+		slot TEXT PRIMARY KEY, key_id TEXT NOT NULL, ikm TEXT NOT NULL,
+		write_versioned INTEGER NOT NULL DEFAULT 0, updated_at TIMESTAMP
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	store := rqlite.NewClient(db)
+	if _, err := store.Exec(context.Background(),
+		`INSERT INTO encryption_roots (slot, key_id, ikm, write_versioned) VALUES ('current', '7', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd', 1)`); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	r, err := LoadOrMaterialize(context.Background(), store, filepath.Join(dir, "secrets"), "cluster-secret-should-not-win")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.CurrentID != "7" || r.CurrentIKM[0] != 'd' || !r.WriteVersioned {
+		t.Fatalf("got %+v", r)
+	}
+}

--- a/core/pkg/secrets/walk.go
+++ b/core/pkg/secrets/walk.go
@@ -1,0 +1,183 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// WalkDB is the RQLite handle the walker writes through.
+type WalkDB = Store
+
+// Column is one ciphertext column to rewrite.
+type Column struct {
+	Table   string
+	Column  string
+	IDCols  []string
+	Purpose string
+}
+
+// NamespaceColumns are the tenant-DB columns sealed with the encryption root.
+func NamespaceColumns() []Column {
+	return []Column{
+		{Table: "function_secrets", Column: "encrypted_value", IDCols: []string{"id"}, Purpose: "orama-secrets-encryption-v1"},
+		{Table: "push_devices", Column: "token_encrypted", IDCols: []string{"id"}, Purpose: "push-device-tokens"},
+		{Table: "namespace_push_config", Column: "ntfy_auth_token_encrypted", IDCols: []string{"namespace"}, Purpose: "namespace-push-config"},
+		{Table: "namespace_push_config", Column: "expo_access_token_encrypted", IDCols: []string{"namespace"}, Purpose: "namespace-push-config"},
+		{Table: "namespace_push_credentials", Column: "credentials_json", IDCols: []string{"namespace", "provider"}, Purpose: "namespace-push-credentials"},
+		{Table: "namespace_webrtc_config", Column: "turn_shared_secret", IDCols: []string{"id"}, Purpose: "turn-encryption"},
+		{Table: "deployments", Column: "environment", IDCols: []string{"id"}, Purpose: "orama-deployment-environment-v1"},
+	}
+}
+
+// IndexColumns are the registry columns sealed with the encryption root.
+func IndexColumns() []Column {
+	return []Column{
+		{Table: "wireguard_peers", Column: "agent_token", IDCols: []string{"node_id"}, Purpose: "node-agent-token"},
+	}
+}
+
+// WalkResult is how many rows the walker looked at and rewrote.
+type WalkResult struct {
+	Scanned  int      `json:"scanned"`
+	Rewrote  int      `json:"rewrote"`
+	Skipped  int      `json:"skipped"`
+	Missing  int      `json:"missing"`
+	Failures []string `json:"failures,omitempty"`
+}
+
+// Walk re-encrypts every listed column under root. It is idempotent: a row
+// already sealed with the current key id is left alone. Unprefixed leftover
+// plaintext (deployment env, TURN) is sealed rather than refused, which is
+// the migration those columns still need.
+func Walk(ctx context.Context, db WalkDB, root Root, cols []Column) (WalkResult, error) {
+	var out WalkResult
+	if db == nil {
+		return out, fmt.Errorf("re-encrypt: no database")
+	}
+	for _, col := range cols {
+		r, err := walkColumn(ctx, db, root, col)
+		out.Scanned += r.Scanned
+		out.Rewrote += r.Rewrote
+		out.Skipped += r.Skipped
+		out.Missing += r.Missing
+		out.Failures = append(out.Failures, r.Failures...)
+		if err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+func walkColumn(ctx context.Context, db WalkDB, root Root, col Column) (WalkResult, error) {
+	var out WalkResult
+	ks, err := root.Keyset(col.Purpose)
+	if err != nil {
+		return out, err
+	}
+
+	selectCols := strings.Join(append(append([]string{}, col.IDCols...), col.Column), ", ")
+	query := fmt.Sprintf("SELECT %s FROM %s", selectCols, col.Table)
+
+	var rows []map[string]any
+	if err := db.Query(ctx, &rows, query); err != nil {
+		if isNoSuchTable(err) {
+			out.Missing = 1
+			return out, nil
+		}
+		return out, fmt.Errorf("re-encrypt %s.%s: %w", col.Table, col.Column, err)
+	}
+
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		raw := stringify(row[col.Column])
+		if strings.TrimSpace(raw) == "" {
+			out.Skipped++
+			continue
+		}
+		out.Scanned++
+
+		if alreadyOnTarget(ks, raw) {
+			out.Skipped++
+			continue
+		}
+		plain, err := decryptForWalk(ks, raw)
+		if err != nil {
+			out.Failures = append(out.Failures, fmt.Sprintf("%s.%s %v: %v", col.Table, col.Column, idsOf(row, col.IDCols), err))
+			continue
+		}
+		sealed, err := ks.Encrypt(plain)
+		if err != nil {
+			out.Failures = append(out.Failures, fmt.Sprintf("%s.%s %v: %v", col.Table, col.Column, idsOf(row, col.IDCols), err))
+			continue
+		}
+		set := fmt.Sprintf("UPDATE %s SET %s = ?", col.Table, col.Column)
+		where, args := whereIDs(col.IDCols, row)
+		args = append([]any{sealed}, args...)
+		if _, err := db.Exec(ctx, set+" WHERE "+where, args...); err != nil {
+			out.Failures = append(out.Failures, fmt.Sprintf("%s.%s %v: %v", col.Table, col.Column, idsOf(row, col.IDCols), err))
+			continue
+		}
+		out.Rewrote++
+	}
+	return out, nil
+}
+
+func alreadyOnTarget(ks Keyset, raw string) bool {
+	env, err := ParseEnvelope(raw)
+	if err != nil {
+		return false
+	}
+	if ks.WriteVersioned {
+		return env.Version == 1 && env.KeyID == ks.CurrentID
+	}
+	return env.Version == 0
+}
+
+func decryptForWalk(ks Keyset, raw string) (string, error) {
+	if !IsEncrypted(raw) {
+		return raw, nil
+	}
+	return ks.Decrypt(raw)
+}
+
+func stringify(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func idsOf(row map[string]any, cols []string) []string {
+	out := make([]string, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, stringify(row[c]))
+	}
+	return out
+}
+
+func whereIDs(cols []string, row map[string]any) (string, []any) {
+	parts := make([]string, 0, len(cols))
+	args := make([]any, 0, len(cols))
+	for _, c := range cols {
+		parts = append(parts, c+" = ?")
+		args = append(args, stringify(row[c]))
+	}
+	return strings.Join(parts, " AND "), args
+}
+
+func isNoSuchTable(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "no such table")
+}

--- a/core/pkg/secrets/walk_test.go
+++ b/core/pkg/secrets/walk_test.go
@@ -1,0 +1,136 @@
+package secrets
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/rqlite"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestWalk_rewritesLegacyAndIsIdempotent(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE function_secrets (
+		id TEXT PRIMARY KEY, encrypted_value TEXT NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	root := Root{CurrentID: "1", CurrentIKM: "ikm-walk", WriteVersioned: true}
+	ks, err := root.Keyset("orama-secrets-encryption-v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := Encrypt("token", ks.Current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := rqlite.NewClient(db)
+	if _, err := store.Exec(context.Background(),
+		`INSERT INTO function_secrets (id, encrypted_value) VALUES ('a', ?)`, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Walk(context.Background(), store, root, []Column{{
+		Table: "function_secrets", Column: "encrypted_value", IDCols: []string{"id"},
+		Purpose: "orama-secrets-encryption-v1",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Rewrote != 1 {
+		t.Fatalf("first pass rewrote %d", first.Rewrote)
+	}
+
+	var rows []struct {
+		Value string `db:"encrypted_value"`
+	}
+	if err := store.Query(context.Background(), &rows, `SELECT encrypted_value FROM function_secrets`); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || !IsEncrypted(rows[0].Value) {
+		t.Fatalf("rows %+v", rows)
+	}
+	env, err := ParseEnvelope(rows[0].Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.Version != 1 || env.KeyID != "1" {
+		t.Fatalf("envelope %+v", env)
+	}
+	got, err := ks.Decrypt(rows[0].Value)
+	if err != nil || got != "token" {
+		t.Fatalf("decrypt %q %v", got, err)
+	}
+
+	second, err := Walk(context.Background(), store, root, []Column{{
+		Table: "function_secrets", Column: "encrypted_value", IDCols: []string{"id"},
+		Purpose: "orama-secrets-encryption-v1",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Rewrote != 0 {
+		t.Fatalf("second pass rewrote %d, want 0", second.Rewrote)
+	}
+}
+
+func TestWalk_sealsPlaintextLeftovers(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE deployments (id TEXT PRIMARY KEY, environment TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	store := rqlite.NewClient(db)
+	if _, err := store.Exec(context.Background(),
+		`INSERT INTO deployments (id, environment) VALUES ('d1', '{"A":"b"}')`); err != nil {
+		t.Fatal(err)
+	}
+	root := Root{CurrentID: "1", CurrentIKM: "ikm-env", WriteVersioned: true}
+	res, err := Walk(context.Background(), store, root, []Column{{
+		Table: "deployments", Column: "environment", IDCols: []string{"id"},
+		Purpose: "orama-deployment-environment-v1",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Rewrote != 1 {
+		t.Fatalf("rewrote %d", res.Rewrote)
+	}
+	var rows []struct {
+		Env string `db:"environment"`
+	}
+	if err := store.Query(context.Background(), &rows, `SELECT environment FROM deployments`); err != nil {
+		t.Fatal(err)
+	}
+	if !IsEncrypted(rows[0].Env) {
+		t.Fatalf("still plaintext %q", rows[0].Env)
+	}
+}
+
+func TestWalk_missingTableIsNotAnError(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store := rqlite.NewClient(db)
+	root := Root{CurrentID: "1", CurrentIKM: "ikm"}
+	res, err := Walk(context.Background(), store, root, []Column{{
+		Table: "function_secrets", Column: "encrypted_value", IDCols: []string{"id"},
+		Purpose: "orama-secrets-encryption-v1",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Missing != 1 {
+		t.Fatalf("missing %d", res.Missing)
+	}
+}

--- a/core/pkg/serverless/hostfunctions/secrets.go
+++ b/core/pkg/serverless/hostfunctions/secrets.go
@@ -20,7 +20,17 @@ const secretsKeyBytes = 32
 type DBSecretsManager struct {
 	db            rqlite.Client
 	encryptionKey []byte // 32-byte AES-256 key
+	holder        *secrets.Holder
 	logger        *zap.Logger
+}
+
+const functionSecretsPurpose = "orama-secrets-encryption-v1"
+
+// SetHolder lets a rotate take effect without restarting this process.
+func (s *DBSecretsManager) SetHolder(h *secrets.Holder) {
+	if s != nil {
+		s.holder = h
+	}
 }
 
 // Ensure DBSecretsManager implements SecretsManager.
@@ -73,7 +83,7 @@ func (s *DBSecretsManager) Set(ctx context.Context, namespace, name, value strin
 	// []byte on both legs and the round-trip never reproduced the ciphertext, so
 	// decrypt() always failed and get_secret returned empty. A text string round-
 	// trips cleanly.
-	encrypted, err := secrets.Encrypt(value, s.encryptionKey)
+	encrypted, err := secrets.Seal(s.holder, functionSecretsPurpose, s.encryptionKey, value)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt secret: %w", err)
 	}
@@ -113,7 +123,7 @@ func (s *DBSecretsManager) Get(ctx context.Context, namespace, name string) (str
 		return "", serverless.ErrSecretNotFound
 	}
 
-	decrypted, err := secrets.Decrypt(rows[0].EncryptedValue, s.encryptionKey)
+	decrypted, err := secrets.Open(s.holder, functionSecretsPurpose, s.encryptionKey, rows[0].EncryptedValue)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt secret: %w", err)
 	}

--- a/core/pkg/serverless/hostfunctions/sqlguard.go
+++ b/core/pkg/serverless/hostfunctions/sqlguard.go
@@ -52,6 +52,7 @@ var protectedTables = map[string]string{
 	// Public keys too, but writing one is deciding which machine the cluster
 	// will accept as a node, and deleting a row un-revokes a retired one.
 	"node_credentials":           "which key the cluster accepts as a node",
+	"encryption_roots":           "the IKM stored secrets are derived from",
 	"grants":                     "who may do what in a namespace",
 	"wireguard_peers":            "mesh membership and node agent tokens",
 	"namespace_push_credentials": "push credentials",

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -220,6 +220,7 @@ unit test read, so a shape change on either side fails without a cluster.
 | `/v1/operator/invite` | CLI | Mint a node invite. `orama invite`. |
 | `/v1/operator/node/register` | CLI | Record a node in the inventory. |
 | `/v1/operator/rotate-signing-key` | CLI | Generate a new signing key for this gateway, publish it, and leave the outgoing one verifying what it already signed for one access-token lifetime. Admin grant **and** a wallet on the operator list. `orama operator rotate-signing-key`. |
+| `/v1/operator/rotate-secrets` | CLI | Rewrite stored ciphertext onto `enc:v1:<id>:`. `--rotate` generates a new encryption root first. Admin grant **and** operator list. `orama operator rotate-secrets`. |
 | `/v1/operator/nodes` | CLI | Fleet inventory. |
 
 ### Internal (node to node)
@@ -234,6 +235,7 @@ unit test read, so a shape change on either side fails without a cluster.
 | `/v1/internal/deployments/replica/update` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
 | `/v1/internal/join` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
 | `/v1/internal/namespace/repair` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
+| `/v1/internal/secrets/reencrypt` | internal | Index fans out `orama operator rotate-secrets` to each namespace gateway. Coordination MAC + overlay. |
 | `/v1/internal/namespace/spawn` | internal | Node-to-node over the WireGuard overlay. Never reachable by a client. |
 | `/v1/internal/node/enrol-key` | internal | From the node's own process over loopback, stamped with the node's libp2p identity key. Refused from off the host. |
 | `/v1/internal/node/heartbeat` | internal | From the node's own process over loopback, stamped with the key that node enrolled. Refused from off the host. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -972,7 +972,7 @@ internal-auth check both accept.
 
 - **Refresh tokens:** Stored as SHA-256 hashes (never plaintext)
 - **API keys:** Stored as HMAC-SHA256 hashes with a server-side secret
-- **TURN secrets:** Encrypted at rest with AES-256-GCM (key derived from cluster secret)
+- **TURN secrets, function secrets, push tokens, deployment env, agent tokens:** Encrypted at rest with AES-256-GCM. The key is HKDF of `secrets/encryption-root` (a cluster-wide IKM that starts as a copy of the cluster secret). `orama operator rotate-secrets --rotate` replaces the IKM and re-encrypts; the cluster secret (IPFS-Cluster PSK / mesh bearer) is not touched
 - **Binary signing:** Build archives signed with rootwallet EVM signature, verified on install
 
 ### Process Isolation

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -446,6 +446,12 @@ verifying the tokens it already signed until they expire. Two `kid`s are in
 flight for that window. Nobody is signed out and nothing restarts. It needs the
 admin grant **and** a wallet on the operator list.
 
+Stored secrets (function secrets, push tokens, TURN, deployment environments,
+agent tokens) are sealed under an encryption root that starts as a copy of the
+cluster secret. `orama operator rotate-secrets` rewrites the envelope;
+`--rotate` generates a new root so a captured previous IKM cannot open new
+rows. The cluster secret (IPFS-Cluster PSK / mesh bearer) is not touched.
+
 `GET /v1/auth/jwks` serves every live key, each carrying the namespace it is
 bound to alongside the standard members.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -148,6 +148,7 @@ is the index.
   - [`orama node wipe`](#orama-node-wipe) — Erase Orama from remote nodes (target-side only)
 - [`orama nodes`](#orama-nodes) — List your nodes across environments
 - [`orama operator`](#orama-operator) — Operate the cluster
+  - [`orama operator rotate-secrets`](#orama-operator-rotate-secrets) — Re-encrypt stored secrets, optionally under a new encryption root
   - [`orama operator rotate-signing-key`](#orama-operator-rotate-signing-key) — Replace the key this gateway signs tokens with
 - [`orama push`](#orama-push) — Push the binary archive to your nodes
 - [`orama rollout`](#orama-rollout) — Build, push, and rolling upgrade every node in an environment
@@ -2216,7 +2217,33 @@ Commands for the wallets on the cluster's operator list.
 Every one of them needs the admin grant and a wallet on that list; a namespace's
 own admin key is not enough.
 
-Subcommands: `rotate-signing-key`
+Subcommands: `rotate-secrets`, `rotate-signing-key`
+
+### orama operator rotate-secrets
+
+Re-encrypt stored secrets, optionally under a new encryption root
+
+```
+orama operator rotate-secrets [flags]
+```
+
+Rewrite function secrets, push tokens, TURN secrets, deployment
+environments and agent tokens onto the versioned envelope (enc:v1:<id>:).
+
+Without --rotate the IKM does not change: leftover plaintext and the legacy
+enc: form are rewritten so a captured snapshot of the old format is no longer
+the live one, and Decrypt can fail closed.
+
+With --rotate a new encryption root is generated. Existing ciphertext is
+re-encrypted under it. A disk that holds only the previous root cannot open
+the new rows. IPFS-Cluster and the mesh bearer are not touched.
+
+Do not run this until every gateway is on a binary that can read enc:v1:.
+The walker is idempotent; if it is interrupted, run it again.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--rotate` | `false` | Generate a new encryption root and re-encrypt under it |
 
 ### orama operator rotate-signing-key
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -333,6 +333,16 @@ These measures apply to all nodes (Ubuntu and OramaOS).
 - Each gateway generates its own key now, `0600` in its own secrets directory, and publishes the public half in `signing_keys` so the rest of the cluster verifies what it mints. A namespace gateway's key is **bound to its namespace**: a token signed with it is refused unless its `namespace` claim matches, on every verifier including the one that signed it
 - The index gateway's key is bound to nothing, deliberately. It is the control plane and it mints what the CLI signs in with for every namespace; a compromise of it is not a tenant-boundary problem
 - `orama operator rotate-signing-key` publishes a successor, signs with it, and leaves the outgoing key verifying what it already signed for one access-token lifetime. Two `kid`s in flight, no forced logouts, nothing restarted. It needs the operator list, not just the admin grant
+
+**Stored secrets (function secrets, push tokens, TURN, deployment env, agent tokens)**
+- These used to be `AES-GCM` under `HKDF(cluster secret, purpose)` wrapped as `enc:<base64>`. The cluster secret is also IPFS-Cluster's PSK and the mesh bearer, so rotating stored secrets meant partitioning the cluster. In practice the cluster secret is never rotated
+- The IKM is now `secrets/encryption-root`, a cluster-wide value that starts as a copy of the cluster secret so existing rows stay readable. Join ships it. `encryption_roots` in the registry is the source of truth after the first persist
+- The envelope is `enc:` until an operator rewrite, then `enc:v1:<keyid>:<base64>`. Decrypt fails closed on anything else. Leftover plaintext (deployment env, TURN) is still recognised by `IsEncrypted` at the caller and sealed by the walker
+- `orama operator rotate-secrets` rewrites every sealed column. Without `--rotate` the IKM does not change. With `--rotate` a new root is generated and the walker re-encrypts; a disk that holds only the previous root cannot open the new rows. IPFS-Cluster and the mesh bearer are not touched
+- Do not run it until every gateway is on a binary that can read `enc:v1:`. The walker is idempotent; if it is interrupted, run it again
+- Editing the HKDF purpose label in Go is not a rotation. It orphans every stored value
+- HKDF salt stays omitted (RFC 5869 zeros). Adding a salt is a key change and belongs inside `--rotate` if it is ever wanted, not as a silent upgrade
+- Rotating the cluster secret itself (IPFS-Cluster PSK + mesh bearer + coordination MACs) is a maintenance window, not this command
 - The old cluster-derived key is accepted for one access-token lifetime after each gateway boots, so tokens issued before the upgrade do not break — and no longer, because a key every node can derive would otherwise keep the hole open for ever
 - A key that is retired and a key whose retirement cannot be parsed are treated the same way: refused. `signing_keys` is on the list of tables a tenant's SQL may not name, because publishing a key is minting authority by another route
 

--- a/website/src/docs/operator/security.mdx
+++ b/website/src/docs/operator/security.mdx
@@ -52,7 +52,7 @@ All internal services require authentication:
 
 ### At Rest
 
-- **TURN secrets** encrypted with AES-256-GCM in the database (key derived from cluster secret)
+- **TURN secrets, function secrets, push tokens, deployment env, agent tokens** encrypted with AES-256-GCM. The key is HKDF of `secrets/encryption-root` (starts as a copy of the cluster secret). `orama operator rotate-secrets --rotate` replaces the IKM without touching IPFS-Cluster or the mesh bearer
 - **OramaOS nodes** — Full-disk LUKS2 encryption with Shamir key distribution (see the OramaOS page)
 - **Refresh tokens and API keys** — Stored as cryptographic hashes, not plaintext
 


### PR DESCRIPTION
Stacked on #126 (`chg-203`).

Make stored-secret rotation actually possible. A captured cluster-secret used to decrypt every function secret, push token, TURN secret, deployment environment and agent token forever, because those keys were HKDF of the same file that is also IPFS-Cluster's PSK and the mesh bearer.

## What changed

**KEK unglued from the cluster secret**
- New cluster-wide IKM `secrets/encryption-root`. First boot copies the cluster secret, so existing `enc:` rows stay readable.
- Registry table `encryption_roots` is the source of truth after persist. Join ships `encryption_root` / `encryption_root_id`.
- Stored-ciphertext HKDF uses that IKM. Live protocol (IPFS-Cluster `CLUSTER_SECRET`, mesh bearer, coordination MACs) stays on the cluster secret.

**Envelope (BUG-249)**
- Dual-read: `enc:<b64>` and `enc:v1:<keyid>:<b64>`.
- New writes stay `enc:` until an operator rewrite, so a mixed-version rolling upgrade can still decrypt.
- `Decrypt` fails closed on an unprefixed value. Leftover plaintext (deployment env, TURN) is still recognised by `IsEncrypted` at the caller and sealed by the walker.
- The HKDF purpose label is a domain separator, not a rotation handle.

**Walker**
- `POST /v1/operator/rotate-secrets` (operator list). Idempotent. Index walks registry columns and fans out to namespace gateways over `/v1/internal/secrets/reencrypt` (coordination MAC).
- `orama operator rotate-secrets` rewrites the envelope under the current IKM.
- `orama operator rotate-secrets --rotate` generates a new IKM first. A disk that holds only the previous root cannot open the new rows.

**BUG-250**
- Nil HKDF salt is unchanged. RFC 5869-legal for high-entropy IKM. Adding a salt would orphan every stored value and is not done here.

## Docs

`SECURITY.md`, `ARCHITECTURE.md`, `AUTH.md`, `API_SURFACE.md`, `CLI_REFERENCE.md` (generated), website operator security page.

## Not in this PR

- Splitting IPFS-Cluster PSK from the mesh bearer (live-protocol maintenance window; follow-up).
- HKDF salt.
- Key custody / ARCH-4 Phase C (this walker is the prerequisite).
- Wiring `SetBackupEncryptionKey` (separate hole).
- Deploy to devnet/testnet.