### PR TITLE
FEAT-215: single-node eval — one VPS runs index + a tenant namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ make vault-build
 | Document | Description |
 |----------|-------------|
 | [Architecture](docs/ARCHITECTURE.md) | System architecture and design patterns |
+| [One-VPS eval](docs/EVAL.md) | Single machine: index + tenant, not HA |
 | [Deployment Guide](docs/DEPLOYMENT_GUIDE.md) | Deploy apps, databases, and domains |
 | [Dev & Deploy](docs/DEV_DEPLOY.md) | Building, deploying to VPS, rolling upgrades |
 | [Authentication](docs/AUTH.md) | Who someone is, what they may do, and how the gateway decides |

--- a/core/cmd/orama/internal/namespace_commands.go
+++ b/core/cmd/orama/internal/namespace_commands.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DeBrosOfficial/network/pkg/auth"
 	"github.com/DeBrosOfficial/network/cmd/orama/internal/clierr"
 	"github.com/DeBrosOfficial/network/cmd/orama/internal/printer"
+	"github.com/DeBrosOfficial/network/pkg/auth"
 	"github.com/DeBrosOfficial/network/pkg/constants"
 )
 
@@ -345,8 +345,8 @@ func NamespaceDelete(force bool) error {
 	if !force {
 		fmt.Printf("This will permanently delete namespace '%s' and all its resources:\n", namespace)
 		fmt.Printf("  - All deployments and their processes\n")
-		fmt.Printf("  - RQLite cluster (3 nodes)\n")
-		fmt.Printf("  - Olric cache cluster (3 nodes)\n")
+		fmt.Printf("  - RQLite cluster\n")
+		fmt.Printf("  - Olric cache cluster\n")
 		fmt.Printf("  - Gateway instances\n")
 		fmt.Printf("  - API keys and credentials\n")
 		fmt.Printf("  - IPFS content and DNS records\n\n")

--- a/core/pkg/gateway/handlers/vault/handlers.go
+++ b/core/pkg/gateway/handlers/vault/handlers.go
@@ -2,7 +2,9 @@
 //
 // The gateway acts as a smart proxy between RootWallet clients and
 // vault guardian nodes on the WireGuard overlay network. It handles
-// Shamir split/combine so clients make a single HTTPS call.
+// Shamir split/combine so clients make a single HTTPS call. On a
+// one-node eval cluster it stores the envelope as a local key instead
+// (K=1, W=1); that is not Shamir.
 package vault
 
 import (

--- a/core/pkg/gateway/handlers/vault/health_handler.go
+++ b/core/pkg/gateway/handlers/vault/health_handler.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
-
-	"github.com/DeBrosOfficial/network/pkg/shamir"
 )
 
 // HealthResponse is returned for GET /v1/vault/health.
@@ -40,8 +38,7 @@ func (h *Handlers) HandleHealth(w http.ResponseWriter, r *http.Request) {
 	n := len(guardians)
 	healthy := h.probeGuardians(r.Context(), guardians)
 
-	k := shamir.AdaptiveThreshold(n)
-	wq := shamir.WriteQuorum(n)
+	k, wq := thresholdsForGuardianCount(n)
 
 	status := "healthy"
 	if healthy < wq {
@@ -70,12 +67,13 @@ func (h *Handlers) HandleStatus(w http.ResponseWriter, r *http.Request) {
 
 	n := len(guardians)
 	healthy := h.probeGuardians(r.Context(), guardians)
+	k, wq := thresholdsForGuardianCount(n)
 
 	writeJSON(w, http.StatusOK, StatusResponse{
 		Guardians:   n,
 		Healthy:     healthy,
-		Threshold:   shamir.AdaptiveThreshold(n),
-		WriteQuorum: shamir.WriteQuorum(n),
+		Threshold:   k,
+		WriteQuorum: wq,
 	})
 }
 

--- a/core/pkg/gateway/handlers/vault/local_key.go
+++ b/core/pkg/gateway/handlers/vault/local_key.go
@@ -1,0 +1,58 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/DeBrosOfficial/network/pkg/shamir"
+)
+
+// thresholdsForGuardianCount returns the read threshold K and write quorum W
+// for a fleet of n guardians.
+//
+// At n==1 Shamir cannot run (Split requires k>=2 and n>=k). Eval stores the
+// envelope as a local key on that disk: K=1, W=1. This is not
+// information-theoretic secret sharing — one disk holds the ciphertext.
+//
+// At n>=2 the Shamir formulas are unchanged: K = max(2, floor(n/3)),
+// W = min(n, max(K+1, ceil(2n/3))). Do not fold K=1 into AdaptiveThreshold.
+func thresholdsForGuardianCount(n int) (k, w int) {
+	if n == 1 {
+		return 1, 1
+	}
+	return shamir.AdaptiveThreshold(n), shamir.WriteQuorum(n)
+}
+
+// splitEnvelope is Shamir split for n>=2. At n==1 it returns one share whose
+// Y is the envelope itself (X=1) and persists threshold 1.
+func splitEnvelope(envelope []byte, n int) (shares []shamir.Share, k, w int, err error) {
+	k, w = thresholdsForGuardianCount(n)
+	if n == 1 {
+		out := make([]byte, len(envelope))
+		copy(out, envelope)
+		return []shamir.Share{{X: 1, Y: out}}, k, w, nil
+	}
+	shares, err = shamir.Split(envelope, n, k)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return shares, k, w, nil
+}
+
+// combineEnvelope reconstructs the envelope. Stored threshold 1 is a local
+// key: return Y, do not call Combine (which refuses fewer than 2 shares).
+// This stays keyed on the stored K so a 1→3 fleet growth does not brick
+// envelopes written on one guardian.
+func combineEnvelope(shares []shamir.Share, k int) ([]byte, error) {
+	if k == 1 {
+		if len(shares) < 1 {
+			return nil, fmt.Errorf("local-key envelope is missing")
+		}
+		out := make([]byte, len(shares[0].Y))
+		copy(out, shares[0].Y)
+		return out, nil
+	}
+	if k > len(shares) {
+		return nil, fmt.Errorf("need %d shares, have %d", k, len(shares))
+	}
+	return shamir.Combine(shares[:k])
+}

--- a/core/pkg/gateway/handlers/vault/local_key_test.go
+++ b/core/pkg/gateway/handlers/vault/local_key_test.go
@@ -1,0 +1,115 @@
+package vault
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/DeBrosOfficial/network/pkg/shamir"
+)
+
+func TestThresholdsForGuardianCount(t *testing.T) {
+	tests := []struct {
+		n, k, w int
+	}{
+		{1, 1, 1},
+		{2, 2, 2},
+		{3, 2, 3},
+		{5, 2, 4},
+		{9, 3, 6},
+	}
+	for _, tt := range tests {
+		k, w := thresholdsForGuardianCount(tt.n)
+		if k != tt.k || w != tt.w {
+			t.Errorf("n=%d: K,W = %d,%d want %d,%d", tt.n, k, w, tt.k, tt.w)
+		}
+	}
+	if got := shamir.AdaptiveThreshold(1); got != 2 {
+		t.Errorf("AdaptiveThreshold(1) = %d, want 2 — the Shamir floor must not move", got)
+	}
+}
+
+func TestSplitEnvelope_localKeyN1(t *testing.T) {
+	envelope := []byte("eval-ciphertext")
+	shares, k, w, err := splitEnvelope(envelope, 1)
+	if err != nil {
+		t.Fatalf("splitEnvelope n=1: %v", err)
+	}
+	if k != 1 || w != 1 {
+		t.Errorf("n=1 K,W = %d,%d want 1,1", k, w)
+	}
+	if len(shares) != 1 {
+		t.Fatalf("n=1 shares = %d, want 1", len(shares))
+	}
+	if shares[0].X != 1 {
+		t.Errorf("share X = %d, want 1", shares[0].X)
+	}
+	if !bytes.Equal(shares[0].Y, envelope) {
+		t.Errorf("share Y = %q, want the envelope", shares[0].Y)
+	}
+
+	got, err := combineEnvelope(shares, 1)
+	if err != nil {
+		t.Fatalf("combineEnvelope k=1: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("round-trip = %q, want %q", got, envelope)
+	}
+}
+
+func TestSplitEnvelope_n3StillShamir(t *testing.T) {
+	envelope := []byte("production-ciphertext-ok")
+	shares, k, w, err := splitEnvelope(envelope, 3)
+	if err != nil {
+		t.Fatalf("splitEnvelope n=3: %v", err)
+	}
+	if k != 2 || w != 3 {
+		t.Errorf("n=3 K,W = %d,%d want 2,3", k, w)
+	}
+	if len(shares) != 3 {
+		t.Fatalf("n=3 shares = %d, want 3", len(shares))
+	}
+	got, err := combineEnvelope(shares[:k], k)
+	if err != nil {
+		t.Fatalf("combine n=3: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("n=3 round-trip = %q, want %q", got, envelope)
+	}
+	if bytes.Equal(shares[0].Y, envelope) {
+		t.Error("n=3 share 0 Y is the envelope — Shamir was skipped")
+	}
+}
+
+func TestCombineEnvelope_storedK1SurvivesFleetGrowth(t *testing.T) {
+	envelope := []byte("written-on-one-guardian")
+	shares, _, _, err := splitEnvelope(envelope, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Discovery later returns 3 guardians; pull still uses stored threshold 1.
+	got, err := combineEnvelope(shares, 1)
+	if err != nil {
+		t.Fatalf("stored K=1 after growth: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("got %q, want %q", got, envelope)
+	}
+}
+
+func TestSplitEnvelope_n2Unchanged(t *testing.T) {
+	envelope := []byte("two-guardian-cluster")
+	shares, k, w, err := splitEnvelope(envelope, 2)
+	if err != nil {
+		t.Fatalf("n=2: %v", err)
+	}
+	if k != 2 || w != 2 {
+		t.Errorf("n=2 K,W = %d,%d want 2,2", k, w)
+	}
+	got, err := combineEnvelope(shares, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("n=2 round-trip = %q", got)
+	}
+}

--- a/core/pkg/gateway/handlers/vault/pull_handler.go
+++ b/core/pkg/gateway/handlers/vault/pull_handler.go
@@ -106,7 +106,7 @@ func (h *Handlers) HandlePull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	n := len(guardians)
-	k := shamir.AdaptiveThreshold(n)
+	k, _ := thresholdsForGuardianCount(n)
 
 	// Fan out pull requests to all guardians.
 	ctx, cancel := context.WithTimeout(r.Context(), overallTimeout)
@@ -230,7 +230,8 @@ func (h *Handlers) HandlePull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Shamir combine exactly bestK shares of the chosen version.
-	envelope, err := shamir.Combine(bestShares[:bestK])
+	// bestK==1 is a local-key envelope stored on one guardian — not Shamir.
+	envelope, err := combineEnvelope(bestShares, bestK)
 	if err != nil {
 		h.logger.ComponentError(logging.ComponentGeneral, "Vault pull: Shamir combine failed", zap.Error(err))
 		writeError(w, http.StatusInternalServerError, "failed to reconstruct envelope")

--- a/core/pkg/gateway/handlers/vault/push_handler.go
+++ b/core/pkg/gateway/handlers/vault/push_handler.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 
 	"github.com/DeBrosOfficial/network/pkg/logging"
-	"github.com/DeBrosOfficial/network/pkg/shamir"
 	"go.uber.org/zap"
 )
 
@@ -110,14 +109,15 @@ func (h *Handlers) HandlePush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	n := len(guardians)
-	k := shamir.AdaptiveThreshold(n)
-	quorum := shamir.WriteQuorum(n)
-
-	shares, err := shamir.Split(envelopeBytes, n, k)
+	shares, k, quorum, err := splitEnvelope(envelopeBytes, n)
 	if err != nil {
 		h.logger.ComponentError(logging.ComponentGeneral, "Vault push: Shamir split failed", zap.Error(err))
 		writeError(w, http.StatusInternalServerError, "failed to split envelope")
 		return
+	}
+	if n == 1 {
+		h.logger.ComponentWarn(logging.ComponentGeneral,
+			"vault: single-node cluster; storing envelope as local key (K=1,W=1); not Shamir")
 	}
 
 	// Fan out to guardians in parallel.

--- a/core/pkg/namespace/blueprint.go
+++ b/core/pkg/namespace/blueprint.go
@@ -251,6 +251,24 @@ func BlueprintNameserver() Blueprint {
 	}
 }
 
+// TenantBlueprintForEligibleCount picks the tenant recipe for a fleet of this
+// many eligible nodes. Production stays N=3 whenever the fleet can support it
+// (never N=fleet). A single eligible node is eval — the same units, replica
+// count 1, not HA. Two nodes are refused: that size is neither eval nor a
+// Raft quorum. Zero is insufficient.
+func TenantBlueprintForEligibleCount(eligible int) (Blueprint, error) {
+	switch {
+	case eligible >= DefaultRQLiteNodeCount:
+		return BlueprintTenant(), nil
+	case eligible == 1:
+		return BlueprintTenantN(1), nil
+	case eligible == 2:
+		return Blueprint{}, ErrTwoNodeFleet
+	default:
+		return Blueprint{}, ErrInsufficientNodes
+	}
+}
+
 // BlueprintTenantN is a tenant cluster of n members. n=3 is the API-key
 // default (BlueprintTenant). n=1 is a single-node cluster (rqlite leader,
 // no -join). Port needs stay 2+2+1.

--- a/core/pkg/namespace/blueprint_test.go
+++ b/core/pkg/namespace/blueprint_test.go
@@ -263,6 +263,39 @@ func TestBlueprintTenantN_1_and_5(t *testing.T) {
 	}
 }
 
+func TestTenantBlueprintForEligibleCount(t *testing.T) {
+	tests := []struct {
+		eligible int
+		wantN    int
+		wantErr  error
+	}{
+		{0, 0, ErrInsufficientNodes},
+		{1, 1, nil},
+		{2, 0, ErrTwoNodeFleet},
+		{3, 3, nil},
+		{10, 3, nil},
+	}
+	for _, tt := range tests {
+		bp, err := TenantBlueprintForEligibleCount(tt.eligible)
+		if tt.wantErr != nil {
+			if err != tt.wantErr {
+				t.Errorf("eligible=%d err = %v, want %v", tt.eligible, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("eligible=%d unexpected err %v", tt.eligible, err)
+			continue
+		}
+		if bp.SelectCount != tt.wantN {
+			t.Errorf("eligible=%d SelectCount = %d, want %d", tt.eligible, bp.SelectCount, tt.wantN)
+		}
+		if err := bp.Validate(); err != nil {
+			t.Errorf("eligible=%d blueprint invalid: %v", tt.eligible, err)
+		}
+	}
+}
+
 func TestBlueprint_gatewayOnlyOnePort(t *testing.T) {
 	bp := Blueprint{
 		Name:        BlueprintNameTenant,

--- a/core/pkg/namespace/cluster_manager.go
+++ b/core/pkg/namespace/cluster_manager.go
@@ -427,9 +427,10 @@ func (cm *ClusterManager) spawnGatewayWithSystemd(ctx context.Context, cfg gatew
 	return cm.systemdSpawner.SpawnGateway(ctx, cfg.Namespace, cfg.NodeID, cfg)
 }
 
-// ProvisionCluster provisions a tenant namespace cluster (BlueprintTenant:
-// 3 nodes, rqlite → olric → gateway, 5-port block). Signature is unchanged;
-// the HTTP path uses ProvisionNamespaceCluster for background provision.
+// ProvisionCluster provisions a tenant namespace cluster (BlueprintTenant N=3
+// when the fleet can support it; BlueprintTenantN(1) on a one-node eval fleet).
+// Signature is unchanged; the HTTP path uses ProvisionNamespaceCluster for
+// background provision.
 func (cm *ClusterManager) ProvisionCluster(ctx context.Context, namespaceID int, namespaceName, provisionedBy string) (*NamespaceCluster, error) {
 	// Check if already provisioning
 	cm.provisioningMu.Lock()
@@ -452,7 +453,13 @@ func (cm *ClusterManager) ProvisionCluster(ctx context.Context, namespaceID int,
 		zap.String("provisioned_by", provisionedBy),
 	)
 
-	cluster := newProvisioningCluster(namespaceID, namespaceName, provisionedBy)
+	bp, err := cm.tenantBlueprintForFleet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cm.logEvalProvision(namespaceName, bp)
+
+	cluster := newProvisioningClusterFrom(bp, namespaceID, namespaceName, provisionedBy)
 
 	// Insert cluster record
 	if err := cm.insertCluster(ctx, cluster); err != nil {
@@ -462,7 +469,6 @@ func (cm *ClusterManager) ProvisionCluster(ctx context.Context, namespaceID int,
 	// Log event
 	cm.logEvent(ctx, cluster.ID, EventProvisioningStarted, "", "Cluster provisioning started", nil)
 
-	bp := BlueprintTenant()
 	nodes, err := cm.nodeSelector.SelectNodesForCluster(ctx, bp.SelectCount)
 	if err != nil {
 		cm.updateClusterStatus(ctx, cluster.ID, ClusterStatusFailed, err.Error())
@@ -1509,7 +1515,16 @@ func (cm *ClusterManager) ProvisionNamespaceCluster(ctx context.Context, namespa
 	cm.provisioning[namespaceName] = true
 	cm.provisioningMu.Unlock()
 
-	cluster := newProvisioningCluster(namespaceID, namespaceName, wallet)
+	bp, err := cm.tenantBlueprintForFleet(ctx)
+	if err != nil {
+		cm.provisioningMu.Lock()
+		delete(cm.provisioning, namespaceName)
+		cm.provisioningMu.Unlock()
+		return "", "", err
+	}
+	cm.logEvalProvision(namespaceName, bp)
+
+	cluster := newProvisioningClusterFrom(bp, namespaceID, namespaceName, wallet)
 
 	// Insert cluster record
 	if err := cm.insertCluster(ctx, cluster); err != nil {
@@ -1522,14 +1537,33 @@ func (cm *ClusterManager) ProvisionNamespaceCluster(ctx context.Context, namespa
 	cm.logEvent(ctx, cluster.ID, EventProvisioningStarted, "", "Cluster provisioning started", nil)
 
 	// Start actual provisioning in background goroutine
-	go cm.provisionClusterAsync(cluster, namespaceID, namespaceName, wallet)
+	go cm.provisionClusterAsync(cluster, bp, namespaceID, namespaceName, wallet)
 
 	pollURL := "/v1/namespace/status?id=" + cluster.ID
 	return cluster.ID, pollURL, nil
 }
 
+// tenantBlueprintForFleet lists eligible nodes and picks N=1 (eval) or N=3
+// (production). It does not retry a failed N=3 select as N=1.
+func (cm *ClusterManager) tenantBlueprintForFleet(ctx context.Context) (Blueprint, error) {
+	eligible, err := cm.nodeSelector.ListEligibleNodes(ctx)
+	if err != nil {
+		return Blueprint{}, err
+	}
+	return TenantBlueprintForEligibleCount(len(eligible))
+}
+
+func (cm *ClusterManager) logEvalProvision(namespaceName string, bp Blueprint) {
+	if bp.SelectCount != 1 {
+		return
+	}
+	cm.logger.Warn("provisioning tenant as a 1-node eval cluster; this is not HA; vault is a local key on this disk",
+		zap.String("namespace", namespaceName),
+	)
+}
+
 // provisionClusterAsync performs the actual cluster provisioning in the background
-func (cm *ClusterManager) provisionClusterAsync(cluster *NamespaceCluster, namespaceID int, namespaceName, provisionedBy string) {
+func (cm *ClusterManager) provisionClusterAsync(cluster *NamespaceCluster, bp Blueprint, namespaceID int, namespaceName, provisionedBy string) {
 	defer func() {
 		// Recover from panics (e.g., gorqlite index-out-of-range) so the
 		// goroutine doesn't die silently leaving status stuck at "provisioning".
@@ -1559,7 +1593,6 @@ func (cm *ClusterManager) provisionClusterAsync(cluster *NamespaceCluster, names
 		zap.String("provisioned_by", provisionedBy),
 	)
 
-	bp := BlueprintTenant()
 	nodes, err := cm.nodeSelector.SelectNodesForCluster(ctx, bp.SelectCount)
 	if err != nil {
 		cm.updateClusterStatus(ctx, cluster.ID, ClusterStatusFailed, err.Error())

--- a/core/pkg/namespace/cluster_manager_test.go
+++ b/core/pkg/namespace/cluster_manager_test.go
@@ -80,6 +80,28 @@ func TestRQLiteMemberConfigs_threeNodeJoin(t *testing.T) {
 	}
 }
 
+func TestNewProvisioningClusterFrom_evalEligibleWritesStoredCounts(t *testing.T) {
+	bp, err := TenantBlueprintForEligibleCount(1)
+	if err != nil {
+		t.Fatalf("TenantBlueprintForEligibleCount(1): %v", err)
+	}
+	cluster := newProvisioningClusterFrom(bp, 1, "solo", "w")
+	if cluster.RQLiteNodeCount != 1 || cluster.OlricNodeCount != 1 || cluster.GatewayNodeCount != 1 {
+		t.Errorf("eval stored counts = %d/%d/%d, want 1/1/1 so repair cannot demand 3",
+			cluster.RQLiteNodeCount, cluster.OlricNodeCount, cluster.GatewayNodeCount)
+	}
+
+	prod, err := TenantBlueprintForEligibleCount(10)
+	if err != nil {
+		t.Fatalf("TenantBlueprintForEligibleCount(10): %v", err)
+	}
+	wide := newProvisioningClusterFrom(prod, 1, "prod", "w")
+	if wide.RQLiteNodeCount != 3 || wide.OlricNodeCount != 3 || wide.GatewayNodeCount != 3 {
+		t.Errorf("10-node fleet stored counts = %d/%d/%d, want 3/3/3 (N=3, not N=fleet)",
+			wide.RQLiteNodeCount, wide.OlricNodeCount, wide.GatewayNodeCount)
+	}
+}
+
 func TestNewProvisioningClusterFrom_N1andN5(t *testing.T) {
 	one := newProvisioningClusterFrom(BlueprintTenantN(1), 1, "solo", "w")
 	if one.RQLiteNodeCount != 1 || one.OlricNodeCount != 1 || one.GatewayNodeCount != 1 {

--- a/core/pkg/namespace/cluster_recovery.go
+++ b/core/pkg/namespace/cluster_recovery.go
@@ -421,6 +421,19 @@ func (cm *ClusterManager) ReplaceClusterNode(ctx context.Context, cluster *Names
 		return cm.settleClusterStatus(ctx, cluster)
 	}
 
+	if cluster.RQLiteNodeCount == 1 {
+		cm.logger.Warn("eval cluster of size 1 cannot be replaced onto another machine; waiting for this node to return",
+			zap.String("namespace", cluster.NamespaceName),
+			zap.String("dead_node", deadNodeID),
+		)
+		if err := cm.updateClusterNodeStatus(ctx, cluster.ID, deadNodeID, NodeStatusFailed); err != nil {
+			cm.logger.Warn("Failed to mark node as failed in cluster", zap.Error(err))
+		}
+		cm.updateClusterStatus(ctx, cluster.ID, ClusterStatusDegraded,
+			fmt.Sprintf("Node %s is dead; eval cluster of size 1 has no spare machine", deadNodeID))
+		return ErrEvalClusterNoReplacement
+	}
+
 	// 1. Mark dead node's assignments as failed
 	if err := cm.updateClusterNodeStatus(ctx, cluster.ID, deadNodeID, NodeStatusFailed); err != nil {
 		cm.logger.Warn("Failed to mark node as failed in cluster", zap.Error(err))
@@ -887,6 +900,22 @@ const staleClusterNodeSQL = `
 // twice — no lock or election is needed the way role reallocation needs one.
 func (cm *ClusterManager) pruneStaleClusterNodes(ctx context.Context, clusterID string) ([]string, error) {
 	internalCtx := client.WithInternalAuth(ctx)
+
+	// An N=1 eval tenant has one member. Pruning it deletes the only
+	// membership and port allocation, after which local restore has nothing
+	// to join and RepairCluster cannot bootstrap a leader. Leave the row;
+	// bounce is restore, not replace.
+	if cluster, err := cm.GetCluster(internalCtx, clusterID); err != nil {
+		cm.logger.Warn("Could not load cluster before pruning stale members — continuing",
+			zap.String("cluster_id", clusterID), zap.Error(err))
+	} else if cluster != nil && cluster.RQLiteNodeCount == 1 {
+		cm.logger.Warn("not pruning members of a 1-node eval cluster; local restore needs the membership",
+			zap.String("cluster_id", clusterID),
+			zap.String("namespace", cluster.NamespaceName),
+		)
+		return nil, nil
+	}
+
 	type row struct {
 		NodeID string `db:"node_id"`
 	}
@@ -1169,6 +1198,14 @@ func (cm *ClusterManager) RepairCluster(ctx context.Context, namespaceName strin
 		// this is what left a fully-recovered cluster marked degraded, which the
 		// edge router then refused to serve (bugboard #278).
 		return cm.settleClusterStatus(ctx, cluster)
+	}
+
+	if cluster.RQLiteNodeCount == 1 {
+		cm.logger.Warn("eval cluster of size 1 cannot add a replacement node; waiting for this node to return",
+			zap.String("namespace", namespaceName),
+			zap.Int("active_nodes", activeCount),
+		)
+		return ErrEvalClusterNoReplacement
 	}
 
 	cm.logger.Info("Cluster needs repair — adding missing nodes",

--- a/core/pkg/namespace/cluster_recovery_alloc_prune_test.go
+++ b/core/pkg/namespace/cluster_recovery_alloc_prune_test.go
@@ -24,6 +24,10 @@ import (
 func TestPruneStaleClusterNodes_alsoDropsPortAllocation(t *testing.T) {
 	db := &recoveryMockDB{}
 	db.queryFunc = func(dest any, query string, _ ...any) error {
+		if strings.Contains(query, "FROM namespace_clusters") {
+			appendToSlice(dest, map[string]any{"ID": "cluster-1", "RQLiteNodeCount": 3})
+			return nil
+		}
 		if query != staleClusterNodeSQL {
 			t.Fatalf("unexpected query: %s", query)
 		}
@@ -63,7 +67,12 @@ func TestPruneStaleClusterNodes_alsoDropsPortAllocation(t *testing.T) {
 // A cluster with no stale members must not delete anything.
 func TestPruneStaleClusterNodes_noStaleMembersDeletesNoAllocations(t *testing.T) {
 	db := &recoveryMockDB{}
-	db.queryFunc = func(dest any, query string, _ ...any) error { return nil }
+	db.queryFunc = func(dest any, query string, _ ...any) error {
+		if strings.Contains(query, "FROM namespace_clusters") {
+			appendToSlice(dest, map[string]any{"ID": "cluster-1", "RQLiteNodeCount": 3})
+		}
+		return nil
+	}
 	cm := &ClusterManager{db: db, logger: zap.NewNop()}
 
 	if _, err := cm.pruneStaleClusterNodes(context.Background(), "cluster-1"); err != nil {

--- a/core/pkg/namespace/cluster_recovery_eval_test.go
+++ b/core/pkg/namespace/cluster_recovery_eval_test.go
@@ -1,0 +1,96 @@
+package namespace
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestReplaceClusterNode_evalN1DoesNotHuntForASpare(t *testing.T) {
+	db := &recoveryMockDB{}
+	cm := &ClusterManager{db: db, logger: zap.NewNop()}
+	cluster := &NamespaceCluster{
+		ID:              "c-eval",
+		NamespaceName:   "solo",
+		RQLiteNodeCount: 1,
+		Status:          ClusterStatusReady,
+	}
+
+	err := cm.ReplaceClusterNode(context.Background(), cluster, "only-node")
+	if err != ErrEvalClusterNoReplacement {
+		t.Fatalf("ReplaceClusterNode N=1 = %v, want ErrEvalClusterNoReplacement", err)
+	}
+
+	for _, q := range db.getQueryCalls() {
+		if strings.Contains(q.Query, "dns_nodes") && strings.Contains(q.Query, "last_seen") {
+			continue // nodeIsLive
+		}
+		if strings.Contains(strings.ToLower(q.Query), "insert") {
+			t.Errorf("N=1 replace must not insert a new member: %s", q.Query)
+		}
+	}
+}
+
+func TestRepairCluster_evalN1WithMemberUpDoesNotDemandThree(t *testing.T) {
+	db := &recoveryMockDB{}
+	db.queryFunc = func(dest any, query string, _ ...any) error {
+		switch {
+		case strings.Contains(query, "FROM namespace_clusters") && strings.Contains(query, "namespace_name"):
+			appendToSlice(dest, map[string]any{
+				"ID":              "c-eval",
+				"NamespaceName":   "solo",
+				"Status":          ClusterStatusReady,
+				"RQLiteNodeCount": 1,
+			})
+		case strings.Contains(query, "FROM namespace_cluster_nodes"):
+			appendToSlice(dest, map[string]any{
+				"NodeID": "only-node",
+				"Status": NodeStatusRunning,
+			})
+		}
+		return nil
+	}
+	cm := &ClusterManager{db: db, logger: zap.NewNop(), provisioning: map[string]bool{}}
+
+	if err := cm.RepairCluster(context.Background(), "solo"); err != nil {
+		t.Fatalf("RepairCluster N=1 with member running: %v", err)
+	}
+
+	for _, q := range db.getQueryCalls() {
+		if strings.Contains(q.Query, "SelectReplacement") || strings.Contains(strings.ToLower(q.Query), "insert into namespace_cluster_nodes") {
+			t.Errorf("repair of a healthy N=1 cluster must not add members: %s", q.Query)
+		}
+	}
+}
+
+func TestPruneStaleClusterNodes_skipsEvalN1(t *testing.T) {
+	db := &recoveryMockDB{}
+	db.queryFunc = func(dest any, query string, _ ...any) error {
+		if strings.Contains(query, "FROM namespace_clusters") {
+			appendToSlice(dest, map[string]any{
+				"ID":              "c-eval",
+				"NamespaceName":   "solo",
+				"RQLiteNodeCount": 1,
+			})
+			return nil
+		}
+		if query == staleClusterNodeSQL {
+			t.Errorf("N=1 eval must not run the stale-member sweep")
+		}
+		return nil
+	}
+	cm := &ClusterManager{db: db, logger: zap.NewNop()}
+
+	removed, err := cm.pruneStaleClusterNodes(context.Background(), "c-eval")
+	if err != nil {
+		t.Fatalf("prune N=1: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("removed = %v, want none", removed)
+	}
+	if len(db.getExecCalls()) != 0 {
+		t.Errorf("N=1 prune must not delete membership: %+v", db.getExecCalls())
+	}
+}

--- a/core/pkg/namespace/cluster_recovery_prune_test.go
+++ b/core/pkg/namespace/cluster_recovery_prune_test.go
@@ -163,6 +163,10 @@ func TestStaleClusterNodeSQL_purgeHorizonBoundary(t *testing.T) {
 func TestPruneStaleClusterNodes_removesReturnedRowsAndReportsThem(t *testing.T) {
 	db := &recoveryMockDB{}
 	db.queryFunc = func(dest any, query string, _ ...any) error {
+		if strings.Contains(query, "FROM namespace_clusters") {
+			appendToSlice(dest, map[string]any{"ID": "cluster-1", "RQLiteNodeCount": 3})
+			return nil
+		}
 		if query != staleClusterNodeSQL {
 			t.Fatalf("unexpected query: %s", query)
 		}
@@ -212,6 +216,10 @@ func TestPruneStaleClusterNodes_removesReturnedRowsAndReportsThem(t *testing.T) 
 func TestPruneStaleClusterNodes_noStaleMembersIsNoop(t *testing.T) {
 	db := &recoveryMockDB{}
 	db.queryFunc = func(dest any, query string, _ ...any) error {
+		if strings.Contains(query, "FROM namespace_clusters") {
+			appendToSlice(dest, map[string]any{"ID": "cluster-1", "RQLiteNodeCount": 3})
+			return nil
+		}
 		if query != staleClusterNodeSQL {
 			t.Fatalf("unexpected query: %s", query)
 		}

--- a/core/pkg/namespace/node_selector.go
+++ b/core/pkg/namespace/node_selector.go
@@ -45,12 +45,12 @@ func NewClusterNodeSelector(db rqlite.Client, portAllocator *NamespacePortAlloca
 	}
 }
 
-// SelectNodesForCluster selects the optimal N nodes for a new namespace cluster.
-// Returns the node IDs sorted by score (best first).
-func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeCount int) ([]NodeCapacity, error) {
+// ListEligibleNodes returns every active node with a free namespace slot,
+// sorted by capacity score (highest first). Provision uses the length of this
+// list to pick N=1 (eval) or N=3 (production) — it is not "try 3, then 1".
+func (cns *ClusterNodeSelector) ListEligibleNodes(ctx context.Context) ([]NodeCapacity, error) {
 	internalCtx := client.WithInternalAuth(ctx)
 
-	// Get all active nodes
 	activeNodes, err := cns.getActiveNodes(internalCtx)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,6 @@ func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeC
 
 	cns.logger.Debug("Found active nodes", zap.Int("count", len(activeNodes)))
 
-	// Filter nodes that have capacity for namespace instances
 	eligibleNodes := make([]NodeCapacity, 0)
 	for _, node := range activeNodes {
 		capacity, err := cns.getNodeCapacity(internalCtx, node.NodeID, node.IPAddress, node.InternalIP)
@@ -70,7 +69,6 @@ func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeC
 			continue
 		}
 
-		// Only include nodes with available namespace slots
 		if capacity.AvailableNamespaceSlots > 0 {
 			eligibleNodes = append(eligibleNodes, *capacity)
 		} else {
@@ -83,7 +81,20 @@ func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeC
 
 	cns.logger.Debug("Eligible nodes after filtering", zap.Int("count", len(eligibleNodes)))
 
-	// Check if we have enough nodes
+	sort.Slice(eligibleNodes, func(i, j int) bool {
+		return eligibleNodes[i].Score > eligibleNodes[j].Score
+	})
+	return eligibleNodes, nil
+}
+
+// SelectNodesForCluster selects the optimal N nodes for a new namespace cluster.
+// Returns the node IDs sorted by score (best first).
+func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeCount int) ([]NodeCapacity, error) {
+	eligibleNodes, err := cns.ListEligibleNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(eligibleNodes) < nodeCount {
 		return nil, &ClusterError{
 			Message: ErrInsufficientNodes.Message,
@@ -91,12 +102,6 @@ func (cns *ClusterNodeSelector) SelectNodesForCluster(ctx context.Context, nodeC
 		}
 	}
 
-	// Sort by score (highest first)
-	sort.Slice(eligibleNodes, func(i, j int) bool {
-		return eligibleNodes[i].Score > eligibleNodes[j].Score
-	})
-
-	// Return top N nodes
 	selectedNodes := eligibleNodes[:nodeCount]
 
 	cns.logger.Info("Selected nodes for cluster",

--- a/core/pkg/namespace/types.go
+++ b/core/pkg/namespace/types.go
@@ -265,9 +265,15 @@ func (e *ClusterError) Unwrap() error {
 }
 
 var (
-	ErrNoPortsAvailable            = &ClusterError{Message: "no ports available on node"}
-	ErrNodeAtCapacity              = &ClusterError{Message: "node has reached maximum namespace instances"}
-	ErrInsufficientNodes           = &ClusterError{Message: "insufficient nodes available for cluster"}
+	ErrNoPortsAvailable  = &ClusterError{Message: "no ports available on node"}
+	ErrNodeAtCapacity    = &ClusterError{Message: "node has reached maximum namespace instances"}
+	ErrInsufficientNodes = &ClusterError{Message: "insufficient nodes available for cluster"}
+	// ErrTwoNodeFleet is a 2-node fleet: not eval (1) and not HA (3). Even-sized
+	// Raft is a split-brain, and vault at N=2 has no spare share. Add a third node.
+	ErrTwoNodeFleet = &ClusterError{Message: "2 eligible nodes is not eval (1) and not HA (3); add a third node"}
+	// ErrEvalClusterNoReplacement: an N=1 eval tenant lives on one machine. There
+	// is no spare VPS to fail over onto; bounce is local restore, not replace.
+	ErrEvalClusterNoReplacement    = &ClusterError{Message: "eval cluster of size 1 cannot be replaced onto another machine; waiting for this node to return"}
 	ErrClusterNotFound             = &ClusterError{Message: "namespace cluster not found"}
 	ErrClusterAlreadyExists        = &ClusterError{Message: "namespace cluster already exists"}
 	ErrProvisioningFailed          = &ClusterError{Message: "cluster provisioning failed"}

--- a/core/pkg/namespace/types_test.go
+++ b/core/pkg/namespace/types_test.go
@@ -173,6 +173,8 @@ func TestPredefinedErrors(t *testing.T) {
 		{"ErrNoPortsAvailable", ErrNoPortsAvailable, "no ports available on node"},
 		{"ErrNodeAtCapacity", ErrNodeAtCapacity, "node has reached maximum namespace instances"},
 		{"ErrInsufficientNodes", ErrInsufficientNodes, "insufficient nodes available for cluster"},
+		{"ErrTwoNodeFleet", ErrTwoNodeFleet, "2 eligible nodes is not eval (1) and not HA (3); add a third node"},
+		{"ErrEvalClusterNoReplacement", ErrEvalClusterNoReplacement, "eval cluster of size 1 cannot be replaced onto another machine; waiting for this node to return"},
 		{"ErrClusterNotFound", ErrClusterNotFound, "namespace cluster not found"},
 		{"ErrClusterAlreadyExists", ErrClusterAlreadyExists, "namespace cluster already exists"},
 		{"ErrProvisioningFailed", ErrProvisioningFailed, "cluster provisioning failed"},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,8 @@ Install enables **only** `orama-node.service`. That process is a supervisor: it 
 | **nameserver** | this node, if `--nameserver` | `orama-namespace-coredns@nameserver` | `:53` |
 | **tenant** | N members chosen at provision | `orama-namespace-{rqlite,olric,gateway}@<name>` (+ `sfu`/`turn` if WebRTC) | `10000–10099` |
 
+Default tenant provision is N=3. A fleet with one eligible node provisions N=1 (eval, not HA; see [EVAL.md](EVAL.md)). Two eligible nodes are refused. A larger fleet still provisions tenants at N=3, not at fleet size. WebRTC still requires 3 members.
+
 Reserved namespace names: **`index`** and **`nameserver`**. They are not tenant-provisionable.
 
 Drive nodes through the `orama` CLI (`orama node …`). Do not `systemctl start` leftover host units (`orama-ipfs`, `orama-olric`, `caddy.service`, `coredns.service`, `wg-quick@wg0`). Those files may still exist on disk for rollback; they are disabled. Inter-node traffic uses the WireGuard overlay (`10.0.0.x`). Rolling upgrades never restart multiple index RQLite voters at once.

--- a/docs/DEVNET_INSTALL.md
+++ b/docs/DEVNET_INSTALL.md
@@ -3,6 +3,9 @@
 Anyone is installed as a **client** on every node by default (SOCKS5 on `:9050`
 for `/v1/proxy/anon`). There is no relay/ORPort mode.
 
+A single VPS (index + one tenant, not HA) is [EVAL.md](EVAL.md). This page is
+the three-nameserver cluster path.
+
 **Note:** Store credentials securely (not in version control).
 
 ## Installation Order

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -1,0 +1,62 @@
+# One-VPS eval
+
+A single VPS can run Orama end to end: the index plane on that machine, then a
+tenant namespace on the same machine, then an app with a database. That path is
+**eval**, not production HA.
+
+## What the code does
+
+Index membership is every node (`MembersAll`). One machine *is* the whole
+index. Tenant provision looks at how many nodes have a free namespace slot:
+
+| Eligible nodes | Tenant size | Notes |
+|---|---|---|
+| 1 | `BlueprintTenantN(1)` | Same units (`orama-namespace-{rqlite,olric,gateway}@<name>`), replica count 1. RQLite is leader, no `-join`. |
+| 3 or more | `BlueprintTenant()` — N=3 | Production default. A 10-node fleet still provisions tenants at 3, not 10. |
+| 0 | refused | Nobody to run on. |
+| 2 | refused | Neither eval nor HA. Even-sized Raft is a split-brain. Add a third node. |
+
+There is no second “dev mode” that skips systemd or blueprints, and no
+`--replicas` flag. The create API is still `POST /v1/namespaces` with `{name}`.
+
+Vault is an index service (one guardian per node). On one VPS there is one
+guardian. Shamir cannot split (`K` is floored at 2). The gateway stores the
+envelope as a **local key** on that disk (`K=1`, `W=1`) and logs it. That is
+not information-theoretic secret sharing: lose the disk, lose the secret.
+Production (`N≥3`) is unchanged: `K = max(2, floor(N/3))`.
+
+WebRTC stays unavailable (`need at least 3` for SFU/TURN). Do not enable it on
+eval.
+
+Bounce of the only node is local restore. There is no spare machine to fail
+over onto. Disk loss is namespace loss.
+
+## Operator path
+
+Genesis on the VPS (nameserver so the node has DNS):
+
+```bash
+sudo orama node install --vps-ip <ip> --domain <domain> --base-domain <domain> --nameserver
+```
+
+Or from your machine, with RootWallet unlocked:
+
+```bash
+orama node setup --ip <ip> --password '<vps-pass>' --env <env> \
+  --base-domain <domain> --role nameserver --genesis
+```
+
+Then:
+
+```bash
+orama auth login
+orama namespace create myapp
+orama auth login --namespace myapp
+```
+
+`namespace create` on a one-node fleet no longer fails with
+`insufficient nodes available for cluster`. The cluster row stores replica
+counts 1/1/1 so repair does not try to grow it to 3.
+
+This is not a substitute for [DEVNET_INSTALL.md](DEVNET_INSTALL.md) (three
+nameservers) or for rolling-upgrade rules. Those remain the cluster path.

--- a/docs/vault/ARCHITECTURE.md
+++ b/docs/vault/ARCHITECTURE.md
@@ -215,7 +215,7 @@ Addition and subtraction in GF(2^8) are both XOR. Multiplication uses log/exp ta
 
 ### Why All-Node Replication
 
-Every guardian stores one share per user. In a 14-node cluster, each user has 14 shares with an adaptive threshold K = max(2, floor(N/3)). This means:
+Every guardian stores one share per user. In a 14-node cluster, each user has 14 shares with an adaptive threshold K = max(2, floor(N/3)). On a one-node eval cluster Shamir cannot run; the gateway stores the envelope as a local key on that disk (see [EVAL.md](../EVAL.md)). On a production fleet:
 
 - With 5 nodes: K=2, so any 2 guardians can reconstruct.
 - With 14 nodes: K=4, so any 4 guardians can reconstruct.

--- a/docs/vault/OPERATOR_GUIDE.md
+++ b/docs/vault/OPERATOR_GUIDE.md
@@ -426,10 +426,11 @@ K = max(2, floor(alive_count / 3))
 
 - Adding nodes generally does not change K until the cluster grows significantly.
 - Removing nodes may reduce K if the alive count drops enough.
-- K never drops below 2. One guardian must never hold enough to reconstruct on
-  its own, and the write quorum W = min(N, max(K+1, ceil(2N/3))) is always
-  greater than K, so a write reported successful stores more shares than a read
-  needs.
+- K never drops below 2 **except on a one-node eval cluster**, where Shamir
+  cannot run and the gateway stores the envelope as a local key (`K=1`, `W=1`)
+  on that disk. That is eval-only; see [EVAL.md](../EVAL.md).
+- For N≥3 the write quorum W = min(N, max(K+1, ceil(2N/3))) is greater than K,
+  so a write reported successful stores more shares than a read needs.
 
 ### Write Quorum
 

--- a/docs/vault/SECURITY_MODEL.md
+++ b/docs/vault/SECURITY_MODEL.md
@@ -52,6 +52,7 @@ reported successful.
 
 | Alive Nodes (N) | Threshold (K) | Write Quorum (W) | Read Fault Tolerance (N-K) |
 |------------------|---------------|------------------|-----------------------------|
+| 1 (eval only) | 1 | 1 | 0 — local key, not Shamir |
 | 3 | 2 | 3 | 1 |
 | 5 | 2 | 4 | 3 |
 | 9 | 3 | 6 | 6 |
@@ -60,10 +61,18 @@ reported successful.
 | 50 | 16 | 34 | 34 |
 | 100 | 33 | 67 | 67 |
 
-Two is the smallest threshold that keeps the secret secret: with K = 1 a single
-guardian holds enough to reconstruct on its own.
+Two is the smallest Shamir threshold that keeps the secret secret: with K = 1 a
+single guardian holds enough to reconstruct on its own.
 
-`W > K` is the durability guarantee. A write reported successful has persisted
+**Eval exception (one VPS).** Shamir `Split` requires `K≥2` and `N≥K`, so a
+single guardian cannot split. The gateway stores the envelope as a local key on
+that disk (`K=1`, `W=1`) and logs it. That is not information-theoretic secret
+sharing; lose the disk, lose the secret. See [EVAL.md](../EVAL.md). Production
+(`N≥3`) is unchanged. Do not fold K=1 into `AdaptiveThreshold`.
+
+`W > K` is the durability guarantee for **N≥3**. At N=1 it cannot hold (one
+disk). At N=2, W=K=2 (no spare share). A two-node fleet is refused at tenant
+provision. A write reported successful has persisted
 strictly more shares than a read requires, so it is always recoverable and
 survives the loss of at least one guardian. The floor used to be 3, which broke
 that guarantee in the other direction: at N = 3 it gave K = 3 against W = 2, so

--- a/sdk-vault/README.md
+++ b/sdk-vault/README.md
@@ -84,11 +84,14 @@ K = max(2, floor(N/3))              read threshold
 W = min(N, max(K + 1, ceil(2N/3)))  write quorum
 ```
 
-N is the number of configured guardians. `W > K` is the durability guarantee: a
-write reported successful has persisted strictly more shares than a read
+N is the number of configured guardians. `W > K` is the durability guarantee for
+N≥3: a write reported successful has persisted strictly more shares than a read
 requires. The same two formulas are implemented in
 `vault/src/membership/quorum.zig` and `core/pkg/shamir/shamir.go`, and the three
-must agree exactly.
+must agree exactly. A one-node eval cluster does not Shamir-split: the Orama
+gateway stores the envelope as a local key (`K=1`, `W=1`). Direct overlay
+clients that call `split(data, 1, 2)` still fail; eval apps use the HTTPS
+gateway. See `docs/EVAL.md`.
 
 ## Authentication, and its current limit
 


### PR DESCRIPTION
Stacked on #128 (`chg-204`).

Someone should be able to install Orama on **one VPS** and actually use it: index up, then a tenant namespace on that same machine, then deploy an app/DB. Provision always asked for 3 nodes (`BlueprintTenant()`), so one eligible node failed with `insufficient nodes available for cluster`. Vault `Split(n=1, k=2)` could not run.

This is **eval**, not production HA. Default stays 3. No second “dev mode.”

## What changed

**Provision**
- Eligible-node count is measured first (`ListEligibleNodes`). N is chosen from that count, not by retrying a failed N=3 select.
- 1 eligible → `BlueprintTenantN(1)`, stored replica counts 1/1/1, warn log.
- ≥3 eligible → `BlueprintTenant()` (N=3, not N=fleet).
- 2 eligible → refused (`ErrTwoNodeFleet`). Even Raft, vault W=K.
- 0 → `ErrInsufficientNodes`.
- Sync and async provision both write those counts **before** spawn, so repair cannot grow an eval tenant to 3.

**Vault**
- One guardian: store the envelope as a local key (`K=1`, `W=1`). Not Shamir. Logged.
- Pull uses **stored** threshold 1, so growing 1→3 does not brick old envelopes.
- `AdaptiveThreshold` floor stays 2. Zig/TS quorum untouched. LUKS untouched.

**Recovery**
- Repair/replace of an N=1 tenant does not hunt for a spare VPS (`ErrEvalClusterNoReplacement`). Bounce is local restore.
- Do not prune the last member of an N=1 cluster (that deleted the only membership + port row).

**Docs**
- `docs/EVAL.md`. Architecture footnote. Vault SECURITY_MODEL / OPERATOR_GUIDE exception. Pointer from DEVNET_INSTALL.

## Not in this PR

- `--replicas` flag (would let a 3-node fleet request N=1).
- WebRTC on one node (still `need at least 3`).
- Growing an eval tenant to HA when more VPS join. Stored N=1 stays N=1.
- LUKS / OramaOS (feat-213 / chg-204).
- Deploy to devnet/testnet.

## Tests

- `TenantBlueprintForEligibleCount`: 0 fail, 1 → N=1, 2 fail, 3 and 10 → N=3.
- Stored counts 1/1/1 vs 3/3/3 on a 10-node fleet.
- Vault local-key round-trip; n=3 still Shamir K=2 W=3; stored K=1 survives “fleet growth”; `AdaptiveThreshold(1)` still 2.
- Replace/repair/prune of N=1 do not demand 3 nodes.
- Pre-push `go test` on `core/` passed.